### PR TITLE
SapMachine #861 (16): Unify behavior for xxxOnOutOfMemoryError

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3095,6 +3095,11 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
   if (native_thread->osthread() == NULL) {
     // No one should hold a reference to the 'native_thread'.
     native_thread->smr_delete();
+
+    // SapMachine 2021-05-21: All ...OnOutOfMemoryError switches should work for
+    //  thread creation failures too.
+    report_java_out_of_memory(os::native_thread_creation_failed_msg());
+
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_THREADS,

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3200,6 +3200,11 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
+  // SapMachine 2021-05-21: Let ExitVMOnOutOfMemory be an alias for CrashOnOutOfMemoryError
+  if (ExitVMOnOutOfMemoryError && !CrashOnOutOfMemoryError) {
+    FLAG_SET_ERGO(CrashOnOutOfMemoryError, true);
+  }
+
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -886,9 +886,18 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, ExitOnOutOfMemoryError, false,                              \
           "JVM exits on the first occurrence of an out-of-memory error")    \
                                                                             \
+  /* SapMachine 2021-05-21: Changed comment (we do not core on OOM) */      \
   product(bool, CrashOnOutOfMemoryError, false,                             \
-          "JVM aborts, producing an error log and core/mini dump, on the "  \
-          "first occurrence of an out-of-memory error")                     \
+          "JVM aborts on the first occurrence of an out-of-memory error "   \
+          "thrown from JVM. A thread stack is dumped to stdout and an "     \
+          "error log produced. No core file will be produced unless "       \
+          "-XX:+CreateCoredumpOnCrash is explicitly specified on the "      \
+          "command line.")                                                  \
+                                                                            \
+  /* SapMachine 2021-05-21: Support ExitVMOnOutOfMemory to keep */          \
+  /*  command line parity with SAPJVM */                                    \
+  product(bool, ExitVMOnOutOfMemoryError, false,                            \
+          "Alias for CrashOnOutOfMemoryError")                              \
                                                                             \
   /* tracing */                                                             \
                                                                             \

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -61,6 +61,10 @@
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
 
+// SapMachine 2021-05-21
+#include "runtime/globals.hpp"
+#include "runtime/globals_extension.hpp"
+
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -328,6 +332,22 @@ void report_java_out_of_memory(const char* message) {
   // commands multiple times we just do it once when the first threads reports
   // the error.
   if (Atomic::cmpxchg(&out_of_memory_reported, 0, 1) == 0) {
+
+    // SapMachine 2021-05-21: If any one of the xxxOnOutOfMemoryError is specified,
+    //  print stack to stdout. Do this before any subsequent handling - this is the
+    //  most important information.
+    if ((HeapDumpOnOutOfMemoryError) ||
+        (OnOutOfMemoryError && OnOutOfMemoryError[0]) ||
+        CrashOnOutOfMemoryError || ExitOnOutOfMemoryError) {
+      VMError::print_stack(tty);
+    }
+
+    // SapMachine 2021-05-21: If we crash due to CrashOnOutOfMemoryError, deactivate
+    //  cores unless they had been explicitly enabled.
+    if (CrashOnOutOfMemoryError && FLAG_IS_DEFAULT(CreateCoredumpOnCrash)) {
+      FLAG_SET_ERGO(CreateCoredumpOnCrash, false);
+    }
+
     // create heap dump before OnOutOfMemoryError commands are executed
     if (HeapDumpOnOutOfMemoryError) {
       tty->print_cr("java.lang.OutOfMemoryError: %s", message);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1894,3 +1894,13 @@ void VMError::controlled_crash(int how) {
   ShouldNotReachHere();
 }
 #endif // !PRODUCT
+
+// SapMachine 2021-05-21: A wrapper for VMError::print_stack_trace(..), public, for printing stacks
+//  to tty on CrashOnOutOfMemoryError
+void VMError::print_stack(outputStream* st) {
+  Thread* t = Thread::current_or_null_safe();
+  char buf[1024];
+  if (t != NULL && t->is_Java_thread()) {
+    VMError::print_stack_trace(st, (JavaThread*) t, buf, sizeof(buf), false);
+  }
+}

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -190,5 +190,10 @@ public:
   // returns an address which is guaranteed to generate a SIGSEGV on read,
   // for test purposes, which is not NULL and contains bits in every word
   static void* get_segfault_address();
+
+  // SapMachine 2021-05-21: A wrapper for VMError::print_stack_trace(..), public, for printing stacks
+  //  to tty on CrashOnOutOfMemoryError
+  static void print_stack(outputStream* st);
+
 };
 #endif // SHARE_UTILITIES_VMERROR_HPP

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestSAPSpecificOnOutOfMemoryError
+ * @summary Test SapMachine/SapJVM specific behavior
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver TestSAPSpecificOnOutOfMemoryError
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.util.ArrayList;
+
+public class TestSAPSpecificOnOutOfMemoryError {
+
+    static OutputAnalyzer run_test(String ... vm_args) throws Exception {
+        ArrayList<String> args = new ArrayList<>();
+        for (String s : vm_args) {
+            args.add(s);
+        }
+        args.add("-Xmx128m");
+        args.add(TestSAPSpecificOnOutOfMemoryError.class.getName());
+        args.add("throwOOME");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        int exitValue = output.getExitValue();
+        if (0 == exitValue) {
+            //expecting a non zero value
+            throw new Error("Expected to get non zero exit value");
+        }
+        return output;
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // This should guarantee to throw:
+            // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
+            Object[] oa = new Object[Integer.MAX_VALUE];
+            return;
+        }
+
+        final String aborting_due = "Aborting due to java.lang.OutOfMemoryError";
+        final String terminating_due = "Terminating due to java.lang.OutOfMemoryError";
+        final String java_frames = "Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)";
+        final String a_fatal_error = "# A fatal error has been detected by the Java Runtime Environment";
+        final String no_core = "CreateCoredumpOnCrash turned off, no core file dumped";
+        final String yes_core_1 = "Core dump will be written.";     // If limit > 0
+        final String yes_core_2 = "Core dumps have been disabled."; // if limit == 0. For the purpose of this test this is still okay
+        final String summary_from_hs_err = "S U M M A R Y";
+
+        // CrashOnOutOfMemoryError, without cores explicitly enabled:
+        // - thread stack
+        // - aborting with hs-err file
+        // - no core
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+        }
+
+        // ExitVMOnOutOfMemoryError is a SAP specific alias for CrashOnOutOfMemoryError
+        {
+            OutputAnalyzer output = run_test("-XX:+ExitVMOnOutOfMemoryError");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+        }
+
+        // CrashOnOutOfMemoryError, with cores explicitly enabled:
+        // - thread stack
+        // - aborting with hs-err file
+        // - core is to be written (or, attempted, if ulimit = 0)
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError", "-XX:+CreateCoredumpOnCrash");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldMatch("(" + yes_core_1 + "|" + yes_core_2 + ")");
+
+            output.shouldNotContain(no_core);
+            output.shouldNotContain(terminating_due);
+        }
+
+        // ExitOnOutOfMemoryError should:
+        // - print thread stack
+        // - terminate the VM
+        {
+            OutputAnalyzer output = run_test("-XX:+ExitOnOutOfMemoryError");
+
+            output.shouldContain(terminating_due);
+            output.shouldContain(java_frames);
+
+            output.shouldNotContain(aborting_due);
+            output.shouldNotContain(a_fatal_error);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+            output.shouldNotContain(no_core);
+        }
+
+        // Test that giving ErrorFileToStdout in combination with CrashOnOutOfMemoryError will
+        //  print the hs-err file - including the limits, which may be important here - to stdout
+        {
+            OutputAnalyzer output = run_test("-XX:+CrashOnOutOfMemoryError", "-XX:+ErrorFileToStdout");
+
+            output.shouldContain(aborting_due);
+            output.shouldContain(java_frames);
+            output.shouldContain(a_fatal_error);
+            output.shouldContain(no_core);
+            output.shouldContain(summary_from_hs_err);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+        }
+
+        // HeapDumpOnOutOfMemoryError should:
+        // - print thread stack
+        // - The VM should just run on. OOM will bubble up and end the program.
+        {
+            OutputAnalyzer output = run_test("-XX:+HeapDumpOnOutOfMemoryError");
+
+            output.shouldContain(java_frames);
+
+            output.shouldNotContain(terminating_due);
+            output.shouldNotContain(aborting_due);
+            output.shouldNotContain(a_fatal_error);
+            output.shouldNotContain(yes_core_1);
+            output.shouldNotContain(yes_core_2);
+            output.shouldNotContain(no_core);
+        }
+    }
+}


### PR DESCRIPTION
(manually cherry picked from commit 6dfb6bd48cebd8cb0d5dd6643f5c594c572fc48b)

Patch for SapMachine 16.

Had to adapt the patch manually a bit since it did not merge automatically (vmError.cpp, vmError.hpp and globals.hpp trivially changed between 16 and 17).

Testing:
- manual tests with thread starvation
- ran runtime/ErrorHandling/TestOnOutOfMemoryError.java
- ran runtime/ErrorHandling/TestSAPSpecificOnOutOfMemoryError.java

fixes #861
