### PR TITLE
SapMachine (16) #876: Integrate test fixes and cleanups

### DIFF
--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -51,19 +51,6 @@
 #
 compiler/rtm/locking/TestRTMSpinLoopCount.java                                       generic-ppc64,linux-ppc64le
 
-# SapMachine 2019-03-11
-# Fails with timeout or "Could not find any processes matching : 'HelpTest$Process'"
-#
-#
-#
-# SapMachine 2019-07-15 Still seen in 11 - 14, rarely on others than windows.
-# SapMachine 2019-08-08 Backported 8205654 to 11 - but this will probably fix the issue for linux only.
-# SapMachine 2020-03-03 We will no more analyse the issues with this test. We will just keep it excluded.
-#
-# SapMachine 2020-03-24 Let's see how it goes if we drop this exclusion. It's already commented out in all
-#                       other lists except for 11_hs. If it is very sporadic we might be able to remove this entry from our list.
-#serviceability/dcmd/framework/HelpTest.java                                          windows-all
-
 # SapMachine 2019-04-29
 # java.lang.IllegalStateException: WB_IncMetaspaceCapacityUntilGC: could not increase capacity until GC due to contention with another thread
 # SapMachine 2019-04-30 Still fails in 11.0.4
@@ -72,26 +59,6 @@ gc/metaspace/TestCapacityUntilGCWrapAround.java                                 
 # SapMachine 2019-04-29
 # Sporadic timeout 11 only since 3.3.2019, which is probably the date we started to run these again.
 vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java                                generic-all
-
-# SapMachine 2019-04-29
-# Very sporadic on linux/ppc.
-# Can't attach to the process: ptrace(PTRACE_ATTACH, ..) failed for 4253: No such process
-# Enable it to find one of the sporadic occurances and paste the link here.
-#serviceability/sa/TestJhsdbJstackMixed.java                                          linux-ppc64le,linux-ppc64
-
-# SapMachine 2019-06-07
-# Frequent timeouts on several platforms, observed only in 11.
-#
-# Oracle does see these issues as well: https://bugs.openjdk.java.net/browse/JDK-8231169
-# Backport JDK-8212028, JDK-8211037 and see if this helps
-#
-#vmTestbase/vm/mlvm/cp/stress/classfmt/correctBootstrap/TestDescription.java          linux-x64,solaris-sparcv9
-#
-#vmTestbase/vm/mlvm/cp/stress/classfmt/mh/TestDescription.java                        linux-x64,solaris-sparcv9
-#
-#vmTestbase/vm/mlvm/cp/stress/classfmt/mt/TestDescription.java                        generic-ppc64,linux-ppc64le
-#
-#vmTestbase/vm/mlvm/meth/stress/gc/createLotsOfMHConsts/Test.java                     solaris-sparcv9
 
 # SapMachine 2019-08-07
 # Seems to occur only on ...
@@ -112,15 +79,6 @@ runtime/StackGuardPages/testme.sh                                               
 # SapMachine 2019-08-08 Backported 8205654 to 11 - but this will probably fix the issue for linux only.
 # For Windows, we should keep the test excluded or we'll see some failing tests sporadically.
 serviceability/dcmd/framework/VMVersionTest.java                                     windows-all
-
-# SapMachine 2019-07-16
-# 11-only crash at:
-# Klass::method_at_vtable
-# linkResolver::runtime_resolve_virtual_method
-#
-#
-# SapMachine 2020-03-24 Disarmed diagnosis patches and made sure test is enabled everywhere. Let's see what happens.
-#vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn007/TestDescription.java  linux-s390x,windows-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.7 (e.g. seen only in jdk11u-dev after branching 11.0.7 to jdk11u)
@@ -144,6 +102,14 @@ serviceability/dcmd/framework/VMVersionTest.java                                
 # SapMachine 2020-05-12: Created JBS issue: https://bugs.openjdk.java.net/browse/JDK-8244847
 # fixed upstream, needs backport
 #runtime/CompressedOops/CompressedClassPointers.java                          8244847 linux-ppc64le
+
+###############################################################################
+# New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
+
+# SapMachine 2020-07-31
+# Fails because UseShenandoahGC is not recognized if JDK is built without shenandoah (default).
+# https://bugs.openjdk.java.net/browse/JDK-8250888
+#vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java       generic-all
 
 ###############################################################################
 # Tests known to be failing in OpenJDK when JDK 12 was released (3/2019)
@@ -208,14 +174,6 @@ gc/shenandoah/mxbeans/TestChurnNotifications.java#id0                           
 #
 #
 testlibrary_tests/process/TestNativeProcessBuilder.java                              aix-all
-
-# SapMachine 2020-03-27
-# Some (new?) Docker issues popped up
-#
-#
-# SapMachine 2020-07-07 Issue showed up after 8231111. Several fixes were made
-# in the meantime, see BL item above. Hence removing exclusion now.
-#containers/docker/TestMemoryAwareness.java                                           linux-s390x,linux-ppc64le
 
 # SapMachine 2020-09-17
 # Fails with: RuntimeException: 'Unloaded library with handle' missing from stdout/stderr

--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -98,13 +98,6 @@ java/awt/font/Rotate/RotatedFontMetricsTest.java                                
 ###############################################################################
 # New failures detected after GA of 11.0.3 (e.g. seen only in jdk11u-dev after branching 11.0.3 to jdk11u)
 
-# SapMachine 2019-06-17
-# java.lang.Exception: Failed for font java.awt.Font[family=Dialog,name=MS Gothic,style=bold,size=30]
-#
-#
-# SapMachine 2019-10-09 I believe this is caused by outdated libfreetype versions and hence fixed by using configure option --with-freetype=bundled everywhere
-#java/awt/font/Outline/OutlineInvarianceTest.java                                     linux-s390x
-
 # SapMachine 2019-06-28
 #
 # java.lang.AssertionError at java.desktop/sun.awt.shell.Win32ShellFolder2$4.call(Win32ShellFolder2.java:440)
@@ -121,20 +114,6 @@ javax/swing/JFileChooser/4847375/bug4847375.java                                
 # https://bugs.openjdk.java.net/browse/JDK-8229023
 java/awt/print/PrinterJob/SameService.java                                   8229023 linux-s390x
 
-# SapMachine 2019-07-18
-# javax.net.ssl.SSLException: The status_request_v2 extension is inconsistent with the expected result: expected = true, actual = false
-# we see this sporadically on rs6000_64 - why? Adding this entry but commented out, for reference.
-#
-#javax/net/ssl/Stapling/StapleEnableProps.java                                        aix-all
-
-# SapMachine 2019-07-19
-# These issues occur in our internal SapMachine test env. Probably infra related on host ... Seen in 11 only.
-#
-# SapMachine 2020-03-26 Enabling these tests in 11u to see whether the issue still occurs
-#sun/management/jdp/JdpDefaultsTest.java                                              linux-ppc64le
-#sun/management/jdp/JdpJmxRemoteDynamicPortTest.java                                  linux-ppc64le
-#sun/management/jdp/JdpSpecificAddressTest.java                                       linux-ppc64le
-
 ###############################################################################
 # New failures detected after GA of 11.0.4 (e.g. seen only in jdk11u-dev after branching 11.0.4 to jdk11u)
 
@@ -146,32 +125,12 @@ java/awt/print/PrinterJob/SameService.java                                   822
 java/awt/FontClass/FontSize1Test.java                                                macosx-all
 
 ###############################################################################
-# New failures detected after GA of 11.0.6 (e.g. seen only in jdk11u-dev after branching 11.0.6 to jdk11u)
-
-# SapMachine 2020-04-23
-# fails in nightly tests since 23.4.2020, seems to be a revocation
-#
-# https://bugs.openjdk.java.net/browse/JDK-8243543
-security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java 8243543 generic-all
-
-###############################################################################
-# New failures detected after GA of 11.0.7 (e.g. seen only in jdk11u-dev after branching 11.0.7 to jdk11u)
-
-# SapMachine 2020-07-06
-# certificate revoked, see https://bugs.openjdk.java.net/browse/JDK-8248899
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java 8248899 generic-all
-
-# SapMachine 2020-07-10
-# certificate issue, see https://bugs.openjdk.java.net/browse/JDK-8249176
-#security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA.java 8249176 generic-all
-
-###############################################################################
 # New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
 
 # SapMachine 2020-09-04
 # This times out on AIX machines. don't fix, AIX is off-topic.  Seen in 11.0.8 and 16.
 #
-java/awt/FontClass/DrawStringWithInfiniteXform.java                                   aix-all
+java/awt/FontClass/DrawStringWithInfiniteXform.java                                  aix-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.9 (e.g. seen only in jdk11u-dev after branching 11.0.9 to jdk11u)
@@ -182,11 +141,23 @@ java/awt/FontClass/DrawStringWithInfiniteXform.java                             
 # Seen a lot on mac, also 7, 11 ...
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java                     macosx-all
 
-# SapMachine 2020-12-30
-# Fails after https://bugs.openjdk.java.net/browse/JDK-8243488 on Mac
-# should be fixed by https://bugs.openjdk.java.net/browse/JDK-8239355 (to be backported)
+###############################################################################
+# New failures detected after GA of 11.0.10 (e.g. seen only in jdk11u-dev after branching 11.0.10 to jdk11u)
+
+# SapMachine 2021-02-16
+# sun.security.pkcs11.wrapper.PKCS11Exception: CKR_ATTRIBUTE_READ_ONLY
+# Test fails on several Linux distributions with some packaged nss libs. We see it on ...
 #
-#java/net/DatagramSocket/SetGetSendBufferSize.java                            8239355 macosx-all
+#
+# https://bugs.openjdk.java.net/browse/JDK-8232153
+sun/security/pkcs11/Secmod/AddTrustedCert.java                               8232153 linux-aarch64,linux-ppc64le
+
+# SapMachine 2021-02-24
+# Test sun/security/pkcs11/fips/SunJSSEKeyExchangeFIPS.java that was introduced
+# with https://bugs.openjdk.java.net/browse/JDK-8257545 fails on ...
+# Probably some issue with OS configuration/libnss. We simply exclude it.
+#
+#sun/security/pkcs11/fips/SunJSSEKeyExchangeFIPS.java                                 linux-s390x
 
 ###############################################################################
 # Tests known to be failing in OpenJDK when JDK 12 was released (3/2019)
@@ -231,14 +202,6 @@ java/nio/channels/FileChannel/CleanerTest.java                                  
 ###############################################################################
 # Failing new tests, unsupported new features in jdk13
 
-# SapMachine 2019-02-21
-# All crash reproducible on one test machine. SIGSEGV [libucrypto.so.1+0xb5a90]  ucrypto_digest_update+0x4
-# SapMachine 2019-10-09 See if this still occurs.
-#java/net/httpclient/DigestEchoClientSSL.java                                         solaris-sparcv9
-#java/net/httpclient/ProxyAuthDisabledSchemesSSL.java                                 solaris-sparcv9
-#sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest                       solaris-sparcv9
-#sun/security/tools/keytool/KeyToolTest.java                                          solaris-sparcv9
-
 # SapMachine 2019-08-08
 # We see this issue occuring for a long time already in 13 and 14.
 # Another one of these flaky font things??
@@ -257,19 +220,12 @@ java/nio/file/WatchService/LotsOfCloses.java                                    
 # Created JBS issue: https://bugs.openjdk.java.net/browse/JDK-8230349
 jdk/jfr/event/gc/detailed/TestStressAllocationGCEventsWithParallel.java      8230349 macosx-all
 
-# SapMachine 2019-09-09
-# Maybe related to new Socket Impl
-#
-#
-# First occurence on 2019-06-04
-#java/net/Socket/asyncClose/Race.java                                                 aix-all
-
 ###############################################################################
 # Failing new tests, unsupported new features in jdk14
 
 # SapMachine 2019-08-30
-# Richard's new test unveils an aarch64 issue. Exclude for the time being. Still a patch in patch queue.
-#com/sun/jdi/EATests.java                                                             linux-aarch64
+# Richard's new test unveils an aarch64 issue.
+com/sun/jdi/EATests.java                                                             linux-aarch64
 
 # SapMachine 2019-12-04
 # New failures on AIX after recent changes in jdk/jdk
@@ -279,52 +235,8 @@ java/nio/channels/DatagramChannel/AfterDisconnect.java                          
 #
 java/nio/channels/DatagramChannel/ChangingAddress.java                               aix-all,macosx-all
 
-# SapMachine 2019-01-02
-# There are quite some failures regarding new jpackage tests
-#
-#
-# SapMachine 2020-02-11: Submitted a few fixes. Need to test which items still fail.
-# https://bugs.openjdk.java.net/browse/JDK-8238947
-# https://bugs.openjdk.java.net/browse/JDK-8238953
-#tools/jpackage/linux/AppCategoryTest.java                                            generic-all
-#tools/jpackage/linux/LicenseTypeTest.java                                            generic-all
-#tools/jpackage/linux/LinuxBundleNameTest.java                                        generic-all
-#tools/jpackage/linux/LinuxResourceTest.java                                          generic-all
-#tools/jpackage/linux/PackageDepsTest.java                                            generic-all
-#tools/jpackage/linux/ReleaseTest.java                                                generic-all
-#tools/jpackage/linux/ShortcutHintTest.java#id0                                       generic-all
-#tools/jpackage/share/jdk/jpackage/tests/AppVersionTest.java                          generic-all
-#tools/jpackage/share/jdk/jpackage/tests/BasicTest.java                               generic-all
-#tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java                           generic-all
-#tools/jpackage/share/jdk/jpackage/tests/ModulePathTest.java                          generic-all
-#tools/jpackage/share/AdditionalLaunchersTest.java                                    generic-all
-#tools/jpackage/share/AddLauncherModuleTest.java                                      generic-all
-#tools/jpackage/share/AddLaunchersTest.java                                           generic-all
-#tools/jpackage/share/AddLauncherTest.java                                            generic-all
-#tools/jpackage/share/AppImagePackageTest.java                                        generic-all
-#tools/jpackage/share/ArgumentsTest.java                                              generic-all
-#tools/jpackage/share/FileAssociationsTest.java                                       generic-all
-#tools/jpackage/share/IconTest.java                                                   generic-all
-#tools/jpackage/share/InstallDirTest.java#id0                                         generic-all
-#tools/jpackage/share/InstallDirTest.java#id1                                         generic-all
-#tools/jpackage/share/JavaOptionsEqualsTest.java                                      generic-all
-#tools/jpackage/share/JavaOptionsModuleTest.java                                      generic-all
-#tools/jpackage/share/JavaOptionsTest.java                                            generic-all
-#tools/jpackage/share/LicenseTest.java#id0                                            generic-all
-#tools/jpackage/share/LicenseTest.java#id1                                            generic-all
-#tools/jpackage/share/RuntimePackageTest.java                                         generic-all
-#tools/jpackage/share/SimplePackageTest.java                                          generic-all
-
 ###############################################################################
 # Failing new tests, unsupported new features in jdk15
-
-# SapMachine 2020-02-24
-# Several tests fail on linuxs390x and linuxppc64le after JDK-8239450
-# Change caused issues in the multivariant builds (minimal+server)
-# SapMachine 2020-03-02: Temporarily disabled minimal builds on linuxs390x and linuxppc64le
-#com/sun/jdi/cds/CDSFieldWatchpoints.java                                             linux-all
-#com/sun/jdi/cds/CDSBreakpointTest.java                                               linux-all
-#com/sun/jdi/cds/CDSDeleteAllBkptsTest.java                                           linux-all
 
 # SapMachine 2019-02-27
 # Fails in nightly tests since middle of February 2020, cannot be reproduced locally

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,6 @@
  */
 
  /*
- * "Lets Encrypt Authority X1" intermediate CA is retired.
- * Test certs should be chained through "Lets Encrypt Authority X3" CA.
- *
  * Obtain TLS test artifacts for Let's Encrypt CA from:
  *
  * Valid TLS Certificates:
@@ -42,120 +39,121 @@
  * Revoked TLS Certificates:
  * https://revoked-isrgrootx1.letsencrypt.org/
  *
- * Test artifacts don't have CRLs listed.
+ * Test artifacts don't have CRLs listed and intermediate cert doesn't have OCSP.
  */
 public class LetsEncryptCA {
 
-    // Owner: CN=Let's Encrypt Authority X3, O=Let's Encrypt, C=US
-    // Issuer: CN=ISRG Root X1, O=Internet Security Research Group, C=US
-    private static final String INT = "-----BEGIN CERTIFICATE-----\n"
-            + "MIIFjTCCA3WgAwIBAgIRANOxciY0IzLc9AUoUSrsnGowDQYJKoZIhvcNAQELBQAw\n"
-            + "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n"
-            + "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTYxMDA2MTU0MzU1\n"
-            + "WhcNMjExMDA2MTU0MzU1WjBKMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg\n"
-            + "RW5jcnlwdDEjMCEGA1UEAxMaTGV0J3MgRW5jcnlwdCBBdXRob3JpdHkgWDMwggEi\n"
-            + "MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCc0wzwWuUuR7dyXTeDs2hjMOrX\n"
-            + "NSYZJeG9vjXxcJIvt7hLQQWrqZ41CFjssSrEaIcLo+N15Obzp2JxunmBYB/XkZqf\n"
-            + "89B4Z3HIaQ6Vkc/+5pnpYDxIzH7KTXcSJJ1HG1rrueweNwAcnKx7pwXqzkrrvUHl\n"
-            + "Npi5y/1tPJZo3yMqQpAMhnRnyH+lmrhSYRQTP2XpgofL2/oOVvaGifOFP5eGr7Dc\n"
-            + "Gu9rDZUWfcQroGWymQQ2dYBrrErzG5BJeC+ilk8qICUpBMZ0wNAxzY8xOJUWuqgz\n"
-            + "uEPxsR/DMH+ieTETPS02+OP88jNquTkxxa/EjQ0dZBYzqvqEKbbUC8DYfcOTAgMB\n"
-            + "AAGjggFnMIIBYzAOBgNVHQ8BAf8EBAMCAYYwEgYDVR0TAQH/BAgwBgEB/wIBADBU\n"
-            + "BgNVHSAETTBLMAgGBmeBDAECATA/BgsrBgEEAYLfEwEBATAwMC4GCCsGAQUFBwIB\n"
-            + "FiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQub3JnMB0GA1UdDgQWBBSo\n"
-            + "SmpjBH3duubRObemRWXv86jsoTAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vY3Js\n"
-            + "LnJvb3QteDEubGV0c2VuY3J5cHQub3JnMHIGCCsGAQUFBwEBBGYwZDAwBggrBgEF\n"
-            + "BQcwAYYkaHR0cDovL29jc3Aucm9vdC14MS5sZXRzZW5jcnlwdC5vcmcvMDAGCCsG\n"
-            + "AQUFBzAChiRodHRwOi8vY2VydC5yb290LXgxLmxldHNlbmNyeXB0Lm9yZy8wHwYD\n"
-            + "VR0jBBgwFoAUebRZ5nu25eQBc4AIiMgaWPbpm24wDQYJKoZIhvcNAQELBQADggIB\n"
-            + "ABnPdSA0LTqmRf/Q1eaM2jLonG4bQdEnqOJQ8nCqxOeTRrToEKtwT++36gTSlBGx\n"
-            + "A/5dut82jJQ2jxN8RI8L9QFXrWi4xXnA2EqA10yjHiR6H9cj6MFiOnb5In1eWsRM\n"
-            + "UM2v3e9tNsCAgBukPHAg1lQh07rvFKm/Bz9BCjaxorALINUfZ9DD64j2igLIxle2\n"
-            + "DPxW8dI/F2loHMjXZjqG8RkqZUdoxtID5+90FgsGIfkMpqgRS05f4zPbCEHqCXl1\n"
-            + "eO5HyELTgcVlLXXQDgAWnRzut1hFJeczY1tjQQno6f6s+nMydLN26WuU4s3UYvOu\n"
-            + "OsUxRlJu7TSRHqDC3lSE5XggVkzdaPkuKGQbGpny+01/47hfXXNB7HntWNZ6N2Vw\n"
-            + "p7G6OfY+YQrZwIaQmhrIqJZuigsrbe3W+gdn5ykE9+Ky0VgVUsfxo52mwFYs1JKY\n"
-            + "2PGDuWx8M6DlS6qQkvHaRUo0FMd8TsSlbF0/v965qGFKhSDeQoMpYnwcmQilRh/0\n"
-            + "ayLThlHLN81gSkJjVrPI0Y8xCVPB4twb1PFUd2fPM3sA1tJ83sZ5v8vgFv2yofKR\n"
-            + "PB0t6JzUA81mSqM3kxl5e+IZwhYAyO0OTg3/fs8HqGTNKd9BqoUwSRBzp06JMg5b\n"
-            + "rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt\n"
-            + "-----END CERTIFICATE-----";
+     // Owner: CN=R3, O=Let's Encrypt, C=US
+     // Issuer: CN=ISRG Root X1, O=Internet Security Research Group, C=US
+     // Serial number: 912b084acf0c18a753f6d62e25a75f5a
+     // Valid from: Thu Sep 03 17:00:00 PDT 2020 until: Mon Sep 15 09:00:00 PDT 2025
+    private static final String INT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFFjCCAv6gAwIBAgIRAJErCErPDBinU/bWLiWnX1owDQYJKoZIhvcNAQELBQAw\n" +
+            "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n" +
+            "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjAwOTA0MDAwMDAw\n" +
+            "WhcNMjUwOTE1MTYwMDAwWjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg\n" +
+            "RW5jcnlwdDELMAkGA1UEAxMCUjMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\n" +
+            "AoIBAQC7AhUozPaglNMPEuyNVZLD+ILxmaZ6QoinXSaqtSu5xUyxr45r+XXIo9cP\n" +
+            "R5QUVTVXjJ6oojkZ9YI8QqlObvU7wy7bjcCwXPNZOOftz2nwWgsbvsCUJCWH+jdx\n" +
+            "sxPnHKzhm+/b5DtFUkWWqcFTzjTIUu61ru2P3mBw4qVUq7ZtDpelQDRrK9O8Zutm\n" +
+            "NHz6a4uPVymZ+DAXXbpyb/uBxa3Shlg9F8fnCbvxK/eG3MHacV3URuPMrSXBiLxg\n" +
+            "Z3Vms/EY96Jc5lP/Ooi2R6X/ExjqmAl3P51T+c8B5fWmcBcUr2Ok/5mzk53cU6cG\n" +
+            "/kiFHaFpriV1uxPMUgP17VGhi9sVAgMBAAGjggEIMIIBBDAOBgNVHQ8BAf8EBAMC\n" +
+            "AYYwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMBIGA1UdEwEB/wQIMAYB\n" +
+            "Af8CAQAwHQYDVR0OBBYEFBQusxe3WFbLrlAJQOYfr52LFMLGMB8GA1UdIwQYMBaA\n" +
+            "FHm0WeZ7tuXkAXOACIjIGlj26ZtuMDIGCCsGAQUFBwEBBCYwJDAiBggrBgEFBQcw\n" +
+            "AoYWaHR0cDovL3gxLmkubGVuY3Iub3JnLzAnBgNVHR8EIDAeMBygGqAYhhZodHRw\n" +
+            "Oi8veDEuYy5sZW5jci5vcmcvMCIGA1UdIAQbMBkwCAYGZ4EMAQIBMA0GCysGAQQB\n" +
+            "gt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCFyk5HPqP3hUSFvNVneLKYY611TR6W\n" +
+            "PTNlclQtgaDqw+34IL9fzLdwALduO/ZelN7kIJ+m74uyA+eitRY8kc607TkC53wl\n" +
+            "ikfmZW4/RvTZ8M6UK+5UzhK8jCdLuMGYL6KvzXGRSgi3yLgjewQtCPkIVz6D2QQz\n" +
+            "CkcheAmCJ8MqyJu5zlzyZMjAvnnAT45tRAxekrsu94sQ4egdRCnbWSDtY7kh+BIm\n" +
+            "lJNXoB1lBMEKIq4QDUOXoRgffuDghje1WrG9ML+Hbisq/yFOGwXD9RiX8F6sw6W4\n" +
+            "avAuvDszue5L3sz85K+EC4Y/wFVDNvZo4TYXao6Z0f+lQKc0t8DQYzk1OXVu8rp2\n" +
+            "yJMC6alLbBfODALZvYH7n7do1AZls4I9d1P4jnkDrQoxB3UqQ9hVl3LEKQ73xF1O\n" +
+            "yK5GhDDX8oVfGKF5u+decIsH4YaTw7mP3GFxJSqv3+0lUFJoi5Lc5da149p90Ids\n" +
+            "hCExroL1+7mryIkXPeFM5TgO9r0rvZaBFOvV2z0gp35Z0+L4WPlbuEjN/lxPFin+\n" +
+            "HlUjr8gRsI3qfJOQFy/9rKIJR0Y/8Omwt/8oTWgy1mdeHmmjk7j1nYsvC9JSQ6Zv\n" +
+            "MldlTTKB3zhThV1+XWYp6rjd5JW1zbVWEkLNxE7GJThEUG3szgBVGP7pSWTUTsqX\n" +
+            "nLRbwHOoq7hHwg==\n" +
+            "-----END CERTIFICATE-----";
 
     // Owner: CN=valid-isrgrootx1.letsencrypt.org
-    // Issuer: CN=Let's Encrypt Authority X3, O=Let's Encrypt, C=US
-    // Serial number: 36916d6db9151ad4428d458a32eae518671
-    // Valid from: Wed Nov 08 07:00:24 PST 2017 until: Tue Feb 06 07:00:24 PST 2018
-    private static final String VALID = "-----BEGIN CERTIFICATE-----\n"
-            + "MIIFIzCCBAugAwIBAgISA2kW1tuRUa1EKNRYoy6uUYZxMA0GCSqGSIb3DQEBCwUA\n"
-            + "MEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD\n"
-            + "ExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xNzExMDgxNTAwMjRaFw0x\n"
-            + "ODAyMDYxNTAwMjRaMCsxKTAnBgNVBAMTIHZhbGlkLWlzcmdyb290eDEubGV0c2Vu\n"
-            + "Y3J5cHQub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyugIOCxl\n"
-            + "4p0Rrs4aggnzKGYezhMyyvqlBgVBkf3DJV5uHbz/B/CxcoFo2rZzIetJEsb7Qnt1\n"
-            + "U8L2O5BKnBeOsI5eFv6WUAQs96VayQ09+xCV3jSNjVpbmKKp1TNWboF/V+EDFq6f\n"
-            + "fxK9h+b88RhBn4gfe+BorPnVTmZZQHgcZCjMGyzlXt68r45dXmZOuh0855Y7z6Et\n"
-            + "wCHTT8k/7VC0DTIs0+veKv+yblUqwGD0htdOh7POkQGfBeJ432FsCCcLCDjg2Jj2\n"
-            + "oYQNpLao55ZnVJGXfP8dJpHqJvuEQVuNT1TbHTs4x7IMftqGcPuhXKhA5FCVf0Hb\n"
-            + "osbVmZ/b2b/WswIDAQABo4ICIDCCAhwwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQW\n"
-            + "MBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQZ\n"
-            + "Mod3QzNPUL56tDMtELpCiwkQOTAfBgNVHSMEGDAWgBSoSmpjBH3duubRObemRWXv\n"
-            + "86jsoTBvBggrBgEFBQcBAQRjMGEwLgYIKwYBBQUHMAGGImh0dHA6Ly9vY3NwLmlu\n"
-            + "dC14My5sZXRzZW5jcnlwdC5vcmcwLwYIKwYBBQUHMAKGI2h0dHA6Ly9jZXJ0Lmlu\n"
-            + "dC14My5sZXRzZW5jcnlwdC5vcmcvMCsGA1UdEQQkMCKCIHZhbGlkLWlzcmdyb290\n"
-            + "eDEubGV0c2VuY3J5cHQub3JnMIH+BgNVHSAEgfYwgfMwCAYGZ4EMAQIBMIHmBgsr\n"
-            + "BgEEAYLfEwEBATCB1jAmBggrBgEFBQcCARYaaHR0cDovL2Nwcy5sZXRzZW5jcnlw\n"
-            + "dC5vcmcwgasGCCsGAQUFBwICMIGeDIGbVGhpcyBDZXJ0aWZpY2F0ZSBtYXkgb25s\n"
-            + "eSBiZSByZWxpZWQgdXBvbiBieSBSZWx5aW5nIFBhcnRpZXMgYW5kIG9ubHkgaW4g\n"
-            + "YWNjb3JkYW5jZSB3aXRoIHRoZSBDZXJ0aWZpY2F0ZSBQb2xpY3kgZm91bmQgYXQg\n"
-            + "aHR0cHM6Ly9sZXRzZW5jcnlwdC5vcmcvcmVwb3NpdG9yeS8wDQYJKoZIhvcNAQEL\n"
-            + "BQADggEBAFBiwKeCZfIh8a7x0Y5QEqGwejil/BY6MOVuIU9FRIJKmhJGdh6lI6ln\n"
-            + "zlBbMZBAjZ+TqDxU0pvM1AsRDyCqt8GbCAC2xQsGyATLdCjedLQ7U7ORm7pBZdbe\n"
-            + "cT7h9Sblj53o5MKa1yFeS89WGjI4UueUemGxp7EQjat0NeAvbnpU+YmuevNYKX2M\n"
-            + "kK33reMC+rgD+wKet1CXcB/ZYl3fDzVH3SwkT/bKW5bsuwxBuD2noScnKCitRgiv\n"
-            + "Ew7YjwqNOm2naki/xr2sfJirR+lJtZ9KC3H8xWeEHrD8Cf7pnmMYqV59uR+hJwMP\n"
-            + "YsjjDbDFCmNN9FBqDwvXs7g86ttkdC8=\n"
-            + "-----END CERTIFICATE-----";
+    // Issuer: CN=R3, O=Let's Encrypt, C=US
+    // Serial number: 46326744d1c2f3feeca7148ed59353144a6
+    // Valid from: Wed Jun 02 08:00:18 PDT 2021 until: Tue Aug 31 08:00:18 PDT 2021
+    private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFSDCCBDCgAwIBAgISBGMmdE0cLz/uynFI7Vk1MUSmMA0GCSqGSIb3DQEBCwUA\n" +
+            "MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD\n" +
+            "EwJSMzAeFw0yMTA2MDIxNTAwMThaFw0yMTA4MzExNTAwMThaMCsxKTAnBgNVBAMT\n" +
+            "IHZhbGlkLWlzcmdyb290eDEubGV0c2VuY3J5cHQub3JnMIIBIjANBgkqhkiG9w0B\n" +
+            "AQEFAAOCAQ8AMIIBCgKCAQEAmdx7jlaUZ0MgEvqzYWXItAFxVAOmR3KF+79vU195\n" +
+            "O5X54Go1+GU+eyFAeTqr6W1gC/MIrSA9LO4neJUx5AWCYaLq7IE7/YnmXTT6BB0x\n" +
+            "WFN3V1OJg9bAqpcEclQp6fbQS6DjdQvUUaEvVIwPzaen6Hmtw6LuHOYOdLk4fUSm\n" +
+            "zadWiyNlMm0/ts+MLHY5iQd9ypGhJED7KBDQ4d4wvyMYo/MYKOUQ+dTXcIegh7p4\n" +
+            "0OVtbrkdCuGJL+cEw1IUtSNQD+MnvUIu1je7Yb6iZ6Qd3iopNLykHYZb8YemakGX\n" +
+            "SDdC54yi35NU+Y+l23vycbVmRd8vK1sizhjRSE+ufmEqXQIDAQABo4ICXTCCAlkw\n" +
+            "DgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAM\n" +
+            "BgNVHRMBAf8EAjAAMB0GA1UdDgQWBBR300bKVFG2auzS0mO4+E57SN6QLzAfBgNV\n" +
+            "HSMEGDAWgBQULrMXt1hWy65QCUDmH6+dixTCxjBVBggrBgEFBQcBAQRJMEcwIQYI\n" +
+            "KwYBBQUHMAGGFWh0dHA6Ly9yMy5vLmxlbmNyLm9yZzAiBggrBgEFBQcwAoYWaHR0\n" +
+            "cDovL3IzLmkubGVuY3Iub3JnLzArBgNVHREEJDAigiB2YWxpZC1pc3Jncm9vdHgx\n" +
+            "LmxldHNlbmNyeXB0Lm9yZzBMBgNVHSAERTBDMAgGBmeBDAECATA3BgsrBgEEAYLf\n" +
+            "EwEBATAoMCYGCCsGAQUFBwIBFhpodHRwOi8vY3BzLmxldHNlbmNyeXB0Lm9yZzCC\n" +
+            "AQYGCisGAQQB1nkCBAIEgfcEgfQA8gB3APZclC/RdzAiFFQYCDCUVo7jTRMZM7/f\n" +
+            "DC8gC8xO8WTjAAABec10PpUAAAQDAEgwRgIhAPDWvnP5mA0RhPa9oiTlE21Ppcez\n" +
+            "eF1+wU0MeoQcjq/7AiEAsox8kMGpWXq0ZVPweTpw1So/sNOZTsSPyBUdbLwjf+MA\n" +
+            "dwBvU3asMfAxGdiZAKRRFf93FRwR2QLBACkGjbIImjfZEwAAAXnNdD7rAAAEAwBI\n" +
+            "MEYCIQCYBSmmb5P+DZGANyYTPHlEbmqOBkEOblkEHq5Lf+wtkQIhAO2HhwOm3wns\n" +
+            "ZTsXjUCcfQA0lKBI2TKkg9tJKFs3uuKDMA0GCSqGSIb3DQEBCwUAA4IBAQBJJ47x\n" +
+            "ZhKN3QRBYVROpoYDSh0a/JW7zPGRCxK5fnDY9UT8m4gEh3yhDTkycX+vo8TReK6W\n" +
+            "fEYareTSTq71MYgtKDYEARm10DuL7Vdig9Tf5DpjXLHaba+wqPz24lwhiJgoKRRr\n" +
+            "8by3wXPFCGSuQyDo1ZUNrAJVYKO4hPMob1ZE8z9IYW63GvzBjEla/HxoVa9iTkv+\n" +
+            "31rsKzpSbMJpnQ7WcgkUPdpoDo4JElGCyf7VZHNicumipAiCmKu0Q6TRCPOXxlKE\n" +
+            "/BIyDey3rXVw3wzOlxmVF6t/V3vGtbgVvN/feUe/ytyv4vLfRR4udi2XxWt3x1la\n" +
+            "7R3zuWdRQhh21p1H\n" +
+            "-----END CERTIFICATE-----";
 
     // Owner: CN=revoked-isrgrootx1.letsencrypt.org
-    // Issuer: CN=Let's Encrypt Authority X3, O=Let's Encrypt, C=US
-    // Serial number: 3ddd39c0755648d6687a5d8ded37775657e
-    // Valid from: Wed Nov 08 07:00:32 PST 2017 until: Tue Feb 06 07:00:32 PST 2018
-    private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n"
-            + "MIIFJzCCBA+gAwIBAgISA93TnAdVZI1mh6XY3tN3dWV+MA0GCSqGSIb3DQEBCwUA\n"
-            + "MEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD\n"
-            + "ExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xNzExMDgxNTAwMzJaFw0x\n"
-            + "ODAyMDYxNTAwMzJaMC0xKzApBgNVBAMTInJldm9rZWQtaXNyZ3Jvb3R4MS5sZXRz\n"
-            + "ZW5jcnlwdC5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5qlZ0\n"
-            + "jslNLn/1uICdZPwflcvsoA2S2Nk+O7cPNew+KQmSIf+LK9AbaWHCkABKx1GdMtfN\n"
-            + "4Q/nKBtzqZ5jX1V1XbPqPd1eeyJo0rNaDFk/gEUHw/zIYi1AtsxVHztMqOXRcsw+\n"
-            + "6QHRKU2XFVsfSctMv+MKnMTEJZARyhr5ur9bQ4/LmxPMhrlHAst97hiSsXKXeyMK\n"
-            + "DWPHmUDn1vz/1mwLMaeYYmuhuRP5HNwYq+LdYvjMV580i6LHY72TwQCfVgOHfqI0\n"
-            + "larISk2p4q6DmTEEiAzJB3yEYaxDn0kEXbKhL9efDC+eirVFa0ta2OnH87s9L8z9\n"
-            + "fm9JIiSFM9ATQ16/AgMBAAGjggIiMIICHjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0l\n"
-            + "BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYE\n"
-            + "FP64lxiV8KwkkzoNaM7iuwX8UBG/MB8GA1UdIwQYMBaAFKhKamMEfd265tE5t6ZF\n"
-            + "Ze/zqOyhMG8GCCsGAQUFBwEBBGMwYTAuBggrBgEFBQcwAYYiaHR0cDovL29jc3Au\n"
-            + "aW50LXgzLmxldHNlbmNyeXB0Lm9yZzAvBggrBgEFBQcwAoYjaHR0cDovL2NlcnQu\n"
-            + "aW50LXgzLmxldHNlbmNyeXB0Lm9yZy8wLQYDVR0RBCYwJIIicmV2b2tlZC1pc3Jn\n"
-            + "cm9vdHgxLmxldHNlbmNyeXB0Lm9yZzCB/gYDVR0gBIH2MIHzMAgGBmeBDAECATCB\n"
-            + "5gYLKwYBBAGC3xMBAQEwgdYwJgYIKwYBBQUHAgEWGmh0dHA6Ly9jcHMubGV0c2Vu\n"
-            + "Y3J5cHQub3JnMIGrBggrBgEFBQcCAjCBngyBm1RoaXMgQ2VydGlmaWNhdGUgbWF5\n"
-            + "IG9ubHkgYmUgcmVsaWVkIHVwb24gYnkgUmVseWluZyBQYXJ0aWVzIGFuZCBvbmx5\n"
-            + "IGluIGFjY29yZGFuY2Ugd2l0aCB0aGUgQ2VydGlmaWNhdGUgUG9saWN5IGZvdW5k\n"
-            + "IGF0IGh0dHBzOi8vbGV0c2VuY3J5cHQub3JnL3JlcG9zaXRvcnkvMA0GCSqGSIb3\n"
-            + "DQEBCwUAA4IBAQCBiokogdgIZxwuPSr43S4GZ9FwrpZNMHADMEZB8ykuotJBGyr1\n"
-            + "QLWDVeoAJ8OIi1AzjcdwKFQks/MKUJwxJ9hYmm9aM14d5lMKGTyoLSI/Z/Vrpx8w\n"
-            + "0GpktSK0WfPeLBHuSpMdrIMWyziSu/bdZtiOIIvMasFwyRhDgII++CIdsnboWXF+\n"
-            + "DZcwy0Yd6XzirXuwENwaWrkrbZPr/JB0xLFmydqXAnA1VFTudwL87q4CTlEo8EiD\n"
-            + "ucKZ/vAhD+ip3/kQFXg90om+9TdHo8D8GxTC1CLZteJt+nqWFRj0e/7eCXIZuUBE\n"
-            + "aSsFCd5RNTHs6tioN9vYJqLojObgF75MgIAC\n"
-            + "-----END CERTIFICATE-----";
+    // Issuer: CN=R3, O=Let's Encrypt, C=US
+    // Serial number: 3626488cf28e94f1719074128bbb58a7829
+    // Valid from: Thu Apr 08 15:58:32 PDT 2021 until: Wed Jul 07 15:58:32 PDT 2021
+    private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFSjCCBDKgAwIBAgISA2JkiM8o6U8XGQdBKLu1ingpMA0GCSqGSIb3DQEBCwUA\n" +
+            "MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD\n" +
+            "EwJSMzAeFw0yMTA0MDgyMjU4MzJaFw0yMTA3MDcyMjU4MzJaMC0xKzApBgNVBAMT\n" +
+            "InJldm9rZWQtaXNyZ3Jvb3R4MS5sZXRzZW5jcnlwdC5vcmcwggEiMA0GCSqGSIb3\n" +
+            "DQEBAQUAA4IBDwAwggEKAoIBAQC1NecSgcQLX4K94pR0HBaUun8wi++lyNTGkpoY\n" +
+            "4xGB7M/WMnJpR8Y+49sO6QSe7fyU18zMjunT3Z5ahQtQi27dGU+xS7KUJUZl2NSJ\n" +
+            "4MLf717cSbBmDBvZiqmuXmUuy5Ehhabk1jBx1NgsR9uqsJFyILPc9sEAKq6MwT7N\n" +
+            "CnaVW1QhpUB9F5Zlc8cmHuhMsyrxGTM3h6P7QeVpqBT91mBEukvWUb01eifk134v\n" +
+            "Sv1gXblr2bksHd9fiIoQvEUnSK9hXcRilDpOjaF5qkiNsQPpuEZqM56XyfOSeaCr\n" +
+            "1HtEYa5Y+SXZ4G4Jt4AZt44WKoDwika9Iex826rETvAFaiTFAgMBAAGjggJdMIIC\n" +
+            "WTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\n" +
+            "MAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFEwvrwbqSUpGjtFPPpoXpNO77gJuMB8G\n" +
+            "A1UdIwQYMBaAFBQusxe3WFbLrlAJQOYfr52LFMLGMFUGCCsGAQUFBwEBBEkwRzAh\n" +
+            "BggrBgEFBQcwAYYVaHR0cDovL3IzLm8ubGVuY3Iub3JnMCIGCCsGAQUFBzAChhZo\n" +
+            "dHRwOi8vcjMuaS5sZW5jci5vcmcvMC0GA1UdEQQmMCSCInJldm9rZWQtaXNyZ3Jv\n" +
+            "b3R4MS5sZXRzZW5jcnlwdC5vcmcwTAYDVR0gBEUwQzAIBgZngQwBAgEwNwYLKwYB\n" +
+            "BAGC3xMBAQEwKDAmBggrBgEFBQcCARYaaHR0cDovL2Nwcy5sZXRzZW5jcnlwdC5v\n" +
+            "cmcwggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdgBElGUusO7Or8RAB9io/ijA2uaC\n" +
+            "vtjLMbU/0zOWtbaBqAAAAXiz7FLbAAAEAwBHMEUCIA8aoTszzeBJMP0aOhnMVizJ\n" +
+            "mQe6c+OHAjG+dP1y9bD2AiEA0oJOb9ZKys+OE0JP5JT0kjdYH8U3ibJ+k6nHKMOI\n" +
+            "CdgAdgD2XJQv0XcwIhRUGAgwlFaO400TGTO/3wwvIAvMTvFk4wAAAXiz7FLQAAAE\n" +
+            "AwBHMEUCIGTdYSTO0IXQ6HSLwwGw1rlkH+lmg7EFpC+A25lhgtWCAiEAgi/7FtTG\n" +
+            "KWKkWLU7ZP1AqIaaWlyXzRK2myrYKcBE804wDQYJKoZIhvcNAQELBQADggEBAByr\n" +
+            "Q4mfzlT+4OBDI4hFjdrPHeHgePUK0HsmQ7GPNwe3pIxTQYs6fKIv+jb4mzKiggLy\n" +
+            "882L+cYLfafggIpRjcoV9bAR2ceea+7uiyat54w5UZYLAmHgAdd4Y7OAUcrTL8rg\n" +
+            "SAXNECrCGIfh0PwxyoJEgxcJnOoGgD5lVAycspUl3u3itmu9tcjcZA7CD5t2xPTQ\n" +
+            "j/eoqH+5fHGXIvZuZxRVllWRwtLHRNafYiotLAW0P1i0i3wevTqmQ8ABVUuzYmJE\n" +
+            "hjTktcZqbYIZqkDalLcGXJm8FFILQHv/vhXd/G2IbPODYgjTS7e4jCTXg2eIf17Z\n" +
+            "yzs5yR8FPDdK48UWPgU=\n" +
+            "-----END CERTIFICATE-----";
 
     public static void main(String[] args) throws Exception {
 
-        ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
-
         if (args.length >= 1 && "CRL".equalsIgnoreCase(args[0])) {
+            ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
             pathValidator.enableCRLCheck();
 
             // Validate int, EE certs don't have CRLs
@@ -163,19 +161,23 @@ public class LetsEncryptCA {
                     ValidatePathWithParams.Status.GOOD, null, System.out);
 
             return;
-        } else {
-            // OCSP check by default
-            pathValidator.enableOCSPCheck();
         }
 
+        // OCSP check by default
+        // intermediate cert R3 doesn't specify OCSP responder
+        ValidatePathWithParams pathValidator = new ValidatePathWithParams(new String[]{INT});
+        pathValidator.enableOCSPCheck();
+
+        // Perform backdate check as test artifacts expire in July 2021
+        pathValidator.setValidationDate("June 15, 2021");
+
         // Validate valid
-        pathValidator.validate(new String[]{VALID, INT},
+        pathValidator.validate(new String[]{VALID},
                 ValidatePathWithParams.Status.GOOD, null, System.out);
 
         // Validate Revoked
-        pathValidator.validate(new String[]{REVOKED, INT},
+        pathValidator.validate(new String[]{REVOKED},
                 ValidatePathWithParams.Status.REVOKED,
-                "Wed Nov 08 08:00:35 PST 2017", System.out);
-
+                "Thu Apr 08 17:05:26 PDT 2021", System.out);
     }
 }


### PR DESCRIPTION
On the verge of SapMachine 16.0.2, we can clean up some testing.

fixes #876

