### PR TITLE
Rename external representation of Statistical History (JDK12)

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
@@ -56,7 +56,7 @@ size_t ClassLoaderDataGraph::num_array_classes() {
 void ClassLoaderDataGraph::inc_instance_classes(size_t count) {
   Atomic::add(count, &_num_instance_classes);
   // SapMachine 2019-02-20 : stathist
-  if (EnableStatHist) {
+  if (EnableVitals) {
     StatisticsHistory::counters::inc_classes_loaded(count);
   }
 }
@@ -65,7 +65,7 @@ void ClassLoaderDataGraph::dec_instance_classes(size_t count) {
   assert(count <= _num_instance_classes, "Sanity");
   Atomic::sub(count, &_num_instance_classes);
   // SapMachine 2019-02-20 : stathist
-  if (EnableStatHist) {
+  if (EnableVitals) {
     StatisticsHistory::counters::inc_classes_unloaded(count);
   }
 }
@@ -73,7 +73,7 @@ void ClassLoaderDataGraph::dec_instance_classes(size_t count) {
 void ClassLoaderDataGraph::inc_array_classes(size_t count) {
   Atomic::add(count, &_num_array_classes);
   // SapMachine 2019-02-20 : stathist
-  if (EnableStatHist) {
+  if (EnableVitals) {
     StatisticsHistory::counters::inc_classes_loaded(count);
   }
 }
@@ -82,7 +82,7 @@ void ClassLoaderDataGraph::dec_array_classes(size_t count) {
   assert(count <= _num_array_classes, "Sanity");
   Atomic::sub(count, &_num_array_classes);
   // SapMachine 2019-02-20 : stathist
-  if (EnableStatHist) {
+  if (EnableVitals) {
     StatisticsHistory::counters::inc_classes_unloaded(count);
   }
 }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -599,14 +599,15 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
           "Print additional debugging information from other modes")        \
                                                                             \
   /* SapMachine 2019-02-20 : stathist */                                    \
-  product(bool, EnableStatHist, true,                                       \
-          "Enable Statistics history")                                      \
+  product(bool, EnableVitals, true,                                         \
+          "Enable sampling of vitals: memory, cpu utilization and various " \
+          "VM core statistics; display via jcmd \"VM.vitals\".")            \
                                                                             \
-  product(uintx, StatHistSampleInterval, 0,                                 \
-          "Statistics history sample rate interval (0=default)")            \
+  product(uintx, VitalsSampleInterval, 0,                                   \
+          "Vitals sample rate interval (0=use default sample rate)")        \
                                                                             \
-  experimental(bool, StatHistLockFree, false,                               \
-          "Do not lock when sampling")                                      \
+  experimental(bool, VitalsLockFreeSampling, false,                         \
+          "When sampling vitals, omit any actions which require locking.")  \
                                                                             \
   develop(bool, PrintMiscellaneous, false,                                  \
           "Print uncategorized debugging information (requires +Verbose)")  \

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3930,7 +3930,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (CheckJNICalls)                  JniPeriodicChecker::engage();
 
   // SapMachine 2019-02-20 : stathist
-  if (EnableStatHist) {
+  if (EnableVitals) {
     StatisticsHistory::initialize();
   }
 

--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -768,8 +768,8 @@ public:
       return false;
     }
 
-    const int short_term_interval = StatHistSampleInterval != 0 ?
-        StatHistSampleInterval : short_term_interval_default;
+    const int short_term_interval = VitalsSampleInterval != 0 ?
+        VitalsSampleInterval : short_term_interval_default;
     return _the_tables->initialize(short_term_interval);
 
   }
@@ -829,7 +829,7 @@ class SamplerThread: public NamedThread {
 
     ::time(&record->timestamp);
 
-    sample_values(record, StatHistLockFree);
+    sample_values(record, VitalsLockFreeSampling);
 
     // After sampling, finish record.
     record_table->finish_current_record();
@@ -842,7 +842,7 @@ public:
     : NamedThread()
     , _stop(false)
   {
-    this->set_name("stathist sampler thread");
+    this->set_name("vitals sampler thread");
   }
 
   virtual void run() {
@@ -1101,7 +1101,7 @@ void cleanup() {
 
 void print_report(outputStream* st, const print_info_t* pi) {
 
-  st->print("stathist:");
+  st->print("Vitals:");
 
   if (ColumnList::the_list() == NULL) {
     st->print_cr(" (unavailable)");

--- a/src/hotspot/share/services/stathistDCmd.hpp
+++ b/src/hotspot/share/services/stathistDCmd.hpp
@@ -41,10 +41,10 @@ protected:
 public:
   StatHistDCmd(outputStream* output, bool heap);
   static const char* name() {
-    return "VM.stathist";
+    return "VM.vitals";
   }
   static const char* description() {
-    return "Provide statistics history.";
+    return "Print Vitals.";
   }
   static const char* impact() {
     return "Low.";

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -987,7 +987,7 @@ void VMError::report(outputStream* st, bool _verbose) {
      }
 
   // SapMachine 2019-02-20 : stathist
-  STEP("Statistics History")
+  STEP("Vitals")
      if (_verbose) {
        static const StatisticsHistory::print_info_t settings = {
            false, false, false, // omit_legend
@@ -1168,7 +1168,7 @@ void VMError::print_vm_info(outputStream* st) {
   MemTracker::error_report(st);
 
   // SapMachine 2019-02-20 : stathist
-  // STEP("Statistics History")
+  // STEP("Vitals")
   StatisticsHistory::print_report(st, NULL);
 
   // STEP("printing system")

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
@@ -43,11 +43,11 @@ import jdk.test.lib.dcmd.JMXExecutor;
 public class StatHistTest {
 
     public void run(CommandExecutor executor) {
-        OutputAnalyzer output = executor.execute("VM.stathist");
+        OutputAnalyzer output = executor.execute("VM.vitals");
         output.shouldContain("--jvm--");
         output.shouldContain("--heap--");
         output.shouldContain("--meta--");
-        output = executor.execute("VM.stathist cvs");
+        output = executor.execute("VM.vitals cvs");
         output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
     }
 


### PR DESCRIPTION
Rename "Statistical History" to "Vitals" with a minimum of fuss:

rename command: VM.stathist -> VM.vitals
rename switches: "EnableStatHist" -> "EnableVitals" etc.

(cherry picked from commit 7fc8c42184d7279a145f81146a12ce879ecd2ca2 ; applied cleanly.)

fixes #420

