### PR TITLE
746: Vitals: show global number of processes and tasks

### DIFF
--- a/src/hotspot/os/linux/stathist_linux.cpp
+++ b/src/hotspot/os/linux/stathist_linux.cpp
@@ -24,8 +24,6 @@
  */
 
 #include "precompiled.hpp"
-
-#include "precompiled.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "services/stathist_internals.hpp"

--- a/src/hotspot/share/services/stathist.cpp
+++ b/src/hotspot/share/services/stathist.cpp
@@ -1183,6 +1183,7 @@ void sample_jvm_values(record_t* record, bool avoid_locking) {
   const size_t codecache_committed = CodeCache::capacity();
   set_value_in_record(g_col_codecache_committed, record, codecache_committed);
 
+#if INCLUDE_NMT
   // NMT
   if (!avoid_locking) {
     size_t malloc_footprint = 0;
@@ -1192,6 +1193,7 @@ void sample_jvm_values(record_t* record, bool avoid_locking) {
     }
     set_value_in_record(g_col_nmt_malloc, record, malloc_footprint);
   }
+#endif
 
   // Java threads
   set_value_in_record(g_col_number_of_java_threads, record, Threads::number_of_threads());


### PR DESCRIPTION
On linux, add two columns: "system/p" and "system/t", which show the number of processes and threads on the system.

Threads in this case means number of tasks which are associated with a userland process, so this number excludes kernel threads.

fixes #746

