### PR TITLE
Minor fixes for statistical history

### DIFF
--- a/src/hotspot/os/linux/stathist_linux.cpp
+++ b/src/hotspot/os/linux/stathist_linux.cpp
@@ -70,11 +70,7 @@ public:
   const char* text() const { return _buf; }
 
   const char* get_prefixed_line(const char* prefix) const {
-    const char* p = ::strstr(_buf, prefix);
-    if (p != NULL) {
-      return p;
-    }
-    return NULL;
+    return ::strstr(_buf, prefix);
   }
 
   value_t parsed_prefixed_value(const char* prefix, size_t scale = 1) const {
@@ -83,8 +79,9 @@ public:
     if (s != NULL) {
       errno = 0;
       const char* p = s + ::strlen(prefix);
-      value = (value_t)::strtoll(p, NULL, 10);
-      if (value == 0 && errno != 0) {
+      char* endptr = NULL;
+      value = (value_t)::strtoll(p, &endptr, 10);
+      if (p == endptr || errno != 0) {
         value = INVALID_VALUE;
       } else {
         value *= scale;
@@ -162,13 +159,13 @@ class CPUTimeColumn: public Column {
         const uint64_t delta_ms = value_ms - last_value_ms;
 
         // Calculate the number of wallclock milliseconds for the delta interval...
-        const int age_ms = last_value_age * 1000;
+        const uint64_t age_ms = last_value_age * 1000;
 
         // times number of available cores.
-        const int total_cpu_time_ms = age_ms * _num_cores;
+        const uint64_t total_cpu_time_ms = age_ms * _num_cores;
 
         // Put the spent cpu time in reference to the total available cpu time.
-        const float percentage = (100.0f * delta_ms) / total_cpu_time_ms;
+        const double percentage = (100.0f * delta_ms) / total_cpu_time_ms;
 
         char buf[32];
         l = jio_snprintf(buf, sizeof(buf), "%.0f", percentage);

--- a/src/hotspot/os/linux/stathist_linux.cpp
+++ b/src/hotspot/os/linux/stathist_linux.cpp
@@ -263,7 +263,7 @@ bool platform_columns_initialize() {
   {
     ProcFile bf;
     if (bf.read("/proc/self/status")) {
-      have_rss_detail_info = bf.parsed_prefixed_value("RssAnon", 1) != INVALID_VALUE;
+      have_rss_detail_info = bf.parsed_prefixed_value("RssAnon:", 1) != INVALID_VALUE;
     }
   }
   if (have_rss_detail_info) {

--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -135,19 +135,6 @@ static void print_timestamp(outputStream* st, time_t t) {
   }
 }
 
-// A little RAII class to temporarily change locale to "C"
-class CLocaleMark {
-  const char* _orig;
-public:
-  CLocaleMark() {
-    _orig = ::setlocale(LC_NUMERIC, NULL);
-    ::setlocale(LC_NUMERIC, "C");
-  }
-  ~CLocaleMark() {
-    ::setlocale(LC_NUMERIC, _orig);
-  }
-};
-
 ////// class ColumnList methods ////
 
 ColumnList* ColumnList::_the_list = NULL;
@@ -689,9 +676,6 @@ public:
 
   void print_table(outputStream* st, const print_info_t* pi, const record_t* values_now = NULL) const {
 
-    // print numbers with C locale to make parsing easier.
-    CLocaleMark clm;
-
     if (is_empty() && values_now == NULL) {
       st->print_cr("(no records)");
       return;
@@ -1174,8 +1158,6 @@ void print_report(outputStream* st, const print_info_t* pi) {
     print_legend(st, pi);
     st->cr();
   }
-
-  CLocaleMark locale_mark; // Print all numbers with locale "C"
 
   record_t* values_now = NULL;
   if (!pi->avoid_sampling) {


### PR DESCRIPTION
- possible misprint for CPU values in long term table
  due to overflow when time delta between samples > ~1 hour
- possible issues when printing the statistics table
  with code printing in parallel due to temp. change
  of process wide locale

fixes #321 

