### PR TITLE
Exclude failing Hotspot test ReplaceCriticalClasses

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -123,6 +123,8 @@ runtime/condy/CondyBadNameTypeTest.java                                         
 runtime/condy/CondyCFVCheckTest.java                                               generic-all
 runtime/condy/CondyLDCTest.java                                                    generic-all
 runtime/condy/CondyNewInvokeSpecialTest.java                                       generic-all
+# Failing since JDK 12+18
+runtime/SharedArchiveFile/serviceability/ReplaceCriticalClasses.java               generic-all
 
 ###############################################################################
 # Functionality supported by IBM (at least on linux-ppc64le).


### PR DESCRIPTION
fixes #191

