### PR TITLE
SapMachine #220: Enable ExtensiveErrorReports in SapMachine

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1261,8 +1261,9 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
           "If an error occurs, save the error data to this file "           \
           "[default: ./hs_err_pid%p.log] (%p replaced with pid)")           \
                                                                             \
+  /* SapMachine 2018-12-18 Enable this per default. */                      \
   product(bool, ExtensiveErrorReports,                                      \
-          PRODUCT_ONLY(false) NOT_PRODUCT(true),                            \
+          PRODUCT_ONLY(true) NOT_PRODUCT(true),                             \
           "Error reports are more extensive.")                              \
                                                                             \
   product(bool, DisplayVMOutputToStderr, false,                             \


### PR DESCRIPTION
Push this to SapMachine. Still needs to be downported to 12, 11. (For 11, we 
need to wait until 8211845 arrives in SapMachine11, which we downport to 
OpenJDK jdk11u.)

fixes #220

