### PR TITLE
SapMachine13: Cherry-pick some changes from OpenJDK jdk13u (13.0.2) for parity of test exclusion list with internal testing

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -2283,7 +2283,7 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
   cmpdi(CCR0, Rcounters, 0);
   bne(CCR0, has_counters);
   call_VM(noreg, CAST_FROM_FN_PTR(address,
-                                  InterpreterRuntime::build_method_counters), method, false);
+                                  InterpreterRuntime::build_method_counters), method);
   ld(Rcounters, in_bytes(Method::method_counters_offset()), method);
   cmpdi(CCR0, Rcounters, 0);
   beq(CCR0, skip); // No MethodCounters, OutOfMemory.

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -1914,7 +1914,7 @@ void InterpreterMacroAssembler::get_method_counters(Register Rmethod,
   load_and_test_long(Rcounters, Address(Rmethod, Method::method_counters_offset()));
   z_brnz(has_counters);
 
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::build_method_counters), Rmethod, false);
+  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::build_method_counters), Rmethod);
   z_ltgr(Rcounters, Z_RET); // Runtime call returns MethodCounters object.
   z_brz(skip); // No MethodCounters, out of memory.
 

--- a/src/hotspot/os/aix/perfMemory_aix.cpp
+++ b/src/hotspot/os/aix/perfMemory_aix.cpp
@@ -1111,7 +1111,7 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 
   if ((statbuf.st_size == 0) ||
      ((size_t)statbuf.st_size % os::vm_page_size() != 0)) {
-    THROW_MSG_0(vmSymbols::java_lang_Exception(),
+    THROW_MSG_0(vmSymbols::java_io_IOException(),
                 "Invalid PerfMemory size");
   }
 

--- a/src/hotspot/os/bsd/perfMemory_bsd.cpp
+++ b/src/hotspot/os/bsd/perfMemory_bsd.cpp
@@ -1028,7 +1028,7 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 
   if ((statbuf.st_size == 0) ||
      ((size_t)statbuf.st_size % os::vm_page_size() != 0)) {
-    THROW_MSG_0(vmSymbols::java_lang_Exception(),
+    THROW_MSG_0(vmSymbols::java_io_IOException(),
                 "Invalid PerfMemory size");
   }
 

--- a/src/hotspot/os/linux/perfMemory_linux.cpp
+++ b/src/hotspot/os/linux/perfMemory_linux.cpp
@@ -1107,7 +1107,7 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 
   if ((statbuf.st_size == 0) ||
      ((size_t)statbuf.st_size % os::vm_page_size() != 0)) {
-    THROW_MSG_0(vmSymbols::java_lang_Exception(),
+    THROW_MSG_0(vmSymbols::java_io_IOException(),
                 "Invalid PerfMemory size");
   }
 

--- a/src/hotspot/os/solaris/perfMemory_solaris.cpp
+++ b/src/hotspot/os/solaris/perfMemory_solaris.cpp
@@ -1055,7 +1055,7 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 
   if ((statbuf.st_size == 0) ||
      ((size_t)statbuf.st_size % os::vm_page_size() != 0)) {
-    THROW_MSG_0(vmSymbols::java_lang_Exception(),
+    THROW_MSG_0(vmSymbols::java_io_IOException(),
                 "Invalid PerfMemory size");
   }
 

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1561,7 +1561,7 @@ static size_t sharedmem_filesize(const char* filename, TRAPS) {
       warning("unexpected file size: size = " SIZE_FORMAT "\n",
               statbuf.st_size);
     }
-    THROW_MSG_0(vmSymbols::java_lang_Exception(),
+    THROW_MSG_0(vmSymbols::java_io_IOException(),
                 "Invalid PerfMemory size");
   }
 

--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -65,9 +65,8 @@
 # SapMachine 2018-11-08
 # RuntimeException: The size computed by SA for java.lang.Object does not match.
 #
-# SapMachine 2019-09-05: Opened https://bugs.openjdk.java.net/browse/JDK-8230664 to track resolution and
-#                        https://bugs.openjdk.java.net/browse/JDK-8230666 to exclude the test (solaris-all is already in common exclude list)
-serviceability/sa/TestInstanceKlassSize.java                         8193639,8230664 solaris-all,linux-ppc64le,linux-ppc64
+# SapMachine 2019-10-02: Excluded with JDK-8230666, requested jdk13 backport
+#serviceability/sa/TestInstanceKlassSize.java                         8193639,8230664 solaris-all,linux-ppc64le,linux-ppc64
 
 # SapMachine 2019-01-08
 # RuntimeException: Total aborts count (1002) should be less or equal to 1001: expected that 1002 <= 1001
@@ -122,6 +121,7 @@ vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java                           
 # These fail because a path breaks a windows limit in jdk11u-dev.
 #
 #
+# SapMachine 2019-10-02 JDK-8191521 was pushed. Working on backports
 vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java         8191521 windows-all
 vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java         8191521 windows-all
 vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java         8191521 windows-all
@@ -148,8 +148,8 @@ vmTestbase/nsk/jvmti/unit/functions/AddToBootstrapClassLoaderSearch/JvmtiTest/Te
 #
 #
 #
-# SapMachine 2019-07-19 Still failing.
-containers/docker/TestMemoryAwareness.java                                           linux-ppc64le,linux-s390x
+# SapMachine 2019-10-02 Fix pushed to jdk/jdk, backported to 11.0.6, requested backport to 13
+#containers/docker/TestMemoryAwareness.java                                           linux-ppc64le,linux-s390x
 
 ###############################################################################
 # Failing new tests, unsupported new features in jdk13
@@ -173,6 +173,7 @@ serviceability/dcmd/framework/VMVersionTest.java                                
 #
 #
 # SapMachine 2019-07-19 CodeHeap::invalidate is too slow in dbg build
+# SapMachine 2019-09-20 We see it in 11 now, too. Lutz is working on it.
 compiler/codecache/OverflowCodeCacheTest.java                                        linux-ppc64le,linux-ppc64,aix-all
 
 # SapMachine 2019-07-17
@@ -200,19 +201,20 @@ runtime/NMT/VirtualAllocTestType.java                                           
 # SapMachine 2019-08-28 We shall remove this entry after release of 11.0.5 and 13.0.2.
 #vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java                          8228618 linux-s390x
 #vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java 8228618 linux-s390x
-# SapMachine 2019-08-26 Fix: JDK-8229925. Pushed to 11.0.5, requested for jdk13u
-vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java                      8229925 linux-s390x
+# SapMachine 2019-08-26 Fix: JDK-8229925. Pushed to 11.0.5, 13.0.2
+#vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java                      8229925 linux-s390x
 
 # SapMachine 2019-07-22
 # Timeout. We see this regularly.
 #
 #
+# SapMachine 2019-09-16 This is already tracked by 8222030.
 compiler/jsr292/ContinuousCallSiteTargetChange.java                                  linux-ppc64
 
 # SapMachine 2019-08-15
-# This is a regression in 13. But just tracing. Working on a fix.
-#
-#serviceability/logging/TestQuotedLogOutputs.java                                     windows-all
+# Exception: Uncommitted too slow
+# In SapMachine, we also see this in 13.
+gc/z/TestUncommit.java                                                               generic-all
 
 # SapMachine 2019-08-29
 # Some aarch stuff, we don't really care. Do we?

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,7 +115,7 @@ serviceability/sa/TestDefaultMethods.java 8193639 solaris-all
 serviceability/sa/TestG1HeapRegion.java 8193639 solaris-all
 serviceability/sa/TestHeapDumpForInvokeDynamic.java 8193639 solaris-all
 serviceability/sa/TestHeapDumpForLargeArray.java 8193639 solaris-all
-serviceability/sa/TestInstanceKlassSize.java 8193639 solaris-all
+serviceability/sa/TestInstanceKlassSize.java 8193639,8230664 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/TestInstanceKlassSizeForInterface.java 8193639 solaris-all
 serviceability/sa/TestIntConstant.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/TestJhsdbJstackLock.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64

--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -52,48 +52,47 @@
 # SapMachine 2019-07-16 Still fails
 java/lang/ProcessHandle/InfoTest.java                                                windows-all,aix-all
 
-# SapMachine 2018-08-22 Failures on sparc.
+# SapMachine 2018-08-22 Failures on sparc/linuxppc64le.
 # Some just fail sporadic.
+#
 com/sun/nio/sctp/SctpChannel/Bind.java                                               solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/Branch.java                                             solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/CommUp.java                                             solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/Connect.java                                            solaris-sparcv9
+#
 com/sun/nio/sctp/SctpChannel/Receive.java                                            solaris-sparcv9
+#
 com/sun/nio/sctp/SctpChannel/ReceiveIntoDirect.java                                  solaris-sparcv9
+#
 com/sun/nio/sctp/SctpChannel/Shutdown.java                                           solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/Send.java                                               solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                                  solaris-sparcv9
+#
 com/sun/nio/sctp/SctpServerChannel/Accept.java                                       solaris-sparcv9
+#
+com/sun/nio/sctp/SctpChannel/CommUp.java                                             solaris-sparcv9
+#
 com/sun/nio/sctp/SctpServerChannel/NonBlockingAccept.java                            solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/Branch.java                                        solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/Send.java                                          solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java                             solaris-sparcv9
-# These even crash!!
-# SapMachine 2019-04-30 Still fails in 11.
-# SapMachine 2019-09-03 See if still failing
-#sun/security/tools/jarsigner/TimestampCheck.java                                     solaris-sparcv9
-#sun/security/tools/keytool/WeakAlg.java                                              solaris-sparcv9
-#javax/net/ssl/TLSCommon/ConcurrentClientAccessTest.java                              solaris-sparcv9
-
-# SapMachine 2018-08-22
-# RuntimeException: Could not find class leak.
-# SapMachine 2019-04-30 Still fails in 11.
-# SapMachine 2019-09-03 See if still failing
-#jdk/jfr/event/oldobject/TestClassLoaderLeak.java                                     solaris-sparcv9
-
-# SapMachine 2018-08-22
-# We see timeouts after 12 min in all jdk9 - jdk12
-# SapMachine 2019-09-03 See if still failing
-#java/net/httpclient/SmokeTest.java                                                   windows-all
+#
+com/sun/nio/sctp/SctpChannel/Connect.java                                            solaris-sparcv9
+#
+com/sun/nio/sctp/SctpMultiChannel/Branch.java                                        linux-ppc64le,solaris-sparcv9
+#
+com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java                             linux-ppc64le,solaris-sparcv9
+#
+com/sun/nio/sctp/SctpMultiChannel/Send.java                                          linux-ppc64le,solaris-sparcv9
+#
+com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                                  linux-ppc64le,solaris-sparcv9
+#
+com/sun/nio/sctp/SctpChannel/Send.java                                               linux-ppc64le,solaris-sparcv9
+# SapMachine 2019-09-18 See if these still occur
+#com/sun/nio/sctp/SctpChannel/Branch.java                                             solaris-sparcv9
 
 # SapMachine 2018-06-22, 2019-04-30
-# Fails only on linuxx86_64. "RuntimeException: Test failed for angle 15.0" on SLES 12.2; SLES 15.
-# The test passes on SLES 12.0; SLES 11.3; RHEL 6.1
-# Opened bug for this:
-# 8219641: java/awt/font/Rotate/RotatedTextTest.java fails on linux x86_64: Test failed for angle 15.0
-# This happens on recent SuSE systems, they have a different default font that causes the issue.
-# Oracle accepted the bug, but did not take any actions yet.
-java/awt/font/Rotate/RotatedTextTest.java                                            linux-all
+# Fails only on recent Suse systems (e.g. SLES 12.2, 12.4, 15): "RuntimeException: Test failed for angle 15.0"
+# The test passes on SLES 12.0, SLES 11.3, RHEL 6.1
+#
+# Opened bug for this: 8219641: java/awt/font/Rotate/RotatedTextTest.java fails on linux x86_64: Test failed for angle 15.0
+java/awt/font/Rotate/RotatedTextTest.java                                    8219641 linux-all
+
+# SapMachine 2019-09-26
+# This seems to fail on RHEL 7: java.lang.RuntimeException: Font metrics differ for angle 165
+#
 java/awt/font/Rotate/RotatedFontMetricsTest.java                                     linux-all
 
 ###############################################################################
@@ -105,23 +104,13 @@ java/awt/font/Rotate/RotatedFontMetricsTest.java                                
 #
 #javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java                    8212096 generic-all
 
-# SapMachine 2019-07-01
-# Sporadic on ppc64le. For sparc see above.
-#
-# SapMachine 2019-07-19 Added com/sun/nio/sctp/SctpMultiChannel/Send.java, probably related to certain test host, link added.
-#
-com/sun/nio/sctp/SctpChannel/Send.java                                               linux-ppc64le,solaris-sparcv9
-com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                                  linux-ppc64le,solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/Branch.java                                        linux-ppc64le,solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java                             linux-ppc64le,solaris-sparcv9
-com/sun/nio/sctp/SctpMultiChannel/Send.java                                          linux-ppc64le,solaris-sparcv9
-
 # SapMachine 2019-07-12
-# Issue with certain font configurations. Excluding this test for now.
-# There is already an exclusion of this test for solaris and mac in the generic
-# exclusion list.
-# JDK-8223869 was opened asking for exclusion on more platforms.
-java/awt/FontMetrics/MaxAdvanceIsMax.java                                    8223869 generic-all
+# Issue with certain font configurations. There is already an exclusion of this test for
+# solaris and mac in the generic exclusion list. Excluding this test for linux now as well.
+# https://bugs.openjdk.java.net/browse/JDK-8231495 to track resolution.
+# https://bugs.openjdk.java.net/browse/JDK-8223869 for exclusion request.
+# SapMachine 2019-10-02 Pushed exclusion to jdk/jdk, requested backport to 11.0.6 and 13.0.2
+#java/awt/FontMetrics/MaxAdvanceIsMax.java                            8221305,8231495 solaris-all,macosx-all,linux-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.3 (e.g. seen only in jdk11u-dev after branching 11.0.3 to jdk11u)
@@ -143,16 +132,14 @@ javax/swing/JFileChooser/4847375/bug4847375.java                                
 #
 #
 # Most likely fixed by https://bugs.openjdk.java.net/browse/JDK-8227435.
-# SapMachine 2019-09-03: Fix is already in 14, requesting downports to 11, 13
-sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java                 8227435 windows-x64
+# SapMachine 2019-10-02: Fix pushed to JDK14, 13.0.2 and 11.0.6
+#sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java                 8227435 windows-x64
 
 # SapMachine 2019-06-28
 # timeout on ppc in 11 only.
 #
 #
-# SapMachine 2019-09-06 Added JDK-8223444 to jdk11u-dev queue but not to jdk11u queue.
-#                       Also improved the test diagnosis patch in jdk11u/jdk11u-dev queues to print time stamps, to verify that issue occurs in freeing code blobs.
-#                       Note as well, that Oracle has disabled the test in jdk/jdk because of timeout issues, tracked by JDK-8225209. Results could be interesting for us in 11, too.
+# SapMachine 2019-09-24 Re-enabled test in jdk/jdk and jdk11u-dev because Lutz is heavily testing.
 #jdk/jfr/event/compiler/TestCodeSweeper.java                                          linux-ppc64,linux-ppc64le
 
 # SapMachine 2019-06-28
@@ -171,8 +158,8 @@ java/awt/print/PrinterJob/SameService.java                                   822
 # Exception in thread "main" java.lang.RuntimeException: Test failed for - cpu:getCpuSystemUsage, expected [2], got [2]
 #
 #
-# Fixed by JDK-8227642. Should be downported (along with 8228434).
-#jdk/internal/platform/docker/TestSystemMetrics.java                                  linux-ppc64le,linux-s390x
+# SapMachine 2019-10-02 Fixed by JDK-8227642 in jdk and JDK13. Should be downported (along with 8228434) to 11.0.6.
+#jdk/internal/platform/docker/TestSystemMetrics.java                          8227642 linux-ppc64le,linux-s390x
 
 # SapMachine 2019-07-18
 # javax.net.ssl.SSLException: The status_request_v2 extension is inconsistent with the expected result: expected = true, actual = false
@@ -184,12 +171,15 @@ java/awt/print/PrinterJob/SameService.java                                   822
 # java.lang.NumberFormatException: For input string: "18446744073709551615"
 #
 #
-# SapMachine 2019-08-08: Change JDK-8228585 pushed to jdk11u-dev, jdk13 and jdk14.
-# There seems to be another issue with this test which the NumberFormat fix probably does not solve.
-# Enabling the test to capture those other issues, new backlog item and Jira bug created:
+# https://bugs.openjdk.java.net/browse/JDK-8228585
+# SapMachine 2019-08-08: Change JDK-8228585 pushed to 11.0.5, 13 and 14.
+#
+# SapMachine 2019-08-08: There seems to be another issue: memory:getMemoryUsage, expected [23040819200], got [23061266432]
+#
 #
 # https://bugs.openjdk.java.net/browse/JDK-8229284
-jdk/internal/platform/cgroup/TestCgroupMetrics.java                          8229284 linux-x64
+# SapMachine 2019-09-23: Change JDK-8229284 already pushed to jdk/jdk. Working on backports to jdk13 and 11.
+#jdk/internal/platform/cgroup/TestCgroupMetrics.java                          8229284 linux-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.4 (e.g. seen only in jdk11u-dev after branching 11.0.4 to jdk11u)
@@ -200,15 +190,15 @@ jdk/internal/platform/cgroup/TestCgroupMetrics.java                          822
 # We didn't see this in 11 yet, only 13, 14; but it's broken as well.
 #
 #
-# Needs to be downported to 11.
+# SapMachine 2019-10-02 Part of jdk/jdk, jdk 13.0.0, jdk 11.0.5
 #sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java                8228658 linux-s390x
 
 # SapMachine 2019-08-01
-# Appears in 11, 13, 14. In 11 not seen for quite some time, but failures
-# with the same error in the database.
+# Appears in 11, 13, 14. In 11 not seen for quite some time, but failures with the same error in the database.
 #
 #
-java/awt/FontClass/FontSize1Test.java                                                darwinintel
+#
+java/awt/FontClass/FontSize1Test.java                                                macosx-all
 
 ###############################################################################
 # Tests known to be failing in OpenJDK when JDK 12 was released (3/2019)
@@ -281,27 +271,12 @@ java/nio/channels/FileChannel/CleanerTest.java                                  
 ###############################################################################
 # Failing new tests, unsupported new features in jdk13
 
-# SapMachine 2018-12-31
-# Tests failing on aarch64, which is unsupported by us. Won't fix.
-# SapMachine 2019-06-28 Check whether fixed
-#sun/nio/cs/FindEncoderBugs.java                                                      linux-aarch64
-# Saw DEADLOCK
-# SapMachine 2019-06-28 Check whether fixed
-#java/beans/XMLDecoder/8028054/TestMethodFinder.java                                  linux-aarch64
-
 # SapMachine 2019-02-21
 # All crash reproducible on one test machine. SIGSEGV [libucrypto.so.1+0xb5a90]  ucrypto_digest_update+0x4
 java/net/httpclient/DigestEchoClientSSL.java                                         solaris-sparcv9
 java/net/httpclient/ProxyAuthDisabledSchemesSSL.java                                 solaris-sparcv9
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest                       solaris-sparcv9
 sun/security/tools/keytool/KeyToolTest.java                                          solaris-sparcv9
-
-# SapMachine 2019-07-17
-# Unexpected value in Event. Occurs since about 2019-05.
-#
-#
-# SapMachine 2019-08-08 Pushed fix. We shall remove this entry after a few days.
-#jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.sh 8228359 linux-ppc64,linux-ppc64le
 
 # SapMachine 2019-07-17
 # Occurring since about 2019-05. Seems to have to do with a missing font in the Windows installation.
@@ -312,24 +287,24 @@ java/awt/font/WindowsIndicFonts.java                                         822
 # SapMachine 2019-07-19
 # java.io.IOException: No route to host
 #
-# SapMachine 2019-08-01: adding mac.  Oracle excluded this on mac due to 7122846.
-# SapMachine 2019-08-29 8229706 was pushed to jdk/jdk. Requested backport to jdk13u.
-java/net/MulticastSocket/NoLoopbackPackets.java                              8229706 aix-all,macosx-all
+# SapMachine 2019-08-01: adding mac. Oracle excluded this on mac due to 7122846.
+# SapMachine 2019-10-02 8229706 was pushed to jdk/jdk and 13.0.2
+#java/net/MulticastSocket/NoLoopbackPackets.java                              8229706 aix-all,macosx-all
 
 # SapMachine 2019-08-01
 # Asserts in TestShutdownEvent.validateStackTrace().
 #
 #
-# SapMachine 2019-08-28 (Test-)fix for 8219082 has been pushed, requested for 13u
-jdk/jfr/event/runtime/TestShutdownEvent.java                                 8219082 linux-all
+# SapMachine 2019-10-02 Fix for 8219082 has been pushed to jdk/jdk and jdk13u (13.0.2)
+#jdk/jfr/event/runtime/TestShutdownEvent.java                                 8219082 linux-all
 
 # SapMachine 2019-08-02
 # RuntimeException: assertGreaterThanOrEqual: expected 1 >= 2
 # Seen only on linuxx86_64, ... . Maybe a specific issue on that box?
 #
 #
-# SapMachine 2019-09-12 We have opened JDK-8229370 and Oracle have JDK-8228990, got excluded by 8230115. Need to downport it.
-jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java               8228990,8229370 linuxx86_64
+# SapMachine 2019-10-02 Excluded by 8230115 and backported to 13.0.2
+#jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java               8228990,8229370 linuxx86_64
 
 # SapMachine 2019-08-08
 # We see this issue occuring for a long time already in 13 and 14.
@@ -364,6 +339,13 @@ jdk/jfr/event/gc/detailed/TestStressAllocationGCEventsWithParallel.java      823
 
 ###############################################################################
 # New failures detected after GA of 13
+
+# SapMachine 2019-09-26
+# This test is failing on our new Ubuntu 18.04 systems for ppcle.
+# Currently only affecting 13 and 14
+#
+#
+javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java                    linux-ppc64le
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -250,7 +250,7 @@ java/awt/font/TextLayout/CombiningPerf.java 8192931 generic-all
 java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
 java/awt/font/StyledMetrics/BoldSpace.java 8198422 linux-all
 java/awt/FontMetrics/FontCrash.java 8198336 windows-all
-java/awt/FontMetrics/MaxAdvanceIsMax.java 8221305 solaris-all,macosx-all
+java/awt/FontMetrics/MaxAdvanceIsMax.java 8221305,8231495 solaris-all,macosx-all,linux-all
 java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 generic-all
 java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 windows-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -891,8 +891,8 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 
 jdk/jfr/event/io/TestInstrumentation.java                       8202142    generic-all
 jdk/jfr/api/recording/event/TestPeriod.java                     8215890    generic-all
-
 jdk/jfr/event/io/EvilInstrument.java                            8221331    generic-all
+jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 
 ############################################################################
 

--- a/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
+++ b/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
@@ -29,6 +29,7 @@
  */
 import java.util.*;
 import java.net.*;
+import jdk.test.lib.NetworkConfiguration;
 import jdk.test.lib.net.IPSupport;
 
 public class NoLoopbackPackets {
@@ -60,7 +61,9 @@ public class NoLoopbackPackets {
             if (IPSupport.hasIPv4()) {
                 groups.add(new InetSocketAddress(InetAddress.getByName("224.1.1.1"), port));
             }
-            if (IPSupport.hasIPv6()) {
+
+            NetworkConfiguration nc = NetworkConfiguration.probe();
+            if (IPSupport.hasIPv6() && nc.hasTestableIPv6Address()) {
                 groups.add(new InetSocketAddress(InetAddress.getByName("::ffff:224.1.1.2"), port));
                 groups.add(new InetSocketAddress(InetAddress.getByName("ff02::1:1"), port));
             }

--- a/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
@@ -169,7 +169,10 @@ public class TestShutdownEvent {
         @Override
         public void verifyEvents(RecordedEvent event, int exitCode) {
             Events.assertField(event, "reason").equal("VM Error");
-            validateStackTrace(event.getStackTrace());
+            // for now avoid validating the stack trace, in case of compiled code
+            // the vframeStream based solution will not work in this special VMCrash case
+            // see 8219082 for details (running the crashed VM with -Xint would solve the issue too)
+            //validateStackTrace(event.getStackTrace());
         }
     }
 

--- a/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,13 @@ import java.util.Collections;
 // in test environment.
 public class DockerRunOptions {
     public String imageNameAndTag;
-    public ArrayList<String> dockerOpts = new ArrayList<String>();
+    public ArrayList<String> dockerOpts = new ArrayList<>();
     public String command;    // normally a full path to java
-    public ArrayList<String> javaOpts = new ArrayList<String>();
+    public ArrayList<String> javaOpts = new ArrayList<>();
+    // more java options, but to be set AFTER the test Java options
+    public ArrayList<String> javaOptsAppended = new ArrayList<>();
     public String classToRun;  // class or "-version"
-    public ArrayList<String> classParams = new ArrayList<String>();
+    public ArrayList<String> classParams = new ArrayList<>();
 
     public boolean tty = true;
     public boolean removeContainerAfterUse = true;
@@ -67,6 +69,11 @@ public class DockerRunOptions {
 
     public DockerRunOptions addJavaOpts(String... opts) {
         Collections.addAll(javaOpts, opts);
+        return this;
+    }
+
+    public DockerRunOptions addJavaOptsAppended(String... opts) {
+        Collections.addAll(javaOptsAppended, opts);
         return this;
     }
 

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -40,12 +40,10 @@ import java.util.List;
 import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
 import jtreg.SkippedException;
 
 
 public class DockerTestUtils {
-    private static final String FS = File.separator;
     private static boolean isDockerEngineAvailable = false;
     private static boolean wasDockerEngineChecked = false;
 
@@ -212,6 +210,7 @@ public class DockerTestUtils {
         if (opts.appendTestJavaOptions) {
             Collections.addAll(cmd, Utils.getTestJavaOpts());
         }
+        cmd.addAll(opts.javaOptsAppended);
 
         cmd.add(opts.classToRun);
         cmd.addAll(opts.classParams);


### PR DESCRIPTION
fixes #517