### PR TITLE
SAPMachine #253: Fix test jdk/java/net/Socket/ExceptionText.java (sapmachine12)

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -26,7 +26,9 @@
 #
 
 # When adding tests to tier1, make sure they end up in one of the tier1_partX groups
+# SapMachine 2019-01-23: Add tests where SAPMachine has different behavior to tier1
 tier1 = \
+    :tier1_sapmachine \
     :tier1_part1 \
     :tier1_part2 \
     :tier1_part3
@@ -44,6 +46,10 @@ tier1_part3 = \
     com/sun/crypto/provider/Cipher \
     sun/nio/cs/ISO8859x.java \
     tools/pack200
+
+# SapMachine 2019-01-23: Add tests where SAPMachine has different behavior to tier1
+tier1_sapmachine = \
+    java/net/Socket/ExceptionText.java
 
 # When adding tests to tier2, make sure they end up in one of the tier2_partX groups
 tier2 = \

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
-
-// SapMachine 2018-11-23: SapMachine has set jdk.includeInExceptions to hostInfo,jar
+// SapMachine 2018-11-23: SapMachine sets "hostInfo" in jdk.includeInExceptions
 //                        by default. Therefore expect according output!
+
 /*
  * @test
  * @library /test/lib
@@ -68,6 +68,7 @@ import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SocketChannel;
 import java.security.Security;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import jdk.test.lib.Utils;
 
@@ -96,10 +97,11 @@ public class ExceptionText {
 
     static void testSecProp() {
         String incInExc = Security.getProperty("jdk.includeInExceptions");
-        // SapMachine 2018-11-23: SapMachine has jdk.includeInExceptions set to hostInfo,jar 
-        if (!"hostInfo,jar".equals(incInExc)) {
+        // SapMachine 2018-11-23: SapMachine sets "hostInfo" in jdk.includeInExceptions
+        if (incInExc == null || !Arrays.asList(incInExc.split(",")).contains("hostInfo")) {
             throw new RuntimeException("Test failed: default value of " +
-                "jdk.includeInExceptions security property is not hostInfo,jar");
+                "jdk.includeInExceptions security property is: " +
+                incInExc);
         }
     }
 


### PR DESCRIPTION
…move it to tier1

(cherry picked from commit 052419a1d409da4efd3c3a3c440ea9c3a457a00a)

fixes #253

