### PR TITLE
SapMachine (15) #659: Exclude serviceability/jvmti/8036666/GetObjectLockCount.java test

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -356,3 +356,6 @@ gc/g1/humongousObjects/TestHumongousNonArrayAllocation.java                     
 #SapMachine 2019-07-14 Lately, we see this sporadically...
 #Should be analysed, but we exclude it for now because it's tier1
 runtime/Safepoint/TestAbortVMOnSafepointTimeout.java                                 generic-all
+
+# SapMachine 2020-06-18 This test fails on our macOS machines due to the SAP specific DNS
+serviceability/jvmti/8036666/GetObjectLockCount.java                                 macosx-all


### PR DESCRIPTION
Cherry pick of commit 331ad31ffdcbe9880901d654bc59f89514f75413

fixes #659
