### PR TITLE
SapMachine (11) #540: Various fixes and improvements to vitals

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -4630,6 +4630,13 @@ void Threads::print_on(outputStream* st, bool print_stacks,
     st->cr();
   }
 
+  // SapMachine 2019-11-07 : stathist
+  const Thread* stathist_sampler_thread = StatisticsHistory::samplerthread();
+  if (stathist_sampler_thread != NULL) {
+    stathist_sampler_thread->print_on(st);
+    st->cr();
+  }
+
   st->flush();
 }
 
@@ -4682,6 +4689,9 @@ void Threads::print_on_error(outputStream* st, Thread* current, char* buf,
   st->print_cr("Other Threads:");
   print_on_error(VMThread::vm_thread(), st, current, buf, buflen, &found_current);
   print_on_error(WatcherThread::watcher_thread(), st, current, buf, buflen, &found_current);
+  // SapMachine 2019-11-07 : stathist
+  print_on_error(const_cast<Thread*>(StatisticsHistory::samplerthread()),
+                 st, current, buf, buflen, &found_current);
 
   PrintOnErrorClosure print_closure(st, current, buf, buflen, &found_current);
   Universe::heap()->gc_threads_do(&print_closure);

--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -74,6 +74,11 @@ void inc_threads_created(size_t count) {
 
 } // namespace counters
 
+// context for printing
+struct print_context_t {
+  int records_printed;
+};
+
 // helper function for the missing outputStream::put(int c, int repeat)
 static void ostream_put_n(outputStream* st, int c, int repeat) {
   for (int i = 0; i < repeat; i ++) {
@@ -647,6 +652,8 @@ class RecordTable : public CHeapObj<mtInternal> {
     const RecordTable* const _rt;
     const bool _reverse;
     int _p;
+    const int _max_steps;
+    int _step;
 
     void move_to_oldest() {
       _p = _rt->oldest_pos();
@@ -656,22 +663,14 @@ class RecordTable : public CHeapObj<mtInternal> {
       _p = _rt->youngest_pos();
     }
 
-    void step_forward() {
-      if (valid()) {
-        _p = _rt->following_pos(_p);
-      }
-    }
-
-    void step_back() {
-      if (valid()) {
-        _p = _rt->preceeding_pos(_p);
-      }
-    }
+    void step_forward() { _p = _rt->following_pos(_p); }
+    void step_back()    { _p = _rt->preceeding_pos(_p); }
 
   public:
 
     ConstIterator(const RecordTable* rt, bool reverse = false)
-      : _rt(rt), _reverse(reverse), _p(-1)
+      : _rt(rt), _reverse(reverse), _p(-1),
+        _max_steps(rt->size()), _step(0)
     {
       if (_reverse) {
         move_to_oldest();
@@ -683,10 +682,17 @@ class RecordTable : public CHeapObj<mtInternal> {
     bool valid() const { return _p != -1; }
 
     void step() {
-      if (_reverse) {
-        step_forward();
-      } else {
-        step_back();
+      if (valid()) {
+        if (_reverse) {
+          step_forward();
+        } else {
+          step_back();
+        }
+        // Safety.
+        _step ++;
+        if (_step > _max_steps) {
+          _p = -1;
+        }
       }
     }
 
@@ -731,13 +737,14 @@ class RecordTable : public CHeapObj<mtInternal> {
   }
 
   // Print all records.
-  void print_all_records(outputStream* st, const int widths[], const print_info_t* pi) const {
+  void print_all_records(outputStream* st, const int widths[], const print_info_t* pi, print_context_t* pc) const {
     ConstIterator it(this, pi->reverse_ordering);
-    while(it.valid()) {
+    while(it.valid() && (pi->max == 0 || pc->records_printed < pi->max)) {
       const record_t* record = it.get();
       const record_t* previous_record = it.get_preceeding();
       print_one_record(st, record, previous_record, widths, pi);
       it.step();
+      pc->records_printed ++;
     }
   }
 
@@ -764,6 +771,9 @@ public:
     return at(_pos);
   }
 
+  // Returns max. number of entries size of this record table.
+  int size() const { return _num_records; }
+
   // finish the current record: advances the write position in the FIFO buffer by one.
   // Should that cause a record to fall out of the FIFO end, it propagates the record to
   // the follower table if needed.
@@ -783,9 +793,9 @@ public:
     }
   }
 
-  void print_table(outputStream* st, const print_info_t* pi, const record_t* values_now = NULL) const {
+  void print_table(outputStream* st, const print_info_t* pi, print_context_t* pc) const {
 
-    if (is_empty() && values_now == NULL) {
+    if (is_empty()) {
       st->print_cr("(no records)");
       return;
     }
@@ -795,9 +805,6 @@ public:
     // Before actually printing, lets calculate the printing widths
     // (if now-values are given, they are part of the table too, so include them in the widths calculation)
     update_widths_from_all_records(g_widths, pi);
-    if (values_now != NULL) {
-      update_widths_from_one_record(values_now, youngest_in_table, g_widths, pi);
-    }
 
     // Print headers (not in csv mode)
     if (pi->csv == false) {
@@ -809,32 +816,25 @@ public:
 
     // Now print the actual values. We preceede the table values with the now value
     //  (if printing order is youngest-to-oldest) or write it last (if printing order is oldest-to-youngest).
-    if (values_now != NULL && pi->reverse_ordering == false) {
-      print_one_record(st, values_now, youngest_in_table, g_widths, pi);
-    }
-    print_all_records(st, g_widths, pi);
-    if (values_now != NULL && pi->reverse_ordering == true) {
-      print_one_record(st, values_now, youngest_in_table, g_widths, pi);
-    }
+    print_all_records(st, g_widths, pi, pc);
 
   }
 };
 
 class RecordTables: public CHeapObj<mtInternal> {
 
-  enum {
-    // short term: 15 seconds per sample, 240 samples or 60 minutes total
-    short_term_interval_default = 15,
-    short_term_num_samples = 240,
+  // short term: 10 seconds per sample, 360 samples or 60 minutes total
+  static const int short_term_interval_default = 10;
+  static const int short_term_num_samples = 360;
 
-    // mid term: 15 minutes per sample (aka 60 short term samples), 96 samples or 24 hours in total
-    mid_term_interval_ratio = 60,
-    mid_term_num_samples = 96,
+  // mid term: 10 minutes per sample (aka 60 short term samples), 144 samples or 24 hours in total
+  static const int mid_term_interval_ratio = 60;
+  static const int mid_term_num_samples = 144;
 
-    // long term history: 2 hour intervals (aka 8 mid term samples), 120 samples or 10 days in total
-    long_term_interval_ratio = 8,
-    long_term_num_samples = 120
-  };
+  // long term history: 2 hour intervals (aka 8 mid term samples), 120 samples or 10 days in total
+  static const int long_term_interval_ratio = 8;
+  static const int long_term_num_samples = 120;
+
 
   int _short_term_interval;
 
@@ -888,21 +888,30 @@ public:
 
   }
 
-  void print_all(outputStream* st, const print_info_t* pi, const record_t* values_now = NULL) const {
+  void print_all(outputStream* st, const print_info_t* pi) const {
 
-    st->print_cr("Short Term Values:");
-    // At the start of the short term table we print the current (now) values. The intent is to be able
-    // to see very short term developments (e.g. a spike in heap usage in the last n seconds)
-    _short_term_table->print_table(st, pi, values_now);
-    st->cr();
+    print_context_t pc;
+    pc.records_printed = 0;
 
-    st->print_cr("Mid Term Values:");
-    _mid_term_table->print_table(st, pi);
-    st->cr();
+    if (pi->max == 0 || pc.records_printed < pi->max) {
+      st->print_cr("Short Term Values:");
+      // At the start of the short term table we print the current (now) values. The intent is to be able
+      // to see very short term developments (e.g. a spike in heap usage in the last n seconds)
+      _short_term_table->print_table(st, pi, &pc);
+      st->cr();
+    }
 
-    st->print_cr("Long Term Values:");
-    _long_term_table->print_table(st, pi);
-    st->cr();
+    if (pi->max == 0 || pc.records_printed < pi->max) {
+      st->print_cr("Mid Term Values:");
+      _mid_term_table->print_table(st, pi, &pc);
+      st->cr();
+    }
+
+    if (pi->max == 0 || pc.records_printed < pi->max) {
+      st->print_cr("Long Term Values:");
+      _long_term_table->print_table(st, pi, &pc);
+      st->cr();
+    }
 
   }
 
@@ -1213,6 +1222,18 @@ void cleanup() {
   }
 }
 
+const print_info_t* default_settings() {
+  static const print_info_t x = {
+      false, // raw
+      false, // csv
+      false, // omit_legend
+      false, // reverse_ordering;
+      0,     // scale
+      0      // max
+  };
+  return &x;
+}
+
 void print_report(outputStream* st, const print_info_t* pi) {
 
   st->print("Vitals:");
@@ -1224,15 +1245,8 @@ void print_report(outputStream* st, const print_info_t* pi) {
 
   st->cr();
 
-  static const print_info_t default_settings = {
-      false, // raw
-      false, // csv
-      false, // omit_legend
-      true   // avoid_sampling
-  };
-
   if (pi == NULL) {
-    pi = &default_settings;
+    pi = default_settings();
   }
 
   // Print legend at the top (omit if suppressed on command line, or in csv mode).
@@ -1241,15 +1255,7 @@ void print_report(outputStream* st, const print_info_t* pi) {
     st->cr();
   }
 
-  record_t* values_now = NULL;
-  if (!pi->avoid_sampling) {
-    // Sample the current values (not when reporting errors, since we do not want to risk secondary errors).
-    values_now = g_record_now;
-    values_now->timestamp = 0; // means "Now"
-    sample_values(values_now, true);
-  }
-
-  RecordTables::the_tables()->print_all(st, pi, values_now);
+  RecordTables::the_tables()->print_all(st, pi);
 
 }
 
@@ -1265,19 +1271,19 @@ void dump_reports() {
   } else {
     os::snprintf(vitals_file_name, sizeof(vitals_file_name), "%s%d.txt", file_prefix, os::current_process_id());
   }
+
+  // Note: we print two reports, both in reverse order (oldest to youngest). One in text form, one as csv.
+
   ::printf("Dumping Vitals to %s\n", vitals_file_name);
-  print_info_t pi;
-  memset(&pi, 0, sizeof(pi));
-  pi.avoid_sampling = true; // this is called during exit, so lets be a bit careful.
   {
     fileStream fs(vitals_file_name);
     static const StatisticsHistory::print_info_t settings = {
         false, // raw
         false, // csv
         false, // no_legend
-        true,  // avoid_sampling
         true,  // reverse_ordering
-        0      // scale
+        0,     // scale
+        0      // max
     };
     print_report(&fs, &settings);
   }
@@ -1288,22 +1294,22 @@ void dump_reports() {
     os::snprintf(vitals_file_name, sizeof(vitals_file_name), "%s%d.csv", file_prefix, os::current_process_id());
   }
   ::printf("Dumping Vitals csv to %s\n", vitals_file_name);
-  pi.csv = true;
-  pi.scale = 1 * K;
-  pi.reverse_ordering = true;
   {
     fileStream fs(vitals_file_name);
     static const StatisticsHistory::print_info_t settings = {
         false, // raw
         true,  // csv
         false, // no_legend
-        true,  // avoid_sampling
         true,  // reverse_ordering
-        1 * K  // scale
+        1 * K, // scale
+        0      // max
     };
     print_report(&fs, &settings);
   }
 
 }
+
+// For printing in thread lists only.
+const Thread* samplerthread() { return g_sampler_thread; }
 
 } // namespace StatisticsHistory

--- a/src/hotspot/share/services/stathist.hpp
+++ b/src/hotspot/share/services/stathist.hpp
@@ -40,22 +40,28 @@ namespace StatisticsHistory {
     bool csv;
     // Omit printing a legend.
     bool no_legend;
-    // Normally, when we print a report, we sample the current values too and print it atop of the table.
-    // We may want to avoid that, e.g. during error handling.
-    bool avoid_sampling;
     // Reverse printing order (default: youngest-to-oldest; reversed: oldest-to-youngest)
     bool reverse_ordering;
 
     size_t scale;
 
+    // max number of samples to print (0 = print all)
+    int max;
+
   };
 
+  // text output, youngest-to-oldest ordered, with legend, all records, dynamic scale.
+  const print_info_t* default_settings();
 
-  void print_report(outputStream* st, const print_info_t* print_info);
+  // Print report to stream. Leave print_info NULL for default settings.
+  void print_report(outputStream* st, const print_info_t* print_info = NULL);
 
   // Dump both textual and csv style reports to two files, "vitals_<pid>.txt" and "vitals_<pid>.csv".
   // If these files exist, they are overwritten.
   void dump_reports();
+
+  // For printing in thread lists only.
+  const Thread* samplerthread();
 
   // These are counters for the statistics history. Ideally, they would live
   // inside their thematical homes, e.g. thread.cpp or classLoaderDataGraph.cpp,

--- a/src/hotspot/share/services/stathistDCmd.cpp
+++ b/src/hotspot/share/services/stathistDCmd.cpp
@@ -41,13 +41,15 @@ StatHistDCmd::StatHistDCmd(outputStream* output, bool heap)
     _csv("csv", "csv format.", "BOOLEAN", false, "false"),
     _no_legend("no-legend", "Omit legend.", "BOOLEAN", false, "false"),
     _reverse("reverse", "Reverse printing order.", "BOOLEAN", false, "false"),
-    _raw("raw", "Print raw values.", "BOOLEAN", false, "false")
+    _raw("raw", "Print raw values.", "BOOLEAN", false, "false"),
+    _max("max", "Limit printing to max items.", "INT", false)
 {
   _dcmdparser.add_dcmd_option(&_scale);
   _dcmdparser.add_dcmd_option(&_no_legend);
   _dcmdparser.add_dcmd_option(&_reverse);
   _dcmdparser.add_dcmd_option(&_raw);
   _dcmdparser.add_dcmd_option(&_csv);
+  _dcmdparser.add_dcmd_option(&_max);
 }
 
 int StatHistDCmd::num_arguments() {
@@ -88,7 +90,7 @@ void StatHistDCmd::execute(DCmdSource source, TRAPS) {
   pi.csv = _csv.value();
   pi.no_legend = _no_legend.value();
   pi.reverse_ordering = _reverse.value();
-  pi.avoid_sampling = false;
+  pi.max = _max.value();
 
   StatisticsHistory::print_report(output(), &pi);
 }

--- a/src/hotspot/share/services/stathistDCmd.hpp
+++ b/src/hotspot/share/services/stathistDCmd.hpp
@@ -37,6 +37,7 @@ protected:
   DCmdArgument<bool> _no_legend;
   DCmdArgument<bool> _reverse;
   DCmdArgument<bool> _raw;
+  DCmdArgument<jlong> _max;
 public:
   StatHistDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -101,16 +101,6 @@ const char *env_list[] = {
   (const char *)0
 };
 
-// SapMachine 2019-09-16: Vitals
-static const StatisticsHistory::print_info_t vitals_print_settings = {
-    false, // raw
-    false, // csv
-    false, // no_legend
-    true,  // avoid_sampling
-    false, // reverse_ordering
-    0      // scale
-};
-
 // A simple parser for -XX:OnError, usage:
 //  ptr = OnError;
 //  while ((cmd = next_OnError_command(buffer, sizeof(buffer), &ptr) != NULL)
@@ -1000,7 +990,7 @@ void VMError::report(outputStream* st, bool _verbose) {
   // SapMachine 2019-02-20 : stathist
   STEP("Vitals")
      if (_verbose) {
-       StatisticsHistory::print_report(st, &vitals_print_settings);
+       StatisticsHistory::print_report(st);
      }
 
   STEP("printing system")
@@ -1176,7 +1166,7 @@ void VMError::print_vm_info(outputStream* st) {
 
   // SapMachine 2019-02-20 : stathist
   // STEP("Vitals")
-  StatisticsHistory::print_report(st, &vitals_print_settings);
+  StatisticsHistory::print_report(st);
 
   // STEP("printing system")
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
@@ -68,6 +68,11 @@ public class StatHistTest {
         output.shouldContain("--heap--");
         output.shouldContain("--meta--");
 
+        output = executor.execute("VM.vitals max=1");
+        output.shouldContain("--jvm--");
+        output.shouldContain("--heap--");
+        output.shouldContain("--meta--");
+
         output = executor.execute("VM.vitals csv");
         output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
 


### PR DESCRIPTION
SapMachine #540: Various fixes and improvements to vitals

* Fix build error on gcc 5.4, Ubuntu 16.4
"stathist.cpp:885:63: error: enumeral and non-enumeral type in conditional expression [-Werror=extra]"

* Add safety measure to guard against suspected endless loop in printing code.

* Remove the take-sample-at-printing-time feature since it
could be dangerous and the output was confusing.

* Reduce default sample interval from 15 to 10 seconds.

* Add a new sub option, "max", to limit number of records printed.

* Add Vitals sampler thread to threads list output.

(cherry picked from commit ff04966519a91608129811c2aa94a0c14fe6a328)

fixes #540