### PR TITLE
Prepare sapmachine11 for current release

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -125,13 +125,6 @@ serviceability/dcmd/framework/VMVersionTest.java                                
 ###############################################################################
 # New failures detected after GA of 11.0.7 (e.g. seen only in jdk11u-dev after branching 11.0.7 to jdk11u)
 
-# SapMachine 2020-03-25
-# This test fails ever since it was introduced and backported on Windows 32bit
-#
-# https://bugs.openjdk.java.net/browse/JDK-8241086
-# SapMachine 2020-05-06 Issue was resolved and test will no longer run on 32 bit. Backport to 11 still tbd.
-runtime/NMT/HugeArenaTracking.java                                           8241086 windows-i586
-
 # SapMachine 2020-04-09
 # We see some new failures on aarch64, 11u only. They probably aren't new but
 # we just started to run tests for 11u on that platform lately

--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -177,6 +177,10 @@ security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA
 ###############################################################################
 # New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
 
+# SapMachine 2020-09-04
+# This times out on AIX machines. don't fix, AIX is off-topic.  Seen in 11.0.8 and 16.
+java/awt/FontClass/DrawStringWithInfiniteXform.java                                   aix-all
+
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.
 

--- a/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
+++ b/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,11 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.cert.*;
+import java.text.DateFormat;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class GetPolicyQualifiers {
@@ -52,6 +54,9 @@ public class GetPolicyQualifiers {
         PKIXParameters params = new PKIXParameters(trustAnchors);
         params.setPolicyQualifiersRejected(false);
         params.setRevocationEnabled(false);
+        // Certificates expired on Oct 6th, 2020
+        params.setDate(DateFormat.getDateInstance(DateFormat.MEDIUM,
+                Locale.US).parse("July 01, 2020"));
         List certList = Collections.singletonList(eeCert);
         CertPath cp = cf.generateCertPath(certList);
         PKIXCertPathValidatorResult result =

--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -269,6 +269,10 @@ public class VerifyCACerts {
             add("addtrustexternalca [jdk]");
             // Valid until: Sat May 30 10:44:50 GMT 2020
             add("addtrustqualifiedca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("verisigntsaca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("thawtepremiumserverca [jdk]");
         }
     };
 


### PR DESCRIPTION
In the current SapMachine branches, some cherry-picks for build fixes and test exclusion lists need to be done to prepare for the upcoming October release.

fixes #736
