### PR TITLE
Exclude test "runtime/NMT/CheckForProperDetailStackTrace.java".

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -1,1 +1,4 @@
 # SapMachine Problem List for Hotspot tests
+
+# This test fails, because we do not have debug symbols available in all tests.
+runtime/NMT/CheckForProperDetailStackTrace.java                        generic-all


### PR DESCRIPTION
This tests fails when the test JDK has no debug symbols available.