### PR TITLE
SapMachine: Increase LogEventsBufferEntries (#409)

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -444,7 +444,8 @@ const size_t minimumSymbolTableSize = 1024;
   diagnostic(bool, LogEvents, true,                                         \
           "Enable the various ring buffer event logs")                      \
                                                                             \
-  diagnostic(uintx, LogEventsBufferEntries, 10,                             \
+  /* SapMachine 2019-05-28 : increase event number */                       \
+  diagnostic(uintx, LogEventsBufferEntries, 75,                             \
           "Number of ring buffer event logs")                               \
           range(1, NOT_LP64(1*K) LP64_ONLY(1*M))                            \
                                                                             \


### PR DESCRIPTION
Increase LogEventsBufferEntries (#409) to 75,  we want to see more events in hs_err file.

The description of this pull request goes here.

fixes #409 

