### PR TITLE
SapMachine(11) #386: Remove exclusion of java/util/Scanner/ScanTest.java for MacOSX

### DIFF
--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -166,8 +166,3 @@ com/sun/jdi/Vars.java                                                           
 com/sun/jdi/redefineMethod/RedefineTest.java                                         macosx-all
 com/sun/jdi/sde/MangleTest.java                                                      macosx-all
 com/sun/jdi/sde/TemperatureTableTest.java                                            macosx-all
-
-# SapMachine 2019-03-16
-# Test fails with local en_DE as set on our mac test server
-# Test can be reenabled when JDK-8172695 is solved (CL will propose a fix)
-java/util/Scanner/ScanTest.java            8172695                                   macosx-all


### PR DESCRIPTION
fixes #386