### PR TITLE
Exclude test "runtime/NMT/CheckForProperDetailStackTrace.java". Alpine

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -6,3 +6,6 @@ runtime/StackGuardPages/testme.sh                              generic-all
 # The test scans the output for the pattern 'error'. Unfortunatly,
 # there is a symbol 'numa_error' in the output of NMT.
 runtime/ElfDecoder/TestElfDirectRead.java
+
+# This test fails, because we do not have debug symbols available in all tests.
+runtime/NMT/CheckForProperDetailStackTrace.java                generic-all


### PR DESCRIPTION
This tests fails when the test JDK has no debug symbols available.