### PR TITLE
Cherry-pick 8238225: Issues reported after replacing symlink at Contents/MacOS/libjli.dylib with binary to SapMachine14

### DIFF
--- a/test/jdk/tools/launcher/JliLaunchTest.java
+++ b/test/jdk/tools/launcher/JliLaunchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 /**
  * @test
- * @bug 8213362
+ * @bug 8213362 8238225
  * @comment Test JLI_Launch for tools distributed outside JDK
  * @library /test/lib
  * @run main/native JliLaunchTest
@@ -56,6 +56,26 @@ public class JliLaunchTest {
 
         OutputAnalyzer outputf = new OutputAnalyzer(pb.start());
         outputf.shouldHaveExitValue(0);
+
+        if (Platform.isOSX()) {
+            Path javaHome = Paths.get(Utils.TEST_JDK);
+            if (javaHome.getFileName().toString().equals("Home")) {
+                // To exercise this test path you need to make sure the JDK under test is
+                // the MacOS bundle and not the simple jdk image. This can currently be
+                // achieved by running something like this (from the build output dir):
+                // $ make test-only TEST=test/jdk/tools/launcher/JliLaunchTest.java \
+                //     JDK_IMAGE_DIR=$PWD/images/jdk-bundle/jdk-15.jdk/Contents/Home
+                System.out.println("MacOS bundle distribution detected, also testing Contents/MacOS/libjli.dylib");
+                String macosDir = javaHome.getParent().resolve("MacOS").toString();
+                ProcessBuilder pb2 = new ProcessBuilder(launcher.toString(), "--version");
+                env = pb2.environment();
+                env.compute(pathEnvVar, (k, v) -> (v == null) ? macosDir : macosDir + File.pathSeparator + v);
+
+                OutputAnalyzer output2 = new OutputAnalyzer(pb2.start());
+                output2.shouldHaveExitValue(0);
+            } else {
+                System.out.println("Not a MacOS bundle distribution, not testing Contents/MacOS/libjli.dylib");
+            }
+        }
     }
 }
-


### PR DESCRIPTION
fixes #596 

