### PR TITLE
Improve resolving of SciMark classpath.

### DIFF
--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -37,12 +37,18 @@ import java.util.Map;
 @Artifact(organization = "gov.nist.math", name = "scimark", revision = "2.0", extension = "zip")
 public class Scimark {
     public static void main(String... args) throws Exception {
-        Map<String, Path> artifacts = ArtifactResolver.resolve(Scimark.class);
+        String sciMark2Cp = System.getProperty("SCIMARK_2_CP");
+
+        if (sciMark2Cp == null) {
+            Map<String, Path> artifacts = ArtifactResolver.resolve(Scimark.class);
+            sciMark2Cp = artifacts.get("gov.nist.math.scimark-2.0").toString();
+        }
 
         OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(
-            "-cp", artifacts.get("gov.nist.math.scimark-2.0").toString(),
+            "-cp", sciMark2Cp,
             "jnt.scimark2.commandline", "-large")
             .start());
+        System.out.println(output.getOutput());
         output.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
First check wether the environment variable for the Scimark classpat is set.
If not, use the artifact resolver.