### PR TITLE
SapMachine #214: Fix Windows build after SapMachine #203

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -52,6 +52,10 @@ BUILD_JDK_JTREG_IMAGE_DIR := $(TEST_IMAGE_DIR)/jdk/jtreg
 ifeq ($(OPENJDK_TARGET_OS), windows)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c
 
+  #SapMachine 2018-12-11: Eclude libCreateNewProcessGroupOnSpawnTest.c from
+  #                       native compilation because test is non-Windows only
+  BUILD_JDK_JTREG_EXCLUDE += libCreateNewProcessGroupOnSpawnTest.c
+
   WIN_LIB_JAVA := $(SUPPORT_OUTPUTDIR)/native/java.base/libjava/java.lib
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := $(WIN_LIB_JAVA)
 else

--- a/test/jdk/sap/java/lang/libCreateNewProcessGroupOnSpawnTest.c
+++ b/test/jdk/sap/java/lang/libCreateNewProcessGroupOnSpawnTest.c
@@ -1,7 +1,29 @@
+/*
+ * Copyright (c) 2018, SAP. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 #include <unistd.h>
 
 #include "jni.h"
-
 
 JNIEXPORT jlong Java_CreateNewProcessGroupOnSpawnTest_getpgid0 (JNIEnv *env, jclass ignore, jlong pid) {
     return (jlong) getpgid((pid_t)pid);


### PR DESCRIPTION
Also add a copyright header to test/jdk/sap/java/lang/libCreateNewProcessGroupOnSpawnTest.c

fixes #214