### PR TITLE
8194762: JTReg failure of "runtime/NMT/PrintNMTStatistics.java"

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/PrintNMTStatistics.java
+++ b/test/hotspot/jtreg/runtime/NMT/PrintNMTStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ public class PrintNMTStatistics {
     OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
     output_detail.shouldContain("Virtual memory map:");
     output_detail.shouldContain("Details:");
-    output_detail.shouldNotContain("error");
     output_detail.shouldHaveExitValue(0);
 
     // Make sure memory reserved for Module processing is recorded.
@@ -62,7 +61,6 @@ public class PrintNMTStatistics {
     output_summary.shouldContain("Java Heap (reserved=");
     output_summary.shouldNotContain("Virtual memory map:");
     output_summary.shouldNotContain("Details:");
-    output_summary.shouldNotContain("error");
     output_summary.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
This test currently fails on alpine because the output contains the symbol `numa_error`.


