### PR TITLE
Switch on extended thread dumps by default.

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -661,7 +661,7 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   product(bool, PrintCompilation, false,                                    \
           "Print compilations")                                             \
                                                                             \
-  product(bool, PrintExtendedThreadInfo, false,                             \
+  product(bool, PrintExtendedThreadInfo, true,                              \
           "Print more information in thread dump")                          \
                                                                             \
   diagnostic(bool, TraceNMethodInstalls, false,                             \


### PR DESCRIPTION
Please merge this little change, as discussed.

Thanks,
Gunter