### PR TITLE
Exclude test "runtime/NMT/CheckForProperDetailStackTrace.java". 10 Alpine

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -2,3 +2,6 @@
 
 gtest/GTestWrapper.java                                        generic-all
 runtime/StackGuardPages/testme.sh                              generic-all
+
+# This test fails, because we do not have debug symbols available in all tests.
+runtime/NMT/CheckForProperDetailStackTrace.java                generic-all


### PR DESCRIPTION
This tests fails when the test JDK has no debug symbols available.