### PR TITLE
Unify behavior for xxxOnOutOfMemoryError switches

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2908,15 +2908,16 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
   if (native_thread->osthread() == NULL) {
     // No one should hold a reference to the 'native_thread'.
     native_thread->smr_delete();
+
+    // SapMachine 2021-05-21: All ...OnOutOfMemoryError switches should work for
+    //  thread creation failures too.
+    report_java_out_of_memory(os::native_thread_creation_failed_msg());
+
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_THREADS,
         os::native_thread_creation_failed_msg());
     }
-
-    // SapMachine 2021-05-21: All ...OnOutOfMemoryError switches should work for
-    //  thread creation failures too.
-    report_java_out_of_memory(os::native_thread_creation_failed_msg());
 
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               os::native_thread_creation_failed_msg());

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2918,7 +2918,6 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_THREADS,
         os::native_thread_creation_failed_msg());
     }
-
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               os::native_thread_creation_failed_msg());
   }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2913,6 +2913,11 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_THREADS,
         os::native_thread_creation_failed_msg());
     }
+
+    // SapMachine 2021-05-21: All ...OnOutOfMemoryError switches should work for
+    //  thread creation failures too.
+    report_java_out_of_memory(os::native_thread_creation_failed_msg());
+
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               os::native_thread_creation_failed_msg());
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3146,8 +3146,8 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
   // SapMachine 2021-05-21:
   // - ExitVMOnOutOfMemory is an alias for CrashOnOutOfMemoryError
-  // - if either one of those is specified, and Crash dumps have not been explicitly enabled,
-  //   turn dumps off (we don't want cores on OOM)
+  // - if either one of these two is active and Crash dumps had not been explicitly enabled,
+  //   we turn dumps off (we generally don't want cores on OOM)
   if (ExitVMOnOutOfMemoryError && !CrashOnOutOfMemoryError) {
     FLAG_SET_ERGO(CrashOnOutOfMemoryError, true);
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3146,7 +3146,7 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
   // SapMachine 2021-05-21:
   // - ExitVMOnOutOfMemory is an alias for CrashOnOutOfMemoryError
-  // - if either one of those is specified, and Crash dumps have not been explicitly disabled,
+  // - if either one of those is specified, and Crash dumps have not been explicitly enabled,
   //   turn dumps off (we don't want cores on OOM)
   if (ExitVMOnOutOfMemoryError && !CrashOnOutOfMemoryError) {
     FLAG_SET_ERGO(CrashOnOutOfMemoryError, true);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3144,15 +3144,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
-  // SapMachine 2021-05-21:
-  // - ExitVMOnOutOfMemory is an alias for CrashOnOutOfMemoryError
-  // - if either one of these two is active and Crash dumps had not been explicitly enabled,
-  //   we turn dumps off (we generally don't want cores on OOM)
+  // SapMachine 2021-05-21: Let ExitVMOnOutOfMemory be an alias for CrashOnOutOfMemoryError
   if (ExitVMOnOutOfMemoryError && !CrashOnOutOfMemoryError) {
     FLAG_SET_ERGO(CrashOnOutOfMemoryError, true);
-  }
-  if (CrashOnOutOfMemoryError && CreateCoredumpOnCrash && FLAG_IS_DEFAULT(CreateCoredumpOnCrash)) {
-    FLAG_SET_ERGO(CreateCoredumpOnCrash, false);
   }
 
   return JNI_OK;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3144,6 +3144,17 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
+  // SapMachine 2021-05-21:
+  // - ExitVMOnOutOfMemory is an alias for CrashOnOutOfMemoryError
+  // - if either one of those is specified, and Crash dumps have not been explicitly disabled,
+  //   turn dumps off (we don't want cores on OOM)
+  if (ExitVMOnOutOfMemoryError && !CrashOnOutOfMemoryError) {
+    FLAG_SET_ERGO(CrashOnOutOfMemoryError, true);
+  }
+  if (CrashOnOutOfMemoryError && CreateCoredumpOnCrash && FLAG_IS_DEFAULT(CreateCoredumpOnCrash)) {
+    FLAG_SET_ERGO(CreateCoredumpOnCrash, false);
+  }
+
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -867,8 +867,11 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   /* SapMachine 2021-05-21: Changed comment (we do not core on OOM) */      \
   product(bool, CrashOnOutOfMemoryError, false,                             \
-          "JVM aborts, producing an error log, on the "                     \
-          "first occurrence of an out-of-memory error thrown from JVM")     \
+          "JVM aborts on the first occurrence of an out-of-memory error "   \
+          "thrown from JVM. A thread stack is dumped to stdout and an "     \
+          "error log produced. No core file will be produced unless "       \
+          "-XX:+CreateCoredumpOnCrash is explicitly specified on the "      \
+          "command line.")                                                  \
                                                                             \
   /* SapMachine 2021-05-21: Support ExitVMOnOutOfMemory to keep */          \
   /*  command line parity with SAPJVM */                                    \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -865,9 +865,15 @@ const intx ObjectAlignmentInBytes = 8;
           "JVM exits on the first occurrence of an out-of-memory error "    \
           "thrown from JVM")                                                \
                                                                             \
+  /* SapMachine 2021-05-21: Changed comment (we do not core on OOM) */      \
   product(bool, CrashOnOutOfMemoryError, false,                             \
-          "JVM aborts, producing an error log and core/mini dump, on the "  \
+          "JVM aborts, producing an error log, on the "                     \
           "first occurrence of an out-of-memory error thrown from JVM")     \
+                                                                            \
+  /* SapMachine 2021-05-21: Support ExitVMOnOutOfMemory to keep */          \
+  /*  command line parity with SAPJVM */                                    \
+  product(bool, ExitVMOnOutOfMemoryError, false,                            \
+          "Alias for CrashOnOutOfMemoryError")                              \
                                                                             \
   /* tracing */                                                             \
                                                                             \

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -361,6 +361,8 @@ void report_java_out_of_memory(const char* message) {
 
     if (CrashOnOutOfMemoryError) {
       tty->print_cr("Aborting due to java.lang.OutOfMemoryError: %s", message);
+      // SapMachine 2021-05-21: Print stack to stdout.
+      VMError::print_stack(tty);
       report_fatal(OOM_JAVA_HEAP_FATAL, __FILE__, __LINE__, "OutOfMemory encountered: %s", message);
     }
 

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -349,8 +349,26 @@ void report_java_out_of_memory(const char* message) {
   // commands multiple times we just do it once when the first threads reports
   // the error.
   if (Atomic::cmpxchg(&out_of_memory_reported, 0, 1) == 0) {
+
+    // SapMachine 2021-05-21: On SapMachine, in contrast to upstream OpenJDK, this
+    //  function gets invoked for OOMs resulting from Thread resource exhaustion as
+    //  well as for the "normal" Heap/Metaspace exhaustion. However, in that case we
+    //  do not handle HeapDumpOnOutOfMemoryError since heap dumps may take a long time
+    //  and are probably not as useful.
+    // (Note: the strstr is a bit tacky here but keeps the patch small.)
+    const bool is_thread_exhaustion =
+        ::strstr(message, "unable to create native thread") != NULL;
+
+    // SapMachine 2021-05-21: Print stack to stdout
+    if ((HeapDumpOnOutOfMemoryError && !is_thread_exhaustion) ||
+        (OnOutOfMemoryError && OnOutOfMemoryError[0]) ||
+        CrashOnOutOfMemoryError || ExitOnOutOfMemoryError) {
+      // SapMachine 2021-05-21: Print stack to stdout
+      VMError::print_stack(tty);
+    }
+
     // create heap dump before OnOutOfMemoryError commands are executed
-    if (HeapDumpOnOutOfMemoryError) {
+    if (HeapDumpOnOutOfMemoryError && !is_thread_exhaustion) {
       tty->print_cr("java.lang.OutOfMemoryError: %s", message);
       HeapDumper::dump_heap_from_oome();
     }
@@ -361,14 +379,10 @@ void report_java_out_of_memory(const char* message) {
 
     if (CrashOnOutOfMemoryError) {
       tty->print_cr("Aborting due to java.lang.OutOfMemoryError: %s", message);
-      // SapMachine 2021-05-21: Print stack to stdout.
-      VMError::print_stack(tty);
       report_fatal(OOM_JAVA_HEAP_FATAL, __FILE__, __LINE__, "OutOfMemory encountered: %s", message);
     }
 
     if (ExitOnOutOfMemoryError) {
-      // SapMachine 2021-05-21: Print stack to stdout.
-      VMError::print_stack(tty);
       tty->print_cr("Terminating due to java.lang.OutOfMemoryError: %s", message);
       os::exit(3);
     }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -367,6 +367,8 @@ void report_java_out_of_memory(const char* message) {
     }
 
     if (ExitOnOutOfMemoryError) {
+      // SapMachine 2021-05-21: Print stack to stdout.
+      VMError::print_stack(tty);
       tty->print_cr("Terminating due to java.lang.OutOfMemoryError: %s", message);
       os::exit(3);
     }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -59,6 +59,10 @@
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
 
+// SapMachine 2021-05-21
+#include "runtime/globals.hpp"
+#include "runtime/globals_extension.hpp"
+
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -357,6 +361,12 @@ void report_java_out_of_memory(const char* message) {
         (OnOutOfMemoryError && OnOutOfMemoryError[0]) ||
         CrashOnOutOfMemoryError || ExitOnOutOfMemoryError) {
       VMError::print_stack(tty);
+    }
+
+    // SapMachine 2021-05-21: If we crash due to CrashOnOutOfMemoryError, deactivate
+    //  cores unless they had been explicitly enabled.
+    if (CrashOnOutOfMemoryError && FLAG_IS_DEFAULT(CreateCoredumpOnCrash)) {
+      FLAG_SET_ERGO(CreateCoredumpOnCrash, false);
     }
 
     // create heap dump before OnOutOfMemoryError commands are executed

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1834,3 +1834,13 @@ void VMError::controlled_crash(int how) {
   ShouldNotReachHere();
 }
 #endif // !ASSERT
+
+// SapMachine 2021-05-21: A wrapper for VMError::print_stack(..), public, for printing stacks
+//  to tty on CrashOnOutOfMemoryError
+void VMError::print_stack(outputStream* st) {
+  Thread* t = Thread::current_or_null_safe();
+  char buf[1024];
+  if (t != NULL && t->is_Java_thread()) {
+    VMError::print_stack_trace(st, (JavaThread*) t, buf, sizeof(buf), false);
+  }
+}

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1835,7 +1835,7 @@ void VMError::controlled_crash(int how) {
 }
 #endif // !ASSERT
 
-// SapMachine 2021-05-21: A wrapper for VMError::print_stack(..), public, for printing stacks
+// SapMachine 2021-05-21: A wrapper for VMError::print_stack_trace(..), public, for printing stacks
 //  to tty on CrashOnOutOfMemoryError
 void VMError::print_stack(outputStream* st) {
   Thread* t = Thread::current_or_null_safe();

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -184,7 +184,7 @@ public:
   // Needed when printing signal handlers.
   NOT_WINDOWS(static const void* crash_handler_address;)
 
-  // SapMachine 2021-05-21: A wrapper for VMError::print_stack(..), public, for printing stacks
+  // SapMachine 2021-05-21: A wrapper for VMError::print_stack_trace(..), public, for printing stacks
   //  to tty on CrashOnOutOfMemoryError
   static void print_stack(outputStream* st);
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -184,5 +184,9 @@ public:
   // Needed when printing signal handlers.
   NOT_WINDOWS(static const void* crash_handler_address;)
 
+  // SapMachine 2021-05-21: A wrapper for VMError::print_stack(..), public, for printing stacks
+  //  to tty on CrashOnOutOfMemoryError
+  static void print_stack(outputStream* st);
+
 };
 #endif // SHARE_UTILITIES_VMERROR_HPP

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -52,8 +52,9 @@ public class TestCrashOnOutOfMemoryError {
             }
         }
         // else this is the main test
+        // SapMachine 2021-05-21: omit -CreateCoreDumpOnCrash; SapMachine should explicitly switch off cores for OOM errors.
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                 "-XX:-CreateCoredumpOnCrash", "-Xmx128m", TestCrashOnOutOfMemoryError.class.getName(),"throwOOME");
+                 "-Xmx128m", TestCrashOnOutOfMemoryError.class.getName(),"throwOOME");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         int exitValue = output.getExitValue();
         if (0 == exitValue) {
@@ -92,6 +93,12 @@ public class TestCrashOnOutOfMemoryError {
         if (hs_err_file == null) {
             throw new Error("Did not find hs-err file in output.\n");
         }
+
+        // SapMachine 2021-05-21: On SapMachine, CrashOnOutOfMemoryError should not write cores.
+        output.shouldContain("CreateCoredumpOnCrash turned off, no core file dumped");
+        // SapMachine 2021-05-21: On SapMachine, a stack should have been written to stdout
+        output.shouldContain("Java frames:");
+
 
         /*
          * Check if hs_err files exist or not

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -52,9 +52,8 @@ public class TestCrashOnOutOfMemoryError {
             }
         }
         // else this is the main test
-        // SapMachine 2021-05-21: omit -CreateCoreDumpOnCrash; SapMachine should explicitly switch off cores for OOM errors.
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                 "-Xmx128m", TestCrashOnOutOfMemoryError.class.getName(),"throwOOME");
+                 "-XX:-CreateCoredumpOnCrash", "-Xmx128m", TestCrashOnOutOfMemoryError.class.getName(),"throwOOME");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         int exitValue = output.getExitValue();
         if (0 == exitValue) {
@@ -93,12 +92,6 @@ public class TestCrashOnOutOfMemoryError {
         if (hs_err_file == null) {
             throw new Error("Did not find hs-err file in output.\n");
         }
-
-        // SapMachine 2021-05-21: On SapMachine, CrashOnOutOfMemoryError should not write cores.
-        output.shouldContain("CreateCoredumpOnCrash turned off, no core file dumped");
-        // SapMachine 2021-05-21: On SapMachine, a stack should have been written to stdout
-        output.shouldContain("Java frames:");
-
 
         /*
          * Check if hs_err files exist or not

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
@@ -71,7 +71,6 @@ public class TestSAPSpecificOnOutOfMemoryError {
         final String yes_core_1 = "Core dump will be written.";     // If limit > 0
         final String yes_core_2 = "Core dumps have been disabled."; // if limit == 0. For the purpose of this test this is still okay
         final String summary_from_hs_err = "S U M M A R Y";
-        final String rlimit_from_hs_err = "rlimit (soft/hard)";
 
         // CrashOnOutOfMemoryError, without cores explicitly enabled:
         // - thread stack
@@ -146,7 +145,6 @@ public class TestSAPSpecificOnOutOfMemoryError {
             output.shouldContain(a_fatal_error);
             output.shouldContain(no_core);
             output.shouldContain(summary_from_hs_err);
-            output.shouldContain(rlimit_from_hs_err);
 
             output.shouldNotContain(terminating_due);
             output.shouldNotContain(yes_core_1);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
@@ -59,12 +59,8 @@ public class TestSAPSpecificOnOutOfMemoryError {
         if (args.length == 1) {
             // This should guarantee to throw:
             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
-            try {
-                Object[] oa = new Object[Integer.MAX_VALUE];
-                throw new Error("OOME not triggered");
-            } catch (OutOfMemoryError err) {
-                throw new Error("OOME didn't abort JVM!");
-            }
+            Object[] oa = new Object[Integer.MAX_VALUE];
+            return;
         }
 
         final String aborting_due = "Aborting due to java.lang.OutOfMemoryError";
@@ -138,5 +134,20 @@ public class TestSAPSpecificOnOutOfMemoryError {
             output.shouldNotContain(no_core);
         }
 
+        // HeapDumpOnOutOfMemoryError should:
+        // - print thread stack
+        // - The VM should just run on. OOM will bubble up and end the program.
+        {
+            OutputAnalyzer output = run_test("-XX:+HeapDumpOnOutOfMemoryError");
+
+            output.shouldContain(java_frames);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(aborting_due);
+            output.shouldNotContain(a_fatal_error);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+            output.shouldNotContain(no_core);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
@@ -70,6 +70,8 @@ public class TestSAPSpecificOnOutOfMemoryError {
         final String no_core = "CreateCoredumpOnCrash turned off, no core file dumped";
         final String yes_core_1 = "Core dump will be written.";     // If limit > 0
         final String yes_core_2 = "Core dumps have been disabled."; // if limit == 0. For the purpose of this test this is still okay
+        final String summary_from_hs_err = "S U M M A R Y";
+        final String rlimit_from_hs_err = "rlimit (soft/hard)";
 
         // CrashOnOutOfMemoryError, without cores explicitly enabled:
         // - thread stack
@@ -132,6 +134,23 @@ public class TestSAPSpecificOnOutOfMemoryError {
             output.shouldNotContain(yes_core_1);
             output.shouldNotContain(yes_core_2);
             output.shouldNotContain(no_core);
+        }
+
+        // Test that giving ErrorFileToStdout in combination with CrashOnOutOfMemoryError will
+        //  print the hs-err file - including the limits, which may be important here - to stdout
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError", "-XX:+ErrorFileToStdout");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+            output.shouldContain(summary_from_hs_err);
+            output.shouldContain(rlimit_from_hs_err);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
         }
 
         // HeapDumpOnOutOfMemoryError should:

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestSAPSpecificOnOutOfMemoryError
+ * @summary Test SapMachine/SapJVM specific behavior
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver TestSAPSpecificOnOutOfMemoryError
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.util.ArrayList;
+
+public class TestSAPSpecificOnOutOfMemoryError {
+
+    static OutputAnalyzer run_test(String ... vm_args) throws Exception {
+        ArrayList<String> args = new ArrayList<>();
+        for (String s : vm_args) {
+            args.add(s);
+        }
+        args.add("-Xmx128m");
+        args.add(TestSAPSpecificOnOutOfMemoryError.class.getName());
+        args.add("throwOOME");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        int exitValue = output.getExitValue();
+        if (0 == exitValue) {
+            //expecting a non zero value
+            throw new Error("Expected to get non zero exit value");
+        }
+        return output;
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // This should guarantee to throw:
+            // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
+            try {
+                Object[] oa = new Object[Integer.MAX_VALUE];
+                throw new Error("OOME not triggered");
+            } catch (OutOfMemoryError err) {
+                throw new Error("OOME didn't abort JVM!");
+            }
+        }
+
+        final String aborting_due = "Aborting due to java.lang.OutOfMemoryError";
+        final String terminating_due = "Terminating due to java.lang.OutOfMemoryError";
+        final String java_frames = "Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)";
+        final String a_fatal_error = "# A fatal error has been detected by the Java Runtime Environment";
+        final String no_core = "CreateCoredumpOnCrash turned off, no core file dumped";
+        final String yes_core_1 = "Core dump will be written.";     // If limit > 0
+        final String yes_core_2 = "Core dumps have been disabled."; // if limit == 0. For the purpose of this test this is still okay
+
+        // CrashOnOutOfMemoryError, without cores explicitly enabled:
+        // - thread stack
+        // - aborting with hs-err file
+        // - no core
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+        }
+
+        // ExitVMOnOutOfMemoryError is a SAP specific alias for CrashOnOutOfMemoryError
+        {
+            OutputAnalyzer output = run_test("-XX:+ExitVMOnOutOfMemoryError");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+        }
+
+        // CrashOnOutOfMemoryError, with cores explicitly enabled:
+        // - thread stack
+        // - aborting with hs-err file
+        // - core is to be written (or, attempted, if ulimit = 0)
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError", "-XX:+CreateCoredumpOnCrash");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldMatch("(" + yes_core_1 + "|" + yes_core_2 + ")");
+
+            output.shouldNotContain(no_core);
+            output.shouldNotContain(terminating_due);
+        }
+
+        // ExitOnOutOfMemoryError should:
+        // - print thread stack
+        // - terminate the VM
+        {
+            OutputAnalyzer output = run_test("-XX:+ExitOnOutOfMemoryError");
+
+            output.shouldContain(terminating_due);
+            output.shouldContain(java_frames);
+
+            output.shouldNotContain(aborting_due);
+            output.shouldNotContain(a_fatal_error);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+            output.shouldNotContain(no_core);
+        }
+
+    }
+}


### PR DESCRIPTION
Hi, may I please have reviews for this change. Details and motivation see https://github.com/SAP/SapMachine/issues/861.

The patch:

- introduces `ExitVMOnOutOfMemoryError` as an alias to `CrashOnOutOfMemoryError`
- adds stack dumping to tty for both
- switches off cores if either one is set, unless cores had been explicitly requested by the user
- Wires all `xxOnOutOfMemoryError` switches up to thread creation too - all these will fire when we cannot start native threads (note that `OnOutOfMemoryError=command` probably won't work since it requires the ability to fork). Note that I decided to wire this up after resource-exhausted-JVMTI-hook is called; does that make sense or should I do it before? to me its a coin toss, really.)
- Adds a new jtreg test to test SapMachine specific logic
- Also adds stack dumping to the otherwise unchanged `ExitOnOutOfMemoryError`
---

Testing:
- ran the jtreg test
- ran hotspot:tier1 locally
- tested manually all these switches both with OOM from Metaspace and OOMs from thread creation; the latter with ulimit -u set. Works. We now print thread stack to tty, then assert, but without core:

```
thomas@starfish$ ulimit -u 3000
thomas@starfish$ ./images/jdk/bin/java -XX:+CrashOnOutOfMemoryError de.stuefe.repros.MultiThreadTest --num-threads=3000 --wait-time=100
Will start 3000 threads, wait time 100s...
<press key>
 ... continuing.
Created: 300...
Created: 600...
Created: 900...
Created: 1200...
Created: 1500...
Created: 1800...
Created: 2100...
[1,119s][warning][os,thread] Failed to start thread - pthread_create failed (EAGAIN) for attributes: stacksize: 1024k, guardsize: 0k, detached.
Aborting due to java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 372  java.lang.Thread.start0()V java.base@17-internal (0 bytes) @ 0x00007fe389087ac4 [0x00007fe389087a60+0x0000000000000064]
J 368 c1 java.lang.Thread.start()V java.base@17-internal (71 bytes) @ 0x00007fe381cd0934 [0x00007fe381cd07e0+0x0000000000000154]
j  de.stuefe.repros.MultiThreadTest.call()Ljava/lang/Integer;+93
j  de.stuefe.repros.MultiThreadTest.call()Ljava/lang/Object;+1
j  picocli.CommandLine.executeUserObject(Lpicocli/CommandLine;Ljava/util/List;)Ljava/util/List;+94
j  picocli.CommandLine.access$900(Lpicocli/CommandLine;Ljava/util/List;)Ljava/util/List;+2
j  picocli.CommandLine$RunLast.handle(Lpicocli/CommandLine$ParseResult;)Ljava/util/List;+29
j  picocli.CommandLine$RunLast.handle(Lpicocli/CommandLine$ParseResult;)Ljava/lang/Object;+2
j  picocli.CommandLine$AbstractParseResultHandler.execute(Lpicocli/CommandLine$ParseResult;)I+16
j  picocli.CommandLine.execute([Ljava/lang/String;)I+31
j  de.stuefe.repros.MultiThreadTest.main([Ljava/lang/String;)V+15
v  ~StubRoutines::call_stub
# To suppress the following error report, specify this argument
# after -XX: or in .hotspotrc:  SuppressErrorAt=/debug.cpp:366
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/shared/projects/openjdk/sapmachine/source/src/hotspot/share/utilities/debug.cpp:366), pid=441918, tid=441919
#  fatal error: OutOfMemory encountered: unable to create native thread: possibly out of memory or process/resource limits reached
#
# JRE version: OpenJDK Runtime Environment (17.0) (fastdebug build 17-internal+0-adhoc.thomas.source)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc.thomas.source, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# CreateCoredumpOnCrash turned off, no core file dumped
#
# An error report file with more information is saved as:
# /shared/projects/openjdk/sapmachine/output-fastdebug/hs_err_pid441918.log

```


fixes #861

