### PR TITLE
First implementation of dt_filesocket transport.

### DIFF
--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -147,6 +147,7 @@ define SetupBuildLauncherBody
       $1_LIBS += \
           $$(shell $(FIND) $(SUPPORT_OUTPUTDIR)/modules_libs/java.base -name "*.a") \
           $(SUPPORT_OUTPUTDIR)/modules_libs/jdk.jdwp.agent/libdt_socket.a \
+          $(SUPPORT_OUTPUTDIR)/modules_libs/jdk.jdwp.agent/libdt_filesocket.a \
           $(SUPPORT_OUTPUTDIR)/modules_libs/jdk.jdwp.agent/libjdwp.a \
           $(SUPPORT_OUTPUTDIR)/native/java.base/$(LIBRARY_PREFIX)fdlibm$(STATIC_LIBRARY_SUFFIX) \
           -framework CoreFoundation \

--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -57,12 +57,15 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBDT_FILESOCKET, \
     EXTRA_HEADER_DIRS := \
         include \
         libjdwp/export, \
-    LDFLAGS := $(LDFLAGS_JDKLIB), \
+    LDFLAGS := $(LDFLAGS_JDKLIB) \
+        $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS_solaris := -lnsl -lsocket, \
     LIBS_windows := $(JKDLIB_LIBS) ws2_32.lib Advapi32.lib, \
 ))
- $(BUILD_LIBDT_FILESOCKET): $(call FindLib, java.base, java)
- # Include file socket transport with JDWP agent to allow for safe local debugging.
+
+$(BUILD_LIBDT_FILESOCKET): $(call FindLib, java.base, java)
+
+# Include file socket transport with JDWP agent to allow for safe local debugging
 TARGETS += $(BUILD_LIBDT_FILESOCKET)
 
 ################################################################################

--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -58,7 +58,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBDT_FILESOCKET, \
         include \
         libjdwp/export, \
     LDFLAGS := $(LDFLAGS_JDKLIB), \
-    LIBS_linux := -lpthread, \
     LIBS_solaris := -lnsl -lsocket, \
     LIBS_windows := $(JKDLIB_LIBS) ws2_32.lib Advapi32.lib, \
 ))

--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -49,6 +49,24 @@ TARGETS += $(BUILD_LIBDT_SOCKET)
 
 ################################################################################
 
+$(eval $(call SetupJdkLibrary, BUILD_LIBDT_FILESOCKET, \
+    NAME := dt_filesocket, \
+    OPTIMIZATION := LOW, \
+    CFLAGS := $(CFLAGS_JDKLIB), \
+    DISABLED_WARNINGS_clang := format-nonliteral, \
+    EXTRA_HEADER_DIRS := \
+        include \
+        libjdwp/export, \
+    LDFLAGS := $(LDFLAGS_JDKLIB), \
+    LIBS_linux := -lpthread, \
+    LIBS_solaris := -lnsl -lsocket, \
+    LIBS_windows := $(JKDLIB_LIBS) ws2_32.lib Advapi32.lib, \
+))
+ $(BUILD_LIBDT_FILESOCKET): $(call FindLib, java.base, java)
+ # Include file socket transport with JDWP agent to allow for safe local debugging.
+TARGETS += $(BUILD_LIBDT_FILESOCKET)
+
+################################################################################
 # JDWP_LOGGING causes log messages to be compiled into the library.
 $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
@@ -40,6 +40,11 @@
 #define MAX_DATA_SIZE 1000
 #define HANDSHAKE "JDWP-Handshake"
 
+/* Since the jdwp agent sometimes kills the VM outright when
+ * the connection fails, we always fake a successful 
+ * connection and instead fail in the read/write packet methods,
+ * which does not cause the VM to exit.
+ */
 static jboolean fake_open = JNI_FALSE;
 static jboolean initialized = JNI_FALSE;
 static JavaVM *jvm;

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
@@ -128,8 +128,8 @@ static int fileSocketTransport_ReadFully(char* buf, int len) {
     while (len > 0) {
         int n = fileSocketTransport_ReadImpl(buf, len);
 
-        if (n <= 0) {
-            return 0;
+        if (n < 0) {
+            return -1;
         }
 
         buf += n;
@@ -146,8 +146,8 @@ static int fileSocketTransport_WriteFully(char* buf, int len) {
     while (len > 0) {
         int n = fileSocketTransport_WriteImpl(buf, len);
 
-        if (n <= 0) {
-            return 0;
+        if (n < 0) {
+            return -1;
         }
 
         buf += n;

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "jni.h"
+#include "jdwpTransport.h"
+#include "fileSocketTransport.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#define MAX_FILE_SOCKET_PATH_LEN 4096
+#define MAX_DATA_SIZE 1000
+#define USE_HANDSHAKE 1
+#define HANDSHAKE "JDWP-Handshake"
+
+static jboolean fake_open = JNI_FALSE;
+static jboolean initialized = JNI_FALSE;
+static JavaVM *jvm;
+static char path[MAX_FILE_SOCKET_PATH_LEN + 1];
+static jdwpTransportCallback *callback;
+static char last_error[2048];
+static struct jdwpTransportNativeInterface_ nif;
+static jdwpTransportEnv single_env = (jdwpTransportEnv) &nif;
+
+void log_error(char const* format, ...) {
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(last_error, sizeof(last_error), format, ap);
+    last_error[sizeof(last_error) - 1] = 0;
+    va_end(ap);
+    printf("Error: %s\n", last_error);
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_GetCapabilities(jdwpTransportEnv* env, JDWPTransportCapabilities *capabilities_ptr) {
+    JDWPTransportCapabilities result;
+
+    memset(&result, 0, sizeof(result));
+    result.can_timeout_attach = JNI_FALSE;
+    result.can_timeout_accept = JNI_FALSE;
+    result.can_timeout_handshake = JNI_FALSE;
+
+    *capabilities_ptr = result;
+
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_SetTransportConfiguration(jdwpTransportEnv* env, jdwpTransportConfiguration *config) {
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_Close(jdwpTransportEnv* env) {
+    if (fileSocketTransport_HasValidHandle()) {
+        fileSocketTransport_CloseImpl();
+    }
+
+    fake_open = JNI_FALSE;
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_Attach(jdwpTransportEnv* env, const char* address, jlong attach_timeout, jlong handshake_timeout) {
+    /* We don't support attach. */
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_StartListening(jdwpTransportEnv* env, const char* address, char** actual_address) {
+    /* Only make sure we have no open connection. */
+    fileSocketTransport_Close(env);
+    *actual_address = (char*) address;
+
+    if (strlen(address) <= MAX_FILE_SOCKET_PATH_LEN) {
+        strcpy(path, address);
+    } else {
+        log_error("Too long address: %s", address);
+        fake_open = JNI_TRUE;
+    }
+
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_StopListening(jdwpTransportEnv* env) {
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jboolean JNICALL fileSocketTransport_IsOpen(jdwpTransportEnv* env) {
+    return fake_open || fileSocketTransport_HasValidHandle();
+}
+
+static int fileSocketTransport_ReadFully(char* buf, int len) {
+    int read = 0;
+
+    while (len > 0) {
+        int n = fileSocketTransport_ReadImpl(buf, len);
+
+        if (n <= 0) {
+            return 0;
+        }
+
+        buf += n;
+        len -= n;
+        read += n;
+    }
+
+    return read;
+}
+
+static int fileSocketTransport_WriteFully(char* buf, int len) {
+    int written = 0;
+
+    while (len > 0) {
+        int n = fileSocketTransport_WriteImpl(buf, len);
+
+        if (n <= 0) {
+            return 0;
+        }
+
+        buf += n;
+        len -= n;
+        written += n;
+    }
+
+    return written;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_Accept(jdwpTransportEnv* env, jlong accept_timeout, jlong handshake_timeout) {
+    fileSocketTransport_AcceptImpl(path);
+
+    if (!fileSocketTransport_HasValidHandle()) {
+        fake_open = JNI_TRUE;
+    } else {
+#if USE_HANDSHAKE
+        char buf[sizeof(HANDSHAKE)];
+        fileSocketTransport_ReadFully(buf, (int) strlen(HANDSHAKE));
+        fileSocketTransport_WriteFully(HANDSHAKE, (int) strlen(HANDSHAKE));
+
+        if (strcmp(buf, HANDSHAKE) != 0) {
+            fake_open = JNI_TRUE;
+        }
+#endif
+    }
+
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_ReadPacket(jdwpTransportEnv* env, jdwpPacket *packet) {
+    jint length, data_len, n;
+
+    if (!fileSocketTransport_HasValidHandle()) {
+        fake_open = JNI_FALSE;
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    } else if (fake_open) {
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
+
+    if (packet == NULL) {
+        log_error("Packet is null while reading");
+        return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    /* Taken mostly from socketTransport.c */
+    n = fileSocketTransport_ReadFully((char *) &length, sizeof(jint));
+
+    if (n == 0) {
+        packet->type.cmd.len = 0;
+        return JDWPTRANSPORT_ERROR_NONE;
+    }
+
+    if (n != sizeof(jint)) {
+        log_error("Only read %d instead of %d bytes for length field", (int) n, (int) sizeof(jint));
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
+
+    length = (jint) htonl(length);
+    packet->type.cmd.len = length;
+    n = fileSocketTransport_ReadFully((char *)&(packet->type.cmd.id), sizeof(jint));
+
+    if (n < (int)sizeof(jint)) {
+        log_error("Only read %d instead of %d bytes for command id", (int) n, (int) sizeof(jint));
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
+
+    packet->type.cmd.id = (jint) htonl(packet->type.cmd.id);
+    n = fileSocketTransport_ReadFully((char *)&(packet->type.cmd.flags), sizeof(jbyte));
+
+    if (n < (int) sizeof(jbyte)) {
+        log_error("Only read %d bytes for flags", (int) n);
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
+
+    if (packet->type.cmd.flags & JDWPTRANSPORT_FLAGS_REPLY) {
+        n = fileSocketTransport_ReadFully((char *)&(packet->type.reply.errorCode), sizeof(jbyte));
+        if (n < (int)sizeof(jshort)) {
+            log_error("Only read %d bytes for error code", (int) n);
+            return JDWPTRANSPORT_ERROR_IO_ERROR;
+        }
+    } else {
+        n = fileSocketTransport_ReadFully((char *)&(packet->type.cmd.cmdSet), sizeof(jbyte));
+        if (n < (int)sizeof(jbyte)) {
+            log_error("Only read %d bytes for command set", (int) n);
+            return JDWPTRANSPORT_ERROR_IO_ERROR;
+        }
+
+        n = fileSocketTransport_ReadFully((char *)&(packet->type.cmd.cmd), sizeof(jbyte));
+        if (n < (int)sizeof(jbyte)) {
+            log_error("Only read %d bytes for command", (int) n);
+            return JDWPTRANSPORT_ERROR_IO_ERROR;
+        }
+    }
+
+    data_len = length - ((sizeof(jint) * 2) + (sizeof(jbyte) * 3));
+
+    if (data_len < 0) {
+        log_error("Inavlid data length %d of read packet", (int) data_len);
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    } else if (data_len == 0) {
+        packet->type.cmd.data = NULL;
+    } else {
+        packet->type.cmd.data = (*callback->alloc)(data_len);
+
+        if (packet->type.cmd.data == NULL) {
+            return JDWPTRANSPORT_ERROR_OUT_OF_MEMORY;
+        }
+
+        n = fileSocketTransport_ReadFully((char *) packet->type.cmd.data, data_len);
+
+        if (n < data_len) {
+            log_error("Only read %d bytes for JDWP payload but expected %d", (int) n, (int) data_len);
+            return JDWPTRANSPORT_ERROR_IO_ERROR;
+        }
+    }
+
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_WritePacket(jdwpTransportEnv* env, const jdwpPacket* packet) {
+    jint len, data_len, id, n;
+    char header[JDWP_HEADER_SIZE + MAX_DATA_SIZE];
+    jbyte *data;
+
+    if (!fileSocketTransport_HasValidHandle()) {
+        fake_open = JNI_FALSE;
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    } else if (fake_open) {
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
+
+    /* Taken mostly from sockectTransport.c */
+    if (packet == NULL) {
+        log_error("Packet is null when writing");
+        return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    len = packet->type.cmd.len;
+    data_len = len - JDWP_HEADER_SIZE;
+
+    if (data_len < 0) {
+        log_error("Packet to write has illegal data length %d", (int) data_len);
+        return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    /* prepare the header for transmission */
+    len = (jint) htonl(len);
+    id = (jint) htonl(packet->type.cmd.id);
+
+    memcpy(header + 0, &len, 4);
+    memcpy(header + 4, &id, 4);
+    header[8] = packet->type.cmd.flags;
+
+    if (packet->type.cmd.flags & JDWPTRANSPORT_FLAGS_REPLY) {
+        jshort errorCode = htons(packet->type.reply.errorCode);
+        memcpy(header + 9, &errorCode, 2);
+    } else {
+        header[9] = packet->type.cmd.cmdSet;
+        header[10] = packet->type.cmd.cmd;
+    }
+
+    data = packet->type.cmd.data;
+
+    /* Do one send for short packets, two for longer ones */
+    if (data_len <= MAX_DATA_SIZE) {
+        memcpy(header + JDWP_HEADER_SIZE, data, data_len);
+        if ((n = fileSocketTransport_WriteFully((char *) &header, JDWP_HEADER_SIZE + data_len)) !=
+            JDWP_HEADER_SIZE + data_len) {
+            log_error("Could only write %d bytes instead of %d of the packet", (int) n, (int) (JDWP_HEADER_SIZE + data_len));
+            return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+        }
+    } else {
+        memcpy(header + JDWP_HEADER_SIZE, data, MAX_DATA_SIZE);
+        if ((n = fileSocketTransport_WriteFully((char *) &header, JDWP_HEADER_SIZE + MAX_DATA_SIZE)) !=
+            JDWP_HEADER_SIZE + MAX_DATA_SIZE) {
+            log_error("Could only write %d bytes instead of %d of the packet", (int) n, (int) (JDWP_HEADER_SIZE + MAX_DATA_SIZE));
+            return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+        }
+        /* Send the remaining data bytes right out of the data area. */
+        if ((n = fileSocketTransport_WriteFully((char *) data + MAX_DATA_SIZE,
+            data_len - MAX_DATA_SIZE)) != data_len - MAX_DATA_SIZE) {
+            log_error("Could only write %d bytes instead of %d of the packet", (int) n, (int) (data_len - MAX_DATA_SIZE));
+            return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
+        }
+    }
+
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+static jdwpTransportError JNICALL fileSocketTransport_GetLastError(jdwpTransportEnv* env, char** error) {
+    jint size = (jint) (strlen(last_error) + 3);
+    *error = (*callback->alloc)(size);
+    snprintf(*error, (int) size, "%s\n", last_error);
+    strcpy(*error, last_error);
+    return JDWPTRANSPORT_ERROR_NONE;
+}
+
+JNIEXPORT jint JNICALL
+jdwpTransport_OnLoad(JavaVM *vm, jdwpTransportCallback* callbacks, jint version, jdwpTransportEnv** env)
+{
+    if (version < JDWPTRANSPORT_VERSION_1_0 ||version > JDWPTRANSPORT_VERSION_1_1) {
+        return JNI_EVERSION;
+    }
+
+    if (initialized) {
+        return JNI_EEXIST;
+    }
+
+    initialized = JNI_TRUE;
+    jvm = vm;
+    callback = callbacks;
+
+    /* initialize interface table */
+    nif.GetCapabilities = fileSocketTransport_GetCapabilities;
+    nif.Attach = fileSocketTransport_Attach;
+    nif.StartListening = fileSocketTransport_StartListening;
+    nif.StopListening = fileSocketTransport_StopListening;
+    nif.Accept = fileSocketTransport_Accept;
+    nif.IsOpen = fileSocketTransport_IsOpen;
+    nif.Close = fileSocketTransport_Close;
+    nif.ReadPacket = fileSocketTransport_ReadPacket;
+    nif.WritePacket = fileSocketTransport_WritePacket;
+    nif.GetLastError = fileSocketTransport_GetLastError;
+    if (version >= JDWPTRANSPORT_VERSION_1_1) {
+        nif.SetTransportConfiguration = fileSocketTransport_SetTransportConfiguration;
+    }
+    *env = (jdwpTransportEnv*) &single_env;
+
+    return JNI_OK;
+}

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
@@ -101,7 +101,8 @@ static jdwpTransportError JNICALL fileSocketTransport_Close(jdwpTransportEnv* en
 
 static jdwpTransportError JNICALL fileSocketTransport_Attach(jdwpTransportEnv* env, const char* address, jlong attach_timeout, jlong handshake_timeout) {
     /* We don't support attach. */
-    return JDWPTRANSPORT_ERROR_NONE;
+    fileSocketTransport_logError("Only server=y mode is supported by dt_filesocket");
+    return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
 }
 
 static jdwpTransportError JNICALL fileSocketTransport_StartListening(jdwpTransportEnv* env, const char* address, char** actual_address) {

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
@@ -34,5 +34,5 @@ void fileSocketTransport_CloseImpl();
 void fileSocketTransport_AcceptImpl(char const* name);
 int fileSocketTransport_ReadImpl(char* buffer, int size);
 int fileSocketTransport_WriteImpl(char* buffer, int size);
-
+char* fileSocketTransport_GetDefaultAddress();
 #endif

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
@@ -28,9 +28,7 @@
 #ifndef FILE_SOCKET_TRANSPORT_H
 #define FILE_SOCKET_TRANSPORT_H
 
-#define log_error fileSocketTransport_logError
-
-void log_error(char const* format, ...);
+void fileSocketTransport_logError(char const* format, ...);
 jboolean fileSocketTransport_HasValidHandle();
 void fileSocketTransport_CloseImpl();
 void fileSocketTransport_AcceptImpl(char const* name);

--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+
+#ifndef FILE_SOCKET_TRANSPORT_H
+#define FILE_SOCKET_TRANSPORT_H
+
+#define log_error fileSocketTransport_logError
+
+void log_error(char const* format, ...);
+jboolean fileSocketTransport_HasValidHandle();
+void fileSocketTransport_CloseImpl();
+void fileSocketTransport_AcceptImpl(char const* name);
+int fileSocketTransport_ReadImpl(char* buffer, int size);
+int fileSocketTransport_WriteImpl(char* buffer, int size);
+
+#endif

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -158,9 +158,13 @@ void fileSocketTransport_AcceptImpl(char const* name) {
 }
 
 int fileSocketTransport_ReadImpl(char* buffer, int size) {
-    int result = read(handle, buffer, size);
+    int result;
 
-    if (result <= 0) {
+    do {
+        result = read(handle, buffer, size);
+    } while (result == -1 && errno == EINTR);
+
+    if (result < 0) {
         fileSocketTransport_logError("Read failed with result %d: %s", result, strerror(errno));
     }
 
@@ -168,9 +172,13 @@ int fileSocketTransport_ReadImpl(char* buffer, int size) {
 }
 
 int fileSocketTransport_WriteImpl(char* buffer, int size) {
-    int result = write(handle, buffer, size);
+    int result;
 
-    if (result <= 0) {
+    do {
+        result = write(handle, buffer, size);
+    } while (result == -1 && errno == EINTR);
+
+    if (result < 0) {
         fileSocketTransport_logError("Write failed with result %d: %s", result, strerror(errno));
     }
 

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -119,27 +119,27 @@ void fileSocketTransport_AcceptImpl(char const* name) {
         }
 
         if ((access(name, F_OK )) != -1 && (unlink(name) != 0)) {
-            log_error("Could not remove %s to create new file socket", name);
+            fileSocketTransport_logError("Could not remove %s to create new file socket", name);
             closeServerHandle();
             return;
         }
 
         if (bind(server_handle, (struct sockaddr*) &addr, addr_size) == -1) {
-            log_error("Could not bind file socket %s: %s", name, strerror(errno));
+            fileSocketTransport_logError("Could not bind file socket %s: %s", name, strerror(errno));
             closeServerHandle();
             return;
         }
 
 
         if (listen(server_handle, 1) == -1) {
-            log_error("Could not listen on file socket %s: %s", name, strerror(errno));
+            fileSocketTransport_logError("Could not listen on file socket %s: %s", name, strerror(errno));
             unlink(name);
             closeServerHandle();
             return;
         }
 
         if (chmod(name, (S_IREAD|S_IWRITE) &  ~(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) == -1) {
-            log_error("Chmod on %s failed: %s", strerror(errno));
+            fileSocketTransport_logError("Chmod on %s failed: %s", strerror(errno));
             unlink(name);
             closeServerHandle();
             return;
@@ -153,7 +153,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
   } while (server_handle == INVALID_HANDLE_VALUE && errno == EINTR);
 
   if (handle == INVALID_HANDLE_VALUE) {
-    log_error("Could not accept on file socket %s: %s", strerror(errno));
+      fileSocketTransport_logError("Could not accept on file socket %s: %s", strerror(errno));
   }
 }
 
@@ -161,7 +161,7 @@ int fileSocketTransport_ReadImpl(char* buffer, int size) {
     int result = read(handle, buffer, size);
 
     if (result <= 0) {
-        log_error("Read failed with result %d: %s", result, strerror(errno));
+        fileSocketTransport_logError("Read failed with result %d: %s", result, strerror(errno));
     }
 
     return result;
@@ -171,7 +171,7 @@ int fileSocketTransport_WriteImpl(char* buffer, int size) {
     int result = write(handle, buffer, size);
 
     if (result <= 0) {
-        log_error("Read failed with result %d: %s", result, strerror(errno));
+        fileSocketTransport_logError("Read failed with result %d: %s", result, strerror(errno));
     }
 
     return result;

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <sys/time.h>
+#include <sys/times.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <signal.h>
+#include <stdio.h>
+#include <strings.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <pthread.h>
+#include <pwd.h>
+
+#ifdef __sun
+#include <sys/filio.h>
+#endif
+
+// MacOS X does not declare the macros SIGRTMIN and SIGRTMAX
+#ifdef __APPLE__
+  #ifndef SIGRTMAX
+    #define SIGRTMAX SIGUSR2
+  #endif
+#endif
+
+#include "jni.h"
+#include "fileSocketTransport.h"
+
+#define INVALID_HANDLE_VALUE -1
+static int server_handle = INVALID_HANDLE_VALUE;
+static int handle = INVALID_HANDLE_VALUE;
+
+static void closeServerHandle() {
+    if (server_handle != INVALID_HANDLE_VALUE) {
+        int rv = -1;
+
+        do {
+           rv = close(server_handle);
+        } while (rv == -1 && errno == EINTR);
+
+
+        server_handle = INVALID_HANDLE_VALUE;
+    }
+}
+
+jboolean fileSocketTransport_HasValidHandle() {
+    return handle == INVALID_HANDLE_VALUE ? JNI_FALSE : JNI_TRUE;
+}
+
+void fileSocketTransport_CloseImpl() {
+    if (handle != INVALID_HANDLE_VALUE) {
+        int rv = -1;
+
+        shutdown(handle, SHUT_RDWR);
+
+        do {
+           rv = close(handle);
+        } while (rv == -1 && errno == EINTR);
+
+
+        handle = INVALID_HANDLE_VALUE;
+    }
+}
+
+void fileSocketTransport_AcceptImpl(char const* name) {
+    struct sockaddr_un addr;
+    socklen_t len = sizeof(struct sockaddr_un);
+
+    if (server_handle == INVALID_HANDLE_VALUE) {
+        struct sockaddr_un addr;
+#ifdef _AIX
+        // on some as400 releases we need this
+        const int addr_size = SUN_LEN(&addr);
+#else
+        const int addr_size = sizeof(addr);
+#endif
+        memset((void *) &addr, 0, len);
+        addr.sun_family = AF_UNIX;
+        strncpy(addr.sun_path, name, sizeof(addr.sun_path) - 1);
+
+        server_handle = socket(PF_UNIX, SOCK_STREAM, 0);
+
+        if (server_handle == INVALID_HANDLE_VALUE) {
+            return;
+        }
+
+        if ((access(name, F_OK )) != -1 && (unlink(name) != 0)) {
+            log_error("Could not remove %s to create new file socket", name);
+            closeServerHandle();
+            return;
+        }
+
+        if (bind(server_handle, (struct sockaddr*) &addr, addr_size) == -1) {
+            log_error("Could not bind file socket %s: %s", name, strerror(errno));
+            closeServerHandle();
+            return;
+        }
+
+
+        if (listen(server_handle, 1) == -1) {
+            log_error("Could not listen on file socket %s: %s", name, strerror(errno));
+            unlink(name);
+            closeServerHandle();
+            return;
+        }
+
+        if (chmod(name, (S_IREAD|S_IWRITE) &  ~(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) == -1) {
+            log_error("Chmod on %s failed: %s", strerror(errno));
+            unlink(name);
+            closeServerHandle();
+            return;
+        }
+  }
+
+  memset((void *) &addr, 0, len);
+
+  do {
+    handle = accept(server_handle, (struct sockaddr *) &addr, &len);
+  } while (server_handle == INVALID_HANDLE_VALUE && errno == EINTR);
+
+  if (handle == INVALID_HANDLE_VALUE) {
+    log_error("Could not accept on file socket %s: %s", strerror(errno));
+  }
+}
+
+int fileSocketTransport_ReadImpl(char* buffer, int size) {
+    int result = read(handle, buffer, size);
+
+    if (result <= 0) {
+        log_error("Read failed with result %d: %s", result, strerror(errno));
+    }
+
+    return result;
+}
+
+int fileSocketTransport_WriteImpl(char* buffer, int size) {
+    int result = write(handle, buffer, size);
+
+    if (result <= 0) {
+        log_error("Read failed with result %d: %s", result, strerror(errno));
+    }
+
+    return result;
+}

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -145,7 +145,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
     }
 
     do {
-        handle = accept(server_handle, NULL, 0);
+        handle = accept(server_handle, NULL, NULL);
     } while (server_handle == INVALID_HANDLE_VALUE && errno == EINTR);
 
     if (handle == INVALID_HANDLE_VALUE) {

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -97,10 +97,8 @@ void fileSocketTransport_CloseImpl() {
 }
 
 void fileSocketTransport_AcceptImpl(char const* name) {
-    struct sockaddr_un addr;
-    socklen_t len = sizeof(struct sockaddr_un);
-
     if (server_handle == INVALID_HANDLE_VALUE) {
+        socklen_t len = sizeof(struct sockaddr_un);
         struct sockaddr_un addr;
 #ifdef _AIX
         // on some as400 releases we need this
@@ -146,10 +144,8 @@ void fileSocketTransport_AcceptImpl(char const* name) {
         }
     }
 
-    memset((void *) &addr, 0, len);
-
     do {
-        handle = accept(server_handle, (struct sockaddr *) &addr, &len);
+        handle = accept(server_handle, NULL, len);
     } while (server_handle == INVALID_HANDLE_VALUE && errno == EINTR);
 
     if (handle == INVALID_HANDLE_VALUE) {

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -145,7 +145,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
     }
 
     do {
-        handle = accept(server_handle, NULL, len);
+        handle = accept(server_handle, NULL, 0);
     } while (server_handle == INVALID_HANDLE_VALUE && errno == EINTR);
 
     if (handle == INVALID_HANDLE_VALUE) {

--- a/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_filesocket/fileSocketTransport_md.c
@@ -180,3 +180,14 @@ int fileSocketTransport_WriteImpl(char* buffer, int size) {
 
     return result;
 }
+
+static char default_name[160] = { 0, };
+
+char* fileSocketTransport_GetDefaultAddress() {
+    if (default_name[0] == '\0') {
+        snprintf(default_name, sizeof(default_name), "/tmp/dt_filesocket_%lld_%lld", (long long) getpid(), (long long) geteuid());
+        default_name[sizeof(default_name) - 1] = '\0';
+    }
+
+    return default_name;
+}

--- a/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
@@ -126,7 +126,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
     static jboolean event_initialized = JNI_FALSE;
 
     if (!event_initialized && !initEvents(events, sizeof(events) / sizeof(events[0]))) {
-        log_error("Could not initialize events.");
+        fileSocketTransport_logError("Could not initialize events.");
         return;
     }
 
@@ -136,10 +136,10 @@ void fileSocketTransport_AcceptImpl(char const* name) {
         PTOKEN_USER sid = GetUserSid();
         LPTSTR result;
         if (!sid) {
-            log_error("Could not get the user sid");
+            fileSocketTransport_logError("Could not get the user sid");
             return;
         } else if (!ConvertSidToStringSid(sid->User.Sid, &result)) {
-            log_error("Could not convert the user sid to a string");
+            fileSocketTransport_logError("Could not convert the user sid to a string");
             return;
         } else {
             user_id = (char const*) result;
@@ -155,7 +155,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
     sec->bInheritHandle = FALSE;
 
     if (!ConvertStringSecurityDescriptorToSecurityDescriptor(sec_spec, SDDL_REVISION_1, &(sec->lpSecurityDescriptor), NULL)) {
-        log_error("Could not convert security descriptor %s", sec_spec);
+        fileSocketTransport_logError("Could not convert security descriptor %s", sec_spec);
         free(sec);
         return;
     }
@@ -165,7 +165,7 @@ void fileSocketTransport_AcceptImpl(char const* name) {
     free(sec);
 
     if (handle == INVALID_HANDLE_VALUE) {
-        log_error("Could not create pipe, error code %lld", (long long) GetLastError());
+        fileSocketTransport_logError("Could not create pipe, error code %lld", (long long) GetLastError());
         return;
     }
 
@@ -197,13 +197,13 @@ void fileSocketTransport_AcceptImpl(char const* name) {
                         CancelIo(handle);
                     }
                 } else {
-                    log_error("Accept error (wait): %d", waitResult);
+                    fileSocketTransport_logError("Accept error (wait): %d", waitResult);
                     fileSocketTransport_CloseImpl();
                     return;
                 }
             } else {
                 // we definitely cannot get a new client connection (for example pipe was closed)
-                log_error("Accept error (connect) : %d.", (int) lastError);
+                fileSocketTransport_logError("Accept error (connect) : %d.", (int) lastError);
                 fileSocketTransport_CloseImpl();
                 return;
             }
@@ -223,16 +223,16 @@ int fileSocketTransport_ReadImpl(char* buffer, int size) {
 
             if (waitResult == WAIT_OBJECT_0) {
                 if (!GetOverlappedResult(handle, &read_event, &nread, FALSE)) {
-                    log_error("Read failed (overlap): %d", (int) GetLastError());
+                    fileSocketTransport_logError("Read failed (overlap): %d", (int) GetLastError());
                     return 0;
                 }
             } else {
                 CancelIo(handle);
-                log_error("Read failed (wait): %d", (int) waitResult);
+                fileSocketTransport_logError("Read failed (wait): %d", (int) waitResult);
                 return 0;
             }
         } else {
-            log_error("Read failed: %d", (int) GetLastError());
+            fileSocketTransport_logError("Read failed: %d", (int) GetLastError());
             return 0;
         }
     }
@@ -252,16 +252,16 @@ int fileSocketTransport_WriteImpl(char* buffer, int size) {
 
             if (waitResult == WAIT_OBJECT_0) {
                 if (!GetOverlappedResult(handle, &write_event, &nwrite, FALSE)) {
-                    log_error("Write failed (overlap): %d", (int) GetLastError());
+                    fileSocketTransport_logError("Write failed (overlap): %d", (int) GetLastError());
                     return 0;
                 }
             } else {
                 CancelIo(handle);
-                log_error("Write_failed (wait): %d", (int) waitResult);
+                fileSocketTransport_logError("Write_failed (wait): %d", (int) waitResult);
                 return 0;
             }
         } else {
-            log_error("Write failed: %d", (int) GetLastError());
+            fileSocketTransport_logError("Write failed: %d", (int) GetLastError());
             return 0;
         }
     }

--- a/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
@@ -224,16 +224,16 @@ int fileSocketTransport_ReadImpl(char* buffer, int size) {
             if (waitResult == WAIT_OBJECT_0) {
                 if (!GetOverlappedResult(handle, &read_event, &nread, FALSE)) {
                     fileSocketTransport_logError("Read failed (overlap): %d", (int) GetLastError());
-                    return 0;
+                    return -1;
                 }
             } else {
                 CancelIo(handle);
                 fileSocketTransport_logError("Read failed (wait): %d", (int) waitResult);
-                return 0;
+                return -1;
             }
         } else {
             fileSocketTransport_logError("Read failed: %d", (int) GetLastError());
-            return 0;
+            return -1;
         }
     }
 
@@ -253,16 +253,16 @@ int fileSocketTransport_WriteImpl(char* buffer, int size) {
             if (waitResult == WAIT_OBJECT_0) {
                 if (!GetOverlappedResult(handle, &write_event, &nwrite, FALSE)) {
                     fileSocketTransport_logError("Write failed (overlap): %d", (int) GetLastError());
-                    return 0;
+                    return -1;
                 }
             } else {
                 CancelIo(handle);
                 fileSocketTransport_logError("Write_failed (wait): %d", (int) waitResult);
-                return 0;
+                return -1;
             }
         } else {
             fileSocketTransport_logError("Write failed: %d", (int) GetLastError());
-            return 0;
+            return -1;
         }
     }
 

--- a/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
@@ -267,3 +267,23 @@ int fileSocketTransport_WriteImpl(char* buffer, int size) {
 
     return (int) nwrite;
 }
+
+static char default_name[160] = { 0, };
+
+char* fileSocketTransport_GetDefaultAddress() {
+    if (default_name[0] == '\0') {
+        PTOKEN_USER user = GetUserSid();
+        char* user_name = NULL;
+        if (ConvertSidToStringSidA(user->User.Sid, &user_name)) {
+            snprintf(default_name, sizeof(default_name), "\\\\.\\Pipe\\dt_filesocket_%lld_%s", (long long) _getpid(),
+                user_name ? user_name : "unknown_user");
+            LocalFree(user_name);
+            default_name[sizeof(default_name) - 1] = '\0';
+        } else {
+            fileSocketTransport_logError("Could not convert sid: %d", GetLastError());
+            return NULL;
+        }
+    }
+
+    return default_name;
+}

--- a/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
@@ -110,7 +110,6 @@ void fileSocketTransport_CloseImpl() {
     SetEvent(cancel_event.hEvent);
 
     if (tmp != INVALID_HANDLE_VALUE) {
-        CancelIo(tmp);
         DisconnectNamedPipe(tmp);
         CloseHandle(tmp);
         handle = INVALID_HANDLE_VALUE;

--- a/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_filesocket/fileSocketTransport_md.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdlib.h>
+
+#include "jni.h"
+#include "fileSocketTransport.h"
+
+#include <windows.h>
+#include <process.h>
+#include <sddl.h>
+
+static volatile HANDLE handle = INVALID_HANDLE_VALUE;
+static PTOKEN_USER our_user_sid = (PTOKEN_USER) &our_user_sid;
+static OVERLAPPED read_event;
+static OVERLAPPED write_event;
+static OVERLAPPED cancel_event;
+static OVERLAPPED accept_event;
+static OVERLAPPED* events[] = { &read_event, &write_event, &cancel_event, &accept_event };
+
+static PTOKEN_USER GetUserSid() {
+    if (our_user_sid == (PTOKEN_USER) &our_user_sid) {
+        HANDLE process = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, _getpid());
+        HANDLE token = NULL;
+        our_user_sid = NULL;
+
+        if (process != NULL && OpenProcessToken(process, TOKEN_QUERY, &token)) {
+            DWORD size = 0;
+            PTOKEN_USER user = NULL;
+            BOOL success;
+
+            GetTokenInformation(token, TokenUser, NULL, 0, &size);
+            user = (PTOKEN_USER) malloc(size);
+            success = GetTokenInformation(token, TokenUser, user, size, &size);
+
+            CloseHandle(token);
+            CloseHandle(process);
+
+            if (success &&  IsValidSid(user->User.Sid)) {
+                our_user_sid = user;
+            } else {
+                free(user);
+            }
+        } else if (process != NULL) {
+            CloseHandle(process);
+        }
+    }
+
+    return our_user_sid;
+}
+
+static void destroyEvents(OVERLAPPED** events, int nr_of_events) {
+    int i;
+
+    for (i = 0; i < nr_of_events; ++i) {
+        if (events[i]->hEvent != NULL) {
+            CloseHandle(events[i]->hEvent);
+        }
+
+        ZeroMemory(events[i], sizeof(OVERLAPPED));
+    }
+}
+
+static jboolean initEvents(OVERLAPPED** events, int nr_of_events) {
+    int i;
+
+    destroyEvents(events, nr_of_events);
+
+    for (i = 0; i < nr_of_events; ++i) {
+        ZeroMemory(events[i], sizeof(OVERLAPPED));
+        events[i]->hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+        if (events[i]->hEvent == NULL) {
+            destroyEvents(events, i - 1);
+            return JNI_FALSE;
+        }
+    }
+
+    return JNI_TRUE;
+}
+
+jboolean fileSocketTransport_HasValidHandle() {
+    return handle == INVALID_HANDLE_VALUE ? JNI_FALSE : JNI_TRUE;
+}
+
+void fileSocketTransport_CloseImpl() {
+    HANDLE tmp = handle;
+    SetEvent(cancel_event.hEvent);
+
+    if (tmp != INVALID_HANDLE_VALUE) {
+        CancelIo(tmp);
+        DisconnectNamedPipe(tmp);
+        CloseHandle(tmp);
+        handle = INVALID_HANDLE_VALUE;
+    }
+}
+
+void fileSocketTransport_AcceptImpl(char const* name) {
+    // Allow access to admins and user, but not others.
+    LPSECURITY_ATTRIBUTES sec = NULL;
+    char sec_spec[1024];
+    static char const* user_id = NULL;
+    jboolean connected = JNI_FALSE;
+    static jboolean event_initialized = JNI_FALSE;
+
+    if (!event_initialized && !initEvents(events, sizeof(events) / sizeof(events[0]))) {
+        log_error("Could not initialize events.");
+        return;
+    }
+
+    event_initialized = TRUE;
+
+    if (user_id == NULL) {
+        PTOKEN_USER sid = GetUserSid();
+        LPTSTR result;
+        if (!sid) {
+            log_error("Could not get the user sid");
+            return;
+        } else if (!ConvertSidToStringSid(sid->User.Sid, &result)) {
+            log_error("Could not convert the user sid to a string");
+            return;
+        } else {
+            user_id = (char const*) result;
+        }
+    }
+
+    snprintf(sec_spec, sizeof(sec_spec),
+        "D:"
+        "(A;OICI;FA;;;%s)"
+        "(A;OICI;FA;;;BA)", user_id);
+    sec = (LPSECURITY_ATTRIBUTES) malloc(sizeof(SECURITY_ATTRIBUTES));
+    sec->nLength = sizeof(SECURITY_ATTRIBUTES);
+    sec->bInheritHandle = FALSE;
+
+    if (!ConvertStringSecurityDescriptorToSecurityDescriptor(sec_spec, SDDL_REVISION_1, &(sec->lpSecurityDescriptor), NULL)) {
+        log_error("Could not convert security descriptor %s", sec_spec);
+        free(sec);
+        return;
+    }
+
+    handle = CreateNamedPipe(name, FILE_FLAG_OVERLAPPED | PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+        1, 4096, 4096, NMPWAIT_USE_DEFAULT_WAIT, sec);
+    free(sec);
+
+    if (handle == INVALID_HANDLE_VALUE) {
+        log_error("Could not create pipe, error code %lld", (long long) GetLastError());
+        return;
+    }
+
+    ResetEvent(accept_event.hEvent);
+    ResetEvent(cancel_event.hEvent);
+
+    while (!connected) {
+        DWORD lastError;
+
+        connected = ConnectNamedPipe(handle, &accept_event);
+        lastError = GetLastError();
+
+        if (!connected && (lastError == ERROR_PIPE_CONNECTED)) {
+            connected = TRUE;
+        }
+
+        if (!connected) {
+            if (lastError == ERROR_IO_PENDING) {
+                // The ConnectNamedPipe is still in progress. wait until signaled...
+                // we wait for two different signals, not both signals must be 1, wait until signal is seen
+                HANDLE hOverlapped[2] = { accept_event.hEvent, cancel_event.hEvent };
+                DWORD waitResult = WaitForMultipleObjects(2, hOverlapped, FALSE, INFINITE);
+
+                if (waitResult == WAIT_OBJECT_0) {
+                    // client has connected
+                    if (HasOverlappedIoCompleted(&accept_event)) {
+                        connected = TRUE;
+                    } else {
+                        CancelIo(handle);
+                    }
+                } else {
+                    log_error("Accept error (wait): %d", waitResult);
+                    fileSocketTransport_CloseImpl();
+                    return;
+                }
+            } else {
+                // we definitely cannot get a new client connection (for example pipe was closed)
+                log_error("Accept error (connect) : %d.", (int) lastError);
+                fileSocketTransport_CloseImpl();
+                return;
+            }
+        }
+    }
+}
+
+int fileSocketTransport_ReadImpl(char* buffer, int size) {
+    DWORD nread = 0;
+
+    ResetEvent(read_event.hEvent);
+
+    if (!ReadFile(handle, (LPVOID) buffer, (DWORD) size, &nread, &read_event)) {
+        if (GetLastError() == ERROR_IO_PENDING) {
+            HANDLE hOverlapped[2] = { read_event.hEvent, cancel_event.hEvent };
+            DWORD waitResult = WaitForMultipleObjects(2, hOverlapped, FALSE, INFINITE);
+
+            if (waitResult == WAIT_OBJECT_0) {
+                if (!GetOverlappedResult(handle, &read_event, &nread, FALSE)) {
+                    log_error("Read failed (overlap): %d", (int) GetLastError());
+                    return 0;
+                }
+            } else {
+                CancelIo(handle);
+                log_error("Read failed (wait): %d", (int) waitResult);
+                return 0;
+            }
+        } else {
+            log_error("Read failed: %d", (int) GetLastError());
+            return 0;
+        }
+    }
+
+    return (int) nread;
+}
+
+int fileSocketTransport_WriteImpl(char* buffer, int size) {
+    DWORD nwrite = 0;
+
+    ResetEvent(write_event.hEvent);
+
+    if (!WriteFile(handle, buffer, (DWORD) size, &nwrite, &write_event)) {
+        if (GetLastError() == ERROR_IO_PENDING) {
+            HANDLE hOverlapped[2] = { write_event.hEvent, cancel_event.hEvent };
+            DWORD waitResult = WaitForMultipleObjects(2, hOverlapped, FALSE, INFINITE);
+
+            if (waitResult == WAIT_OBJECT_0) {
+                if (!GetOverlappedResult(handle, &write_event, &nwrite, FALSE)) {
+                    log_error("Write failed (overlap): %d", (int) GetLastError());
+                    return 0;
+                }
+            } else {
+                CancelIo(handle);
+                log_error("Write_failed (wait): %d", (int) waitResult);
+                return 0;
+            }
+        } else {
+            log_error("Write failed: %d", (int) GetLastError());
+            return 0;
+        }
+    }
+
+    return (int) nwrite;
+}


### PR DESCRIPTION
This is the first implementation of the dt_filesocket transport. It still resides in the jdk.jdwp.agent module and has not yet the best possible behaviour in case of errors (when the pipe/domain socket cannot be created).

fixes #207

