### PR TITLE
SapMachine(12) #386: Remove exclusion of java/util/Scanner/ScanTest.java for MacOSX

### DIFF
--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -249,8 +249,3 @@ com/sun/jdi/Vars.java                                                           
 com/sun/jdi/redefineMethod/RedefineTest.java                                         macosx-all
 com/sun/jdi/sde/MangleTest.java                                                      macosx-all
 com/sun/jdi/sde/TemperatureTableTest.java                                            macosx-all
-
-# SapMachine 2019-03-16
-# Test fails with local en_DE as set on our mac test server
-# Test can be reenabled when JDK-8172695 is solved (CL will propose a fix)
-java/util/Scanner/ScanTest.java            8172695                                   macosx-all

--- a/test/jdk/java/util/Scanner/ScanTest.java
+++ b/test/jdk/java/util/Scanner/ScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 4313885 4926319 4927634 5032610 5032622 5049968 5059533 6223711 6277261 6269946 6288823
- *      8072722 8139414 8166261
+ *      8072722 8139414 8166261 8172695
  * @summary Basic tests of java.util.Scanner methods
  * @key randomness
  * @modules jdk.localedata
@@ -49,26 +49,12 @@ public class ScanTest {
     private static File inputFile = new File(System.getProperty("test.src", "."), "input.txt");
 
     public static void main(String[] args) throws Exception {
-
-        Locale reservedLocale = Locale.getDefault();
-        String lang = reservedLocale.getLanguage();
+        Locale defaultLocale = Locale.getDefault();
         try {
-            if (!"en".equals(lang) &&
-                !"zh".equals(lang) &&
-                !"ko".equals(lang) &&
-                !"ja".equals(lang)) {
-                //Before we have resource to improve the test to be ready for
-                //arbitrary locale, force the default locale to be "English"
-                //for now. First we check whether the "English" locale is
-                //available on the system as it could be absent due to varying
-                //configurations.
-                if (!Arrays.asList(Locale.getAvailableLocales())
-                    .contains(Locale.ENGLISH)) {
-                    throw new RuntimeException
-                       ("The \"English\" Locale is unavailable on this system");
-                }
-                Locale.setDefault(Locale.ENGLISH);
-            }
+            // Before we have resource to improve the test to be ready for
+            // arbitrary locale, force the default locale to be ROOT for now.
+            Locale.setDefault(Locale.US);
+
             skipTest();
             findInLineTest();
             findWithinHorizonTest();
@@ -128,7 +114,7 @@ public class ScanTest {
                 System.err.println("OKAY: All tests passed.");
         } finally {
             // restore the default locale
-            Locale.setDefault(reservedLocale);
+            Locale.setDefault(defaultLocale);
         }
     }
 


### PR DESCRIPTION
fixes #386