### PR TITLE
SapMachine #560: When printing/dumping Vitals in csv format there are duplicate column names

### DIFF
--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -275,9 +275,13 @@ static void print_column_names(outputStream* st, int widths[], const print_info_
     if (pi->csv == false) {
       st->print("%-*s ", widths[c->index()], c->name());
     } else { // csv mode
-      // csv: use comma as delimiter, don't pad, and precede name with header if there is one.
+      // csv: use comma as delimiter, don't pad, and precede name with category/header
+      //  (limited to 4 chars).
+      if (c->category() != NULL) {
+        st->print("%.4s-", c->category());
+      }
       if (c->header() != NULL) {
-        st->print("%s-", c->header());
+        st->print("%.4s-", c->header());
       }
       st->print("%s,", c->name());
     }

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
@@ -74,16 +74,16 @@ public class StatHistTest {
         output.shouldContain("--meta--");
 
         output = executor.execute("VM.vitals csv");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv reverse");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv reverse raw");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
     }
 
     @Test


### PR DESCRIPTION
When printing vitals in csv format, we do not print separate lines (category, header, column name) like in text mode. So precede column names with both category and header to prevent duplicate column names.

Before:
```
Time,avail,swap,si,so,pr,pb,cpu-us,cpu-sy,cpu-id,cpu-wa,cpu-st,cpu-gu,virt,rss-all,rss-anon,rss-file,rss-shm,swdo,cpu-us,cpu-sy,io-of,io-rd,io-wr,thr,heap-comm,heap-used,meta-comm,meta-used,meta-csc,meta-csu,meta-gctr,code,mlc,jthr-num,jthr-nd,jthr-cr,jthr-st,cldg-num,cldg-anon,cls-num,cls-ld,cls-uld,
```
(note the duplicate "cpu-sy" and "cpu-us" from both system-wide and process-local category)

Now:
```
Time,syst-avail,syst-swap,syst-si,syst-so,syst-pr,syst-pb,syst-cpu-us,syst-cpu-sy,syst-cpu-id,syst-cpu-wa,syst-cpu-st,syst-cpu-gu,proc-virt,proc-rss-all,proc-rss-anon,proc-rss-file,proc-rss-shm,proc-swdo,proc-cpu-us,proc-cpu-sy,proc-io-of,proc-io-rd,proc-io-wr,proc-thr,jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used,jvm-meta-csc,jvm-meta-csu,jvm-meta-gctr,jvm-code,jvm-mlc,jvm-jthr-num,jvm-jthr-nd,jvm-jthr-cr,jvm-jthr-st,jvm-cldg-num,jvm-cldg-anon,jvm-cls-num,jvm-cls-ld,jvm-cls-uld,
```

fixes #560
