### PR TITLE
Downport to SapMachine 11: Fix Test test/jdk/java/net/Socket/ExceptionText.java

### DIFF
--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -21,6 +21,9 @@
  * questions.
  */
 
+
+// SapMachine 2018-11-23: SapMachine has set jdk.includeInExceptions to hostInfo,jar
+//                        by default. Therefore expect according output!
 /*
  * @test
  * @library /test/lib
@@ -31,7 +34,7 @@
  *       ExceptionText
  * @run main/othervm
  *       ExceptionText
- *       WITHOUT_Enhanced_Text
+ *       expectEnhancedText
  * @run main/othervm
  *       -Djdk.includeInExceptions=
  *       ExceptionText
@@ -93,10 +96,10 @@ public class ExceptionText {
 
     static void testSecProp() {
         String incInExc = Security.getProperty("jdk.includeInExceptions");
-        if (incInExc != null) {
+        // SapMachine 2018-11-23: SapMachine has jdk.includeInExceptions set to hostInfo,jar 
+        if (!"hostInfo,jar".equals(incInExc)) {
             throw new RuntimeException("Test failed: default value of " +
-                "jdk.includeInExceptions security property is not null: " +
-                incInExc);
+                "jdk.includeInExceptions security property is not hostInfo,jar");
         }
     }
 


### PR DESCRIPTION
Fix Test test/jdk/java/net/Socket/ExceptionText.java which failed because property jdk.includeInExceptions is set to hostInfo,jar in SapMachine, while it's not set in OpenJDK.

fixes #202