### PR TITLE
11u2 backports

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1113,7 +1113,7 @@ void LIRGenerator::do_ExceptionObject(ExceptionObject* x) {
   // no moves are created for phi functions at the begin of exception
   // handlers, so assign operands manually here
   for_each_phi_fun(block(), phi,
-                   operand_for_instruction(phi));
+                   if (!phi->is_illegal()) { operand_for_instruction(phi); });
 
   LIR_Opr thread_reg = getThreadPointer();
   __ move_wide(new LIR_Address(thread_reg, in_bytes(JavaThread::exception_oop_offset()), T_OBJECT),

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -574,7 +574,7 @@ void LinearScan::compute_local_live_sets() {
       // Phi functions at the begin of an exception handler are
       // implicitly defined (= killed) at the beginning of the block.
       for_each_phi_fun(block, phi,
-        live_kill.set_bit(phi->operand()->vreg_number())
+        if (!phi->is_illegal()) { live_kill.set_bit(phi->operand()->vreg_number()); }
       );
     }
 
@@ -1904,7 +1904,7 @@ void LinearScan::resolve_exception_entry(BlockBegin* block, MoveResolver &move_r
 
   // the live_in bits are not set for phi functions of the xhandler entry, so iterate them separately
   for_each_phi_fun(block, phi,
-    resolve_exception_entry(block, phi->operand()->vreg_number(), move_resolver)
+    if (!phi->is_illegal()) { resolve_exception_entry(block, phi->operand()->vreg_number(), move_resolver); }
   );
 
   if (move_resolver.has_mappings()) {
@@ -1978,7 +1978,7 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, M
 
   // the live_in bits are not set for phi functions of the xhandler entry, so iterate them separately
   for_each_phi_fun(block, phi,
-    resolve_exception_edge(handler, throwing_op_id, phi->operand()->vreg_number(), phi, move_resolver)
+    if (!phi->is_illegal()) { resolve_exception_edge(handler, throwing_op_id, phi->operand()->vreg_number(), phi, move_resolver); }
   );
 
   if (move_resolver.has_mappings()) {

--- a/src/hotspot/share/c1/c1_ValueStack.hpp
+++ b/src/hotspot/share/c1/c1_ValueStack.hpp
@@ -299,7 +299,7 @@ class ValueStack: public CompilationResourceObj {
 }
 
 
-// Macro definition for simple iteration of all phif functions of a block, i.e all
+// Macro definition for simple iteration of all phi functions of a block, i.e all
 // phi functions of the ValueStack where the block matches.
 // Use the following code pattern to iterate all phi functions of a block:
 //
@@ -315,7 +315,7 @@ class ValueStack: public CompilationResourceObj {
   Value value;                                                                                 \
   {                                                                                            \
     for_each_stack_value(cur_state, cur_index, value) {                                        \
-      Phi* v_phi = value->as_Phi();                                                      \
+      Phi* v_phi = value->as_Phi();                                                            \
       if (v_phi != NULL && v_phi->block() == v_block) {                                        \
         v_code;                                                                                \
       }                                                                                        \
@@ -323,7 +323,7 @@ class ValueStack: public CompilationResourceObj {
   }                                                                                            \
   {                                                                                            \
     for_each_local_value(cur_state, cur_index, value) {                                        \
-      Phi* v_phi = value->as_Phi();                                                      \
+      Phi* v_phi = value->as_Phi();                                                            \
       if (v_phi != NULL && v_phi->block() == v_block) {                                        \
         v_code;                                                                                \
       }                                                                                        \

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -894,14 +894,19 @@ void CompileBroker::possibly_add_compiler_threads() {
   EXCEPTION_MARK;
 
   julong available_memory = os::available_memory();
+  // If SegmentedCodeCache is off, both values refer to the single heap (with type CodeBlobType::All).
+  size_t available_cc_np  = CodeCache::unallocated_capacity(CodeBlobType::MethodNonProfiled),
+         available_cc_p   = CodeCache::unallocated_capacity(CodeBlobType::MethodProfiled);
+
   // Only do attempt to start additional threads if the lock is free.
   if (!CompileThread_lock->try_lock()) return;
 
   if (_c2_compile_queue != NULL) {
     int old_c2_count = _compilers[1]->num_compiler_threads();
-    int new_c2_count = MIN3(_c2_count,
+    int new_c2_count = MIN4(_c2_count,
         _c2_compile_queue->size() / 2,
-        (int)(available_memory / 200*M));
+        (int)(available_memory / (200*M)),
+        (int)(available_cc_np / (128*K)));
 
     for (int i = old_c2_count; i < new_c2_count; i++) {
       JavaThread *ct = make_thread(compiler2_object(i), _c2_compile_queue, _compilers[1], true, CHECK);
@@ -910,17 +915,18 @@ void CompileBroker::possibly_add_compiler_threads() {
       if (TraceCompilerThreads) {
         ResourceMark rm;
         MutexLocker mu(Threads_lock);
-        tty->print_cr("Added compiler thread %s (available memory: %dMB)",
-                      ct->get_thread_name(), (int)(available_memory/M));
+        tty->print_cr("Added compiler thread %s (available memory: %dMB, available non-profiled code cache: %dMB)",
+                      ct->get_thread_name(), (int)(available_memory/M), (int)(available_cc_np/M));
       }
     }
   }
 
   if (_c1_compile_queue != NULL) {
     int old_c1_count = _compilers[0]->num_compiler_threads();
-    int new_c1_count = MIN3(_c1_count,
+    int new_c1_count = MIN4(_c1_count,
         _c1_compile_queue->size() / 4,
-        (int)(available_memory / 100*M));
+        (int)(available_memory / (100*M)),
+        (int)(available_cc_p / (128*K)));
 
     for (int i = old_c1_count; i < new_c1_count; i++) {
       JavaThread *ct = make_thread(compiler1_object(i), _c1_compile_queue, _compilers[0], true, CHECK);
@@ -929,8 +935,8 @@ void CompileBroker::possibly_add_compiler_threads() {
       if (TraceCompilerThreads) {
         ResourceMark rm;
         MutexLocker mu(Threads_lock);
-        tty->print_cr("Added compiler thread %s (available memory: %dMB)",
-                      ct->get_thread_name(), (int)(available_memory/M));
+        tty->print_cr("Added compiler thread %s (available memory: %dMB, available profiled code cache: %dMB)",
+                      ct->get_thread_name(), (int)(available_memory/M), (int)(available_cc_p/M));
       }
     }
   }


### PR DESCRIPTION
I'd like to backport 8213086 from 11u3 to have a better limit for compiler threads.
The backport of 8214352 from 13 is for better behavior with debugging on demand (JVMTI "can_access_local_variables" enabled). Both changes apply cleanly.

fixes #232