### PR TITLE
SapMachine (13) #530: Enable ShowCodeDetailsInExceptionMessages per default in SapMachine (JDK-8233014)

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -675,7 +675,8 @@ const size_t minimumSymbolTableSize = 1024;
   product(bool, OmitStackTraceInFastThrow, true,                            \
           "Omit backtraces for some 'hot' exceptions in optimized code")    \
                                                                             \
-  manageable(bool, ShowCodeDetailsInExceptionMessages, false,               \
+  /* SapMachine 2019-11-04: Push JDK-8233014 early. */                      \
+  manageable(bool, ShowCodeDetailsInExceptionMessages, true,                \
           "Show exception messages from RuntimeExceptions that contain "    \
           "snippets of the failing code. Disable this to improve privacy.") \
                                                                             \

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/SuppressMessagesTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/SuppressMessagesTest.java
@@ -24,12 +24,13 @@
 
 /**
  * @test
- * @summary Test that the default of flag ShowCodeDetailsInExceptionMessages is 'false',
- *          i.e., make sure the VM does not print the message on default.
+ * @comment SapMachine 2019-11-04: Push JDK-8233014 early.
+ * @summary Test that the default of flag ShowCodeDetailsInExceptionMessages is 'true',
+ *          i.e., make sure the VM does print the message on default.
  * @bug 8218628
  * @library /test/lib
  * @compile -g SuppressMessagesTest.java
- * @run main/othervm SuppressMessagesTest noMessage
+ * @run main/othervm SuppressMessagesTest printMessage
  */
 /**
  * @test

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t104/t104.gold
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t104/t104.gold
@@ -1,2 +1,2 @@
 Exception thrown.
-java.lang.NullPointerException
+java.lang.NullPointerException: Cannot enter synchronized block because "<local1>" is null

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -116,6 +116,7 @@ public class ToolSimpleTest extends ReplToolTesting {
         );
     }
 
+    // SapMachine 2019-11-04: Push JDK-8233014 early.
     @Test
     public void testChainedThrow() {
         test(
@@ -132,7 +133,7 @@ public class ToolSimpleTest extends ReplToolTesting {
                         + "|  Caused by: java.io.IOException: bar\n"
                         + "|        at n (#2:1)\n"
                         + "|        ...\n"
-                        + "|  Caused by: java.lang.NullPointerException\n"
+                        + "|  Caused by: java.lang.NullPointerException: Cannot invoke \"String.toString()\" because \"null\" is null\n"
                         + "|        at p (#1:1)\n"
                         + "|        ..."),
                 (a) -> assertCommand(a, "/drop p",


### PR DESCRIPTION
fixes #530