### PR TITLE
SapMachine (11) #560: When printing/dumping Vitals in csv format there are duplicate column names

### DIFF
--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -275,9 +275,13 @@ static void print_column_names(outputStream* st, int widths[], const print_info_
     if (pi->csv == false) {
       st->print("%-*s ", widths[c->index()], c->name());
     } else { // csv mode
-      // csv: use comma as delimiter, don't pad, and precede name with header if there is one.
+      // csv: use comma as delimiter, don't pad, and precede name with category/header
+      //  (limited to 4 chars).
+      if (c->category() != NULL) {
+        st->print("%.4s-", c->category());
+      }
       if (c->header() != NULL) {
-        st->print("%s-", c->header());
+        st->print("%.4s-", c->header());
       }
       st->print("%s,", c->name());
     }

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/StatHistTest.java
@@ -74,16 +74,16 @@ public class StatHistTest {
         output.shouldContain("--meta--");
 
         output = executor.execute("VM.vitals csv");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv reverse");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
 
         output = executor.execute("VM.vitals csv reverse raw");
-        output.shouldContain("heap-comm,heap-used,meta-comm,meta-used");
+        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
     }
 
     @Test


### PR DESCRIPTION
(cherry picked from commit 14d1d0ef7df725757a171fb5f93824bdaf2e43d8)

fixes #560
