### PR TITLE
Prepare sapmachine15 for current release

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2850,8 +2850,8 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
     BufferBlob*  buf = buffer_blob(); // the temporary code buffer in CodeCache
     if (buf != NULL) {
       CodeBuffer buffer(buf);
-      double locs_buf[20];
-      buffer.insts()->initialize_shared_locs((relocInfo*)locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
+      struct { double data[20]; } locs_buf;
+      buffer.insts()->initialize_shared_locs((relocInfo*)&locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
 #if defined(AARCH64)
       // On AArch64 with ZGC and nmethod entry barriers, we need all oops to be
       // in the constant pool to ensure ordering between the barrier and oops

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
 + (NSColor*)getColor:(NSUInteger)colorIndex useAppleColor:(BOOL)useAppleColor {
     NSColor* result = nil;
 
-    if (colorIndex < (useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS) {
+    if (colorIndex < ((useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS)) {
         result = (useAppleColor ? appleColors : sColors)[colorIndex];
     }
     else {

--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -125,13 +125,6 @@ serviceability/dcmd/framework/VMVersionTest.java                                
 ###############################################################################
 # New failures detected after GA of 11.0.7 (e.g. seen only in jdk11u-dev after branching 11.0.7 to jdk11u)
 
-# SapMachine 2020-03-25
-# This test fails ever since it was introduced and backported on Windows 32bit
-#
-# https://bugs.openjdk.java.net/browse/JDK-8241086
-# SapMachine 2020-05-06 Issue was resolved and test will no longer run on 32 bit. Backport to 11 still tbd.
-#runtime/NMT/HugeArenaTracking.java                                           8241086 windows-i586
-
 # SapMachine 2020-04-09
 # We see some new failures on aarch64, 11u only. They probably aren't new but
 # we just started to run tests for 11u on that platform lately
@@ -219,8 +212,19 @@ testlibrary_tests/process/TestNativeProcessBuilder.java                         
 # Some (new?) Docker issues popped up
 #
 #
-# SapMachine 2020-07-07 Issue showed up after 8231111. Several fixes were made in the meantime. Hence removing exclusion now.
+# SapMachine 2020-07-07 Issue showed up after 8231111. Several fixes were made
+# in the meantime, see BL item above. Hence removing exclusion now.
 #containers/docker/TestMemoryAwareness.java                                           linux-s390x,linux-ppc64le
+
+# SapMachine 2020-09-17
+# Fails with: RuntimeException: 'Unloaded library with handle' missing from stdout/stderr
+# Recurring, 1-2 times a month.
+runtime/logging/loadLibraryTest/LoadLibraryTest.java                                 generic-all
+
+# SapMachine 2020-09-17
+# agent library failed to init: FieldAccessWatch
+# Failed to set capabilities, error: 98
+serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java                          aix-all
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -152,7 +152,7 @@ java/awt/print/PrinterJob/SameService.java                                   822
 #
 #
 # SapMachine 2019-08-13 Remove entry after moving tests to OSX 10.12+. There the font iteration is fast.
-java/awt/FontClass/FontSize1Test.java                                                darwinintel
+java/awt/FontClass/FontSize1Test.java                                                macosx-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.6 (e.g. seen only in jdk11u-dev after branching 11.0.6 to jdk11u)
@@ -167,8 +167,19 @@ security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java
 # New failures detected after GA of 11.0.7 (e.g. seen only in jdk11u-dev after branching 11.0.7 to jdk11u)
 
 # SapMachine 2020-07-06
-# certificate revoked
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java        generic-all
+# certificate revoked, see https://bugs.openjdk.java.net/browse/JDK-8248899
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java 8248899 generic-all
+
+# SapMachine 2020-07-10
+# certificate issue, see https://bugs.openjdk.java.net/browse/JDK-8249176
+security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA.java 8249176 generic-all
+
+###############################################################################
+# New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
+
+# SapMachine 2020-09-04
+# This times out on AIX machines. don't fix, AIX is off-topic.  Seen in 11.0.8 and 16.
+java/awt/FontClass/DrawStringWithInfiniteXform.java                                   aix-all
 
 ###############################################################################
 # Tests known to be failing in OpenJDK when JDK 12 was released (3/2019)
@@ -324,6 +335,44 @@ lib/testlibrary/OutputAnalyzerTest.java                                         
 # The bug deals with a similar issue, our info has been added
 javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java                       8227651 linux-s390x, aix-all
 javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java                       8227651 linux-s390x
+
+# SapMachine 2020-09-17
+# Seen only on this one machine -- machine issue?
+# *** glibc detected *** /bin/java: double free or corruption
+javax/sound/sampled/Clip/ClipIsRunningAfterStop.java                                 linux-ppc64
+
+# SapMachine 2020-09-17
+# RuntimeException: '/net/usr.work': 13570272264192 != 13570272198656
+java/io/File/GetXSpace.java                                                          generic-all
+
+# SapMachine 2020-09-17
+# Sporadic timeout on ls3876.  Exclude only here
+java/net/Socket/AsyncShutdown.java                                                   linux-ppc64
+
+# SapMachine 2020-09-17
+# WARNING: Using incubator modules: jdk.incubator.foreign
+# Exclude, retry once foreign is no more incubator.
+java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java    linux-ppc64,linux-ppc64le
+
+# SapMachine 2020-09-17
+# IllegalArgumentException: IPv6 socket cannot join IPv4 multicast group
+# many aix machines
+# Added macosx-all to the tests that are in the original exclude list.
+java/net/MulticastSocket/B6427403.java                                               aix-all
+java/net/MulticastSocket/NoLoopbackPackets.java                                      aix-all,macosx-all
+java/net/MulticastSocket/Promiscuous.java                                            aix-all
+java/net/MulticastSocket/SetLoopbackMode.java                                        aix-all,macosx-all
+java/net/MulticastSocket/Test.java                                                   aix-all,macosx-all
+
+# SapMachine 2020-09-17
+# Exception: ERROR: IsModifiableClass failed.
+# I'd assume this test should not be run on mac.
+java/lang/instrument/IsModifiableClassAgent.java                                     macosx-all
+
+# SapMachine 2020-09-17
+# SocketException: Cannot allocate memory
+# Seen a lot on mac, also 7, 11 ...
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java                     macosx-all
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
+++ b/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,11 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.cert.*;
+import java.text.DateFormat;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class GetPolicyQualifiers {
@@ -52,6 +54,9 @@ public class GetPolicyQualifiers {
         PKIXParameters params = new PKIXParameters(trustAnchors);
         params.setPolicyQualifiersRejected(false);
         params.setRevocationEnabled(false);
+        // Certificates expired on Oct 6th, 2020
+        params.setDate(DateFormat.getDateInstance(DateFormat.MEDIUM,
+                Locale.US).parse("July 01, 2020"));
         List certList = Collections.singletonList(eeCert);
         CertPath cp = cf.generateCertPath(certList);
         PKIXCertPathValidatorResult result =

--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -261,6 +261,10 @@ public class VerifyCACerts {
             add("addtrustexternalca [jdk]");
             // Valid until: Sat May 30 10:44:50 GMT 2020
             add("addtrustqualifiedca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("verisigntsaca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("thawtepremiumserverca [jdk]");
         }
     };
 


### PR DESCRIPTION
In the current SapMachine branches, some cherry-picks for build fixes and test exclusion lists need to be done to prepare for the upcoming October release.

fixes #736
