### PR TITLE
SapMachine (13) #540: Various fixes and improvements to vitals

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -4769,6 +4769,13 @@ void Threads::print_on(outputStream* st, bool print_stacks,
     st->cr();
   }
 
+  // SapMachine 2019-11-07 : stathist
+  const Thread* stathist_sampler_thread = StatisticsHistory::samplerthread();
+  if (stathist_sampler_thread != NULL) {
+    stathist_sampler_thread->print_on(st);
+    st->cr();
+  }
+
   st->flush();
 }
 
@@ -4821,6 +4828,9 @@ void Threads::print_on_error(outputStream* st, Thread* current, char* buf,
   st->print_cr("Other Threads:");
   print_on_error(VMThread::vm_thread(), st, current, buf, buflen, &found_current);
   print_on_error(WatcherThread::watcher_thread(), st, current, buf, buflen, &found_current);
+  // SapMachine 2019-11-07 : stathist
+  print_on_error(const_cast<Thread*>(StatisticsHistory::samplerthread()),
+                 st, current, buf, buflen, &found_current);
 
   PrintOnErrorClosure print_closure(st, current, buf, buflen, &found_current);
   Universe::heap()->gc_threads_do(&print_closure);

--- a/src/hotspot/share/services/stathist.hpp
+++ b/src/hotspot/share/services/stathist.hpp
@@ -40,22 +40,28 @@ namespace StatisticsHistory {
     bool csv;
     // Omit printing a legend.
     bool no_legend;
-    // Normally, when we print a report, we sample the current values too and print it atop of the table.
-    // We may want to avoid that, e.g. during error handling.
-    bool avoid_sampling;
     // Reverse printing order (default: youngest-to-oldest; reversed: oldest-to-youngest)
     bool reverse_ordering;
 
     size_t scale;
 
+    // max number of samples to print (0 = print all)
+    int max;
+
   };
 
+  // text output, youngest-to-oldest ordered, with legend, all records, dynamic scale.
+  const print_info_t* default_settings();
 
-  void print_report(outputStream* st, const print_info_t* print_info);
+  // Print report to stream. Leave print_info NULL for default settings.
+  void print_report(outputStream* st, const print_info_t* print_info = NULL);
 
   // Dump both textual and csv style reports to two files, "vitals_<pid>.txt" and "vitals_<pid>.csv".
   // If these files exist, they are overwritten.
   void dump_reports();
+
+  // For printing in thread lists only.
+  const Thread* samplerthread();
 
   // These are counters for the statistics history. Ideally, they would live
   // inside their thematical homes, e.g. thread.cpp or classLoaderDataGraph.cpp,

--- a/src/hotspot/share/services/stathistDCmd.cpp
+++ b/src/hotspot/share/services/stathistDCmd.cpp
@@ -41,13 +41,15 @@ StatHistDCmd::StatHistDCmd(outputStream* output, bool heap)
     _csv("csv", "csv format.", "BOOLEAN", false, "false"),
     _no_legend("no-legend", "Omit legend.", "BOOLEAN", false, "false"),
     _reverse("reverse", "Reverse printing order.", "BOOLEAN", false, "false"),
-    _raw("raw", "Print raw values.", "BOOLEAN", false, "false")
+    _raw("raw", "Print raw values.", "BOOLEAN", false, "false"),
+    _max("max", "Limit printing to max items.", "INT", false)
 {
   _dcmdparser.add_dcmd_option(&_scale);
   _dcmdparser.add_dcmd_option(&_no_legend);
   _dcmdparser.add_dcmd_option(&_reverse);
   _dcmdparser.add_dcmd_option(&_raw);
   _dcmdparser.add_dcmd_option(&_csv);
+  _dcmdparser.add_dcmd_option(&_max);
 }
 
 int StatHistDCmd::num_arguments() {
@@ -88,7 +90,7 @@ void StatHistDCmd::execute(DCmdSource source, TRAPS) {
   pi.csv = _csv.value();
   pi.no_legend = _no_legend.value();
   pi.reverse_ordering = _reverse.value();
-  pi.avoid_sampling = false;
+  pi.max = _max.value();
 
   StatisticsHistory::print_report(output(), &pi);
 }

--- a/src/hotspot/share/services/stathistDCmd.hpp
+++ b/src/hotspot/share/services/stathistDCmd.hpp
@@ -37,6 +37,7 @@ protected:
   DCmdArgument<bool> _no_legend;
   DCmdArgument<bool> _reverse;
   DCmdArgument<bool> _raw;
+  DCmdArgument<jlong> _max;
 public:
   StatHistDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -105,16 +105,6 @@ const char *env_list[] = {
   (const char *)0
 };
 
-// SapMachine 2019-09-16: Vitals
-static const StatisticsHistory::print_info_t vitals_print_settings = {
-    false, // raw
-    false, // csv
-    false, // no_legend
-    true,  // avoid_sampling
-    false, // reverse_ordering
-    0      // scale
-};
-
 // A simple parser for -XX:OnError, usage:
 //  ptr = OnError;
 //  while ((cmd = next_OnError_command(buffer, sizeof(buffer), &ptr) != NULL)
@@ -1017,7 +1007,7 @@ void VMError::report(outputStream* st, bool _verbose) {
   // SapMachine 2019-02-20 : stathist
   STEP("Vitals")
      if (_verbose) {
-       StatisticsHistory::print_report(st, &vitals_print_settings);
+       StatisticsHistory::print_report(st);
      }
 
   STEP("printing system")
@@ -1193,7 +1183,7 @@ void VMError::print_vm_info(outputStream* st) {
 
   // SapMachine 2019-02-20 : stathist
   // STEP("Vitals")
-  StatisticsHistory::print_report(st, &vitals_print_settings);
+  StatisticsHistory::print_report(st);
 
   // STEP("printing system")
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
@@ -68,6 +68,11 @@ public class StatHistTest {
         output.shouldContain("--heap--");
         output.shouldContain("--meta--");
 
+        output = executor.execute("VM.vitals max=1");
+        output.shouldContain("--jvm--");
+        output.shouldContain("--heap--");
+        output.shouldContain("--meta--");
+
         output = executor.execute("VM.vitals csv");
         output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
 


### PR DESCRIPTION
SapMachine #540: Various fixes and improvements to vitals

* Fix build error on gcc 5.4, Ubuntu 16.4
"stathist.cpp:885:63: error: enumeral and non-enumeral type in conditional expression [-Werror=extra]"

* Add safety measure to guard against suspected endless loop in printing code.

* Remove the take-sample-at-printing-time feature since it
could be dangerous and the output was confusing.

* Reduce default sample interval from 15 to 10 seconds.

* Add a new sub option, "max", to limit number of records printed.

* Add Vitals sampler thread to threads list output.

(cherry picked from commit ff04966519a91608129811c2aa94a0c14fe6a328)

fixes #540 