### PR TITLE
SapMachine(12) #330: Reduce SapMachine specific exclusion list for jdk jtreg tests

### DIFF
--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -210,7 +210,6 @@ com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                             
 
 # None, so far.
 
-
 #############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.
 
@@ -222,7 +221,6 @@ java/nio/channels/AsyncCloseAndInterrupt.java                                   
 
 # SapMachine 2018-10-05
 # Flaky tests / other failing - should be checked whether issue still exists
-com/sun/jdi/JdbExprTest.sh                                                           generic-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java                                     generic-all
 javax/accessibility/AccessibilityProvider/basic.sh                                   generic-all
 
@@ -262,7 +260,3 @@ com/sun/jdi/sde/TemperatureTableTest.java                                       
 # These tests fail on linux-ppc64le and linux-ppc64. Probably due to resource constraints.
 tools/pack200/Pack200Props.java                                                      linux-ppc64le,linux-ppc64
 tools/pack200/Pack200Test.java                                                       linux-ppc64le,linux-ppc64
-
-# SapMachine 2019-01-31
-# This test failed on windows. Check if this still happens.
-jdk/modules/scenarios/overlappingpackages/OverlappingPackagesTest.java               windows-all


### PR DESCRIPTION
fixes #330

