### PR TITLE
(SapMachine12) Include tests for areas where SapMachine differs from OpenJDK in tier1

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -26,7 +26,9 @@
 #
 
 # When adding tests to tier1, make sure they end up in one of the tier1_partX groups
+# SapMachine 2019-01-24: Add tests where SAPMachine has different behavior to tier1
 tier1 = \
+    :tier1_sapmachine \
     :tier1_part1 \
     :tier1_part2 \
     :tier1_part3
@@ -44,6 +46,13 @@ tier1_part3 = \
     com/sun/crypto/provider/Cipher \
     sun/nio/cs/ISO8859x.java \
     tools/pack200
+
+# SapMachine 2019-01-24: Add tests where SAPMachine has different behavior to tier1
+tier1_sapmachine = \
+    java/net/Socket/ExceptionText.java \
+    java/util/jar/Manifest/IncludeInExceptionsTest.java \
+    jdk/security/JavaDotSecurity/TestJDKIncludeInExceptions.java \
+    sun/security/lib/cacerts/VerifyCACerts.java
 
 # When adding tests to tier2, make sure they end up in one of the tier2_partX groups
 tier2 = \


### PR DESCRIPTION

fixes #267 

