### PR TITLE
SapMachine(12) #340: Exclude Test java/util/Scanner/ScanTest.java until JDK-8172695 is solved

### DIFF
--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -74,12 +74,6 @@ jdk/jfr/event/oldobject/TestClassLoaderLeak.java                                
 #java/nio/file/WatchService/DeleteInterference.java                                   generic-all
 
 # SapMachine 2018-08-22
-# java.util.InputMismatchException. Fails a lot on mac in jdk9 - jdk12
-# Testproblem with locale?
-# SapMachine 2019-02-07 Check whether fixed.
-#java/util/Scanner/ScanTest.java                                                      macosx-all
-
-# SapMachine 2018-08-22
 # We see timeouts after 12 min in all jdk9 - jdk12
 # SapMachine 2019-02-07 Still fails in 12.
 java/net/httpclient/SmokeTest.java                                                   windows-all
@@ -255,6 +249,11 @@ com/sun/jdi/Vars.java                                                           
 com/sun/jdi/redefineMethod/RedefineTest.java                                         macosx-all
 com/sun/jdi/sde/MangleTest.java                                                      macosx-all
 com/sun/jdi/sde/TemperatureTableTest.java                                            macosx-all
+
+# SapMachine 2019-03-16
+# Test fails with local en_DE as set on our mac test server
+# Test can be reenabled when JDK-8172695 is solved (CL will propose a fix)
+java/util/Scanner/ScanTest.java            8172695                                   macosx-all
 
 # SapMachine 2019-01-30
 # These tests fail on linux-ppc64le and linux-ppc64. Probably due to resource constraints.


### PR DESCRIPTION
fixes #340