### PR TITLE
SapMachine (11) #820: Bring Vitals up to date

### DIFF
--- a/src/hotspot/os/aix/vitals_aix.cpp
+++ b/src/hotspot/os/aix/vitals_aix.cpp
@@ -1,6 +1,7 @@
 /*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +27,17 @@
 #include "precompiled.hpp"
 
 #include "runtime/os.hpp"
-#include "services/stathist_internals.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "vitals/vitals_internals.hpp"
 
-namespace StatisticsHistory {
+namespace sapmachine_vitals {
 
 bool platform_columns_initialize() {
   return true;
 }
 
-void sample_platform_values(record_t* record) {
+void sample_platform_values(Sample* record) {
 }
 
-} // namespace StatisticsHistory
+} // namespace sapmachine_vitals

--- a/src/hotspot/os/bsd/vitals_bsd.cpp
+++ b/src/hotspot/os/bsd/vitals_bsd.cpp
@@ -1,6 +1,7 @@
 /*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +27,17 @@
 #include "precompiled.hpp"
 
 #include "runtime/os.hpp"
-#include "services/stathist_internals.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "vitals/vitals_internals.hpp"
 
-namespace StatisticsHistory {
+namespace sapmachine_vitals {
 
 bool platform_columns_initialize() {
   return true;
 }
 
-void sample_platform_values(record_t* record) {
+void sample_platform_values(Sample* record) {
 }
 
-} // namespace StatisticsHistory
+} // namespace sapmachine_vitals

--- a/src/hotspot/share/classfile/classLoaderData.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.inline.hpp
@@ -28,12 +28,12 @@
 #include "classfile/classLoaderData.hpp"
 #include "classfile/javaClasses.hpp"
 #include "oops/oop.inline.hpp"
-// SapMachine 2019-02-20 : stathist
+// SapMachine 2019-02-20 : vitals
 #include "runtime/globals.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
-// SapMachine 2019-02-20 : stathist
-#include "services/stathist.hpp"
+// SapMachine 2019-02-20 : vitals
+#include "vitals/vitals.hpp"
 
 inline oop ClassLoaderData::class_loader() const {
   assert(!_unloading, "This oop is not available to unloading class loader data");
@@ -82,7 +82,7 @@ void ClassLoaderDataGraph::inc_instance_classes(size_t count) {
   Atomic::add(count, &_num_instance_classes);
   // SapMachine 2019-02-20 : stathist
   if (EnableVitals) {
-    StatisticsHistory::counters::inc_classes_loaded(count);
+    sapmachine_vitals::counters::inc_classes_loaded(count);
   }
 }
 
@@ -91,7 +91,7 @@ void ClassLoaderDataGraph::dec_instance_classes(size_t count) {
   Atomic::sub(count, &_num_instance_classes);
   // SapMachine 2019-02-20 : stathist
   if (EnableVitals) {
-    StatisticsHistory::counters::inc_classes_unloaded(count);
+    sapmachine_vitals::counters::inc_classes_unloaded(count);
   }
 }
 
@@ -99,7 +99,7 @@ void ClassLoaderDataGraph::inc_array_classes(size_t count) {
   Atomic::add(count, &_num_array_classes);
   // SapMachine 2019-02-20 : stathist
   if (EnableVitals) {
-    StatisticsHistory::counters::inc_classes_loaded(count);
+    sapmachine_vitals::counters::inc_classes_loaded(count);
   }
 }
 
@@ -108,7 +108,7 @@ void ClassLoaderDataGraph::dec_array_classes(size_t count) {
   Atomic::sub(count, &_num_array_classes);
   // SapMachine 2019-02-20 : stathist
   if (EnableVitals) {
-    StatisticsHistory::counters::inc_classes_unloaded(count);
+    sapmachine_vitals::counters::inc_classes_unloaded(count);
   }
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -624,16 +624,19 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
           "Enable sampling of vitals: memory, cpu utilization and various " \
           "VM core statistics; display via jcmd \"VM.vitals\".")            \
                                                                             \
-  product(uintx, VitalsSampleInterval, 0,                                   \
-          "Vitals sample rate interval (0=use default sample rate)")        \
+  product(uintx, VitalsSampleInterval, 10,                                  \
+          "Vitals sample rate interval in seconds (default 10)")            \
                                                                             \
-  experimental(bool, VitalsLockFreeSampling, false,                         \
+  diagnostic(bool, VitalsLockFreeSampling, false,                           \
           "When sampling vitals, omit any actions which require locking.")  \
                                                                             \
   product(bool, DumpVitalsAtExit, false,                                    \
           "Dump vitals at VM exit into two files, by default called "       \
           "sapmachine_vitals_<pid>.txt and sapmachine_vitals_<pid>.csv. "   \
           "Use -XX:VitalsFile option to change the file names.")            \
+                                                                            \
+  product(bool, PrintVitalsAtExit, false,                                   \
+          "Prints vitals at VM exit to tty.")                               \
                                                                             \
   product(ccstr, VitalsFile, NULL,                                          \
           "When DumpVitalsAtExit is set, the file name prefix for the "     \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -69,8 +69,6 @@
 #include "runtime/timer.hpp"
 #include "runtime/vmOperations.hpp"
 #include "services/memTracker.hpp"
-// SapMachine 2019-09-01: vitals.
-#include "services/stathist.hpp"
 #include "utilities/dtrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/histogram.hpp"
@@ -90,6 +88,10 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+
+// SapMachine 2019-09-01: vitals.
+#include "runtime/globals.hpp"
+#include "vitals/vitals.hpp"
 
 GrowableArray<Method*>* collected_profiled_methods;
 
@@ -384,7 +386,10 @@ void print_statistics() {
 
   // SapMachine 2019-09-01: vitals.
   if (DumpVitalsAtExit) {
-    StatisticsHistory::dump_reports();
+    sapmachine_vitals::dump_reports();
+  }
+  if (PrintVitalsAtExit) {
+    sapmachine_vitals::print_report(tty);
   }
 
   ThreadsSMRSupport::log_statistics();
@@ -432,7 +437,10 @@ void print_statistics() {
 
   // SapMachine 2019-09-01: vitals.
   if (DumpVitalsAtExit) {
-    StatisticsHistory::dump_reports();
+    sapmachine_vitals::dump_reports();
+  }
+  if (PrintVitalsAtExit) {
+    sapmachine_vitals::print_report(tty);
   }
 
   if (LogTouchedMethods && PrintTouchedMethodsAtExit) {

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -46,12 +46,13 @@
 #include "services/diagnosticFramework.hpp"
 #include "services/heapDumper.hpp"
 #include "services/management.hpp"
-// SapMachine 2019-02-20 : stathist
-#include "services/stathistDCmd.hpp"
 #include "services/writeableFlags.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
+
+// SapMachine 2019-02-20 : vitals
+#include "vitals/vitalsDCmd.hpp"
 
 
 static void loadAgentModule(TRAPS) {
@@ -88,8 +89,8 @@ void DCmdRegistrant::register_dcmds(){
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<RunFinalizationDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<HeapInfoDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<FinalizerInfoDCmd>(full_export, true, false));
-  // SapMachine 2019-02-20 : stathist
-  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<StatisticsHistory::StatHistDCmd>(full_export, true, false));
+  // SapMachine 2019-02-20 : vitals
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<sapmachine_vitals::VitalsDCmd>(full_export, true, false));
 #if INCLUDE_SERVICES
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<HeapDumpDCmd>(DCmd_Source_Internal | DCmd_Source_AttachAPI, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<ClassHistogramDCmd>(full_export, true, false));

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -43,8 +43,6 @@
 #include "runtime/vmOperations.hpp"
 #include "runtime/vm_version.hpp"
 #include "runtime/flags/jvmFlag.hpp"
-// SapMachine 2019-02-20 : stathist
-#include "services/stathist.hpp"
 #include "services/memTracker.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/decoder.hpp"
@@ -56,6 +54,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+
+// SapMachine 2019-02-20 : vitals
+#include "vitals/vitals.hpp"
 
 #ifndef PRODUCT
 #include <signal.h>
@@ -997,10 +998,13 @@ void VMError::report(outputStream* st, bool _verbose) {
        MemTracker::error_report(st);
      }
 
-  // SapMachine 2019-02-20 : stathist
+  // SapMachine 2019-02-20 : vitals
   STEP("Vitals")
      if (_verbose) {
-       StatisticsHistory::print_report(st);
+       sapmachine_vitals::print_info_t info;
+       sapmachine_vitals::default_settings(&info);
+       info.sample_now = true; // About the only place where we do this apart from explicitly setting the "now" parm on jcmd
+       sapmachine_vitals::print_report(st);
      }
 
   STEP("printing system")
@@ -1174,9 +1178,12 @@ void VMError::print_vm_info(outputStream* st) {
 
   MemTracker::error_report(st);
 
-  // SapMachine 2019-02-20 : stathist
+  // SapMachine 2019-02-20 : vitals
   // STEP("Vitals")
-  StatisticsHistory::print_report(st);
+  sapmachine_vitals::print_info_t info;
+  sapmachine_vitals::default_settings(&info);
+  info.sample_now = false;
+  sapmachine_vitals::print_report(st);
 
   // STEP("printing system")
 

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -1,6 +1,7 @@
 /*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +24,15 @@
  *
  */
 
-#ifndef HOTSPOT_SHARE_SERVICES_STATHIST_HPP
-#define HOTSPOT_SHARE_SERVICES_STATHIST_HPP
+#ifndef HOTSPOT_SHARE_VITALS_VITALS_HPP
+#define HOTSPOT_SHARE_VITALS_VITALS_HPP
 
 #include "utilities/globalDefinitions.hpp"
 
 class outputStream;
+class Thread;
 
-namespace StatisticsHistory {
+namespace sapmachine_vitals {
 
   bool initialize();
   void cleanup();
@@ -45,13 +47,13 @@ namespace StatisticsHistory {
 
     size_t scale;
 
-    // max number of samples to print (0 = print all)
-    int max;
+    // if true, sample and print the current values too. If false,
+    // just print the sample tables.
+    bool sample_now;
 
   };
 
-  // text output, youngest-to-oldest ordered, with legend, all records, dynamic scale.
-  const print_info_t* default_settings();
+  void default_settings(print_info_t* out);
 
   // Print report to stream. Leave print_info NULL for default settings.
   void print_report(outputStream* st, const print_info_t* print_info = NULL);
@@ -63,11 +65,6 @@ namespace StatisticsHistory {
   // For printing in thread lists only.
   const Thread* samplerthread();
 
-  // These are counters for the statistics history. Ideally, they would live
-  // inside their thematical homes, e.g. thread.cpp or classLoaderDataGraph.cpp,
-  // however since this is unlikely ever to be brought upstream we keep this separate
-  // to easy maintenance.
-
   namespace counters {
     void inc_classes_loaded(size_t count);
     void inc_classes_unloaded(size_t count);
@@ -76,4 +73,4 @@ namespace StatisticsHistory {
 
 };
 
-#endif /* HOTSPOT_SHARE_SERVICES_STATHIST_HPP */
+#endif /* HOTSPOT_SHARE_VITALS_VITALS_HPP */

--- a/src/hotspot/share/vitals/vitalsDCmd.hpp
+++ b/src/hotspot/share/vitals/vitalsDCmd.hpp
@@ -1,6 +1,7 @@
 /*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +24,24 @@
  *
  */
 
-#ifndef HOTSPOT_SHARE_SERVICES_STATHIST_INTERNALS_HPP
-#define HOTSPOT_SHARE_SERVICES_STATHIST_INTERNALS_HPP
+
+#ifndef HOTSPOT_SHARE_VITALS_VITALSDCMD_HPP
+#define HOTSPOT_SHARE_VITALS_VITALSDCMD_HPP
 
 #include "services/diagnosticCommand.hpp"
 
-namespace StatisticsHistory {
+namespace sapmachine_vitals {
 
-class StatHistDCmd : public DCmdWithParser {
+class VitalsDCmd : public DCmdWithParser {
 protected:
   DCmdArgument<char*> _scale;
   DCmdArgument<bool> _csv;
   DCmdArgument<bool> _no_legend;
   DCmdArgument<bool> _reverse;
   DCmdArgument<bool> _raw;
-  DCmdArgument<jlong> _max;
+  DCmdArgument<bool> _sample_now;
 public:
-  StatHistDCmd(outputStream* output, bool heap);
+  VitalsDCmd(outputStream* output, bool heap);
   static const char* name() {
     return "VM.vitals";
   }
@@ -58,6 +60,7 @@ public:
   virtual void execute(DCmdSource source, TRAPS);
 };
 
-}; // namespace StatisticsHistory
+}; // namespace sapmachine_vitals
 
-#endif /* HOTSPOT_SHARE_SERVICES_STATHIST_INTERNALS_HPP */
+#endif /* HOTSPOT_SHARE_VITALS_VITALSDCMD_HPP */
+

--- a/test/hotspot/gtest/vitals/test_vitals.cpp
+++ b/test/hotspot/gtest/vitals/test_vitals.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/globals.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/ostream.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "unittest.hpp"
+#include "vitals/vitals.hpp"
+
+//#define LOG(s) tty->print_raw(s);
+#define LOG(s)
+
+TEST_VM(vitals, report_with_explicit_default_settings) {
+  char tmp[64*K];
+  stringStream ss(tmp, sizeof(tmp));
+  sapmachine_vitals::print_info_t info;
+  ::memset(&info, 0xBB, sizeof(info));
+  sapmachine_vitals::default_settings(&info);
+  sapmachine_vitals::print_report(&ss, &info);
+  LOG(tmp);
+  if (EnableVitals) {
+    ASSERT_NE(::strstr(tmp, "--jvm--"), (char*)NULL);
+  }
+}
+
+TEST_VM(vitals, report_with_implicit_default_settings) {
+  char tmp[64*K];
+  stringStream ss(tmp, sizeof(tmp));
+  sapmachine_vitals::print_report(&ss, NULL);
+  LOG(tmp);
+  if (EnableVitals) {
+    ASSERT_NE(::strstr(tmp, "--jvm--"), (char*)NULL);
+  }
+}
+
+TEST_VM(vitals, report_with_nownow) {
+  char tmp[64*K];
+  stringStream ss(tmp, sizeof(tmp));
+  sapmachine_vitals::print_info_t info;
+  ::memset(&info, 0xBB, sizeof(info));
+  sapmachine_vitals::default_settings(&info);
+  info.sample_now = true;
+  for (int i = 0; i < 100; i ++) {
+    ss.reset();
+    sapmachine_vitals::print_report(&ss, NULL);
+    if (EnableVitals) {
+      ASSERT_NE(::strstr(tmp, "--jvm--"), (char*)NULL);
+    }
+  }
+}

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -305,11 +305,6 @@ tier1_runtime = \
  -:tier1_runtime_appcds_exclude \
  -runtime/signal
 
-# SapMachine 2019-02-24 : Add tests where SAPMachine has different behavior to tier1,
-#  or which tests downstream-only features.
-tier1_sapmachine = \
-  serviceability/dcmd/vm/StatHistTest.java
-
 hotspot_cds = \
   runtime/SharedArchiveFile/ \
   runtime/CompressedOops/
@@ -337,6 +332,11 @@ tier1_serviceability = \
   -serviceability/sa/ClhsdbScanOops.java \
   -serviceability/sa/TestJmapCore.java \
   -serviceability/sa/TestJmapCoreMetaspace.java
+
+# SapMachine 2019-02-24 : Add tests where SAPMachine has different behavior to tier1,
+#  or which tests downstream-only features.
+tier1_sapmachine = \
+  runtime/Vitals
 
 # SapMachine 2019-02-24 : Add tests where SAPMachine has different behavior to tier1,
 #  or which tests downstream-only features.

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsAtExit.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsAtExit.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestVitalsAtExit
+ * @summary Test verifies that -XX:+PrintVitalsAtExit prints vitals at exit.
+ * @library /test/lib
+ * @run driver TestVitalsAtExit run print
+ */
+
+/*
+ * @test TestVitalsAtExit
+ * @summary Test verifies that -XX:+DumpVitalsAtExit works
+ * @library /test/lib
+ * @run driver TestVitalsAtExit run dump
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+
+public class TestVitalsAtExit {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            try {
+		Thread.sleep(2000);
+            } catch (InterruptedException err) {
+            }
+            return;
+        }
+        if (args[0].equals("print")) {
+            testPrint();
+        } else {
+            testDump();
+        }
+    }
+
+    static void testPrint() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+EnableVitals",
+                "-XX:+PrintVitalsAtExit",
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xmx128m",
+                TestVitalsAtExit.class.getName());
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.stdoutShouldNotBeEmpty();
+        output.shouldContain("--jvm--");
+    }
+
+    static void testDump() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+EnableVitals",
+                "-XX:+DumpVitalsAtExit",
+                "-XX:VitalsFile=abcd",
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xmx128m",
+                TestVitalsAtExit.class.getName());
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.stdoutShouldNotBeEmpty();
+        output.shouldContain("Dumping Vitals to abcd.txt");
+        output.shouldContain("Dumping Vitals csv to abcd.csv");
+        File dump = new File("abcd.txt");
+        Asserts.assertTrue(dump.exists() && dump.isFile(),
+                "Could not find abcd.txt");
+        File dump2 = new File("abcd.csv");
+        Asserts.assertTrue(dump2.exists() && dump2.isFile(),
+                "Could not find abcd.csv");
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdStressTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdStressTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -XX:VitalsSampleInterval=1 VitalsDCmdStressTest
+ */
+
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import org.testng.annotations.Test;
+
+public class VitalsDCmdStressTest {
+
+    final long runtime_secs = 30;
+
+    public void run_once(CommandExecutor executor, boolean silent) {
+        OutputAnalyzer output = executor.execute("VM.vitals now", silent);
+        output.shouldContain("--jvm--");
+        output.shouldContain("--heap--");
+        output.shouldContain("--meta--");
+        output.shouldContain("Now");
+    }
+
+    public void run(CommandExecutor executor) {
+        // Let vitals run a while and bombard it with report requests which include "now" sampling
+        long t1 = System.currentTimeMillis();
+        long t2 = t1 + runtime_secs * 1000;
+        int invocations = 0;
+        while (System.currentTimeMillis() < t2) {
+            run_once(executor, true); // run silent to avoid filling logs with garbage output
+            invocations ++;
+        }
+
+        // One last time run with silent off
+        run_once(executor, false);
+        invocations ++;
+
+        System.out.println("Called " + invocations + " times.");
+    }
+
+    @Test
+    public void jmx() {
+        run(new JMXExecutor());
+        // wait two seconds to collect some samples, then repeat with filled tables
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        run(new JMXExecutor());
+    }
+
+}


### PR DESCRIPTION
Cherry-Pick Vitals update to sapmachine 11

Changes after JDK11 causing this patch not to apply:
- MutexLockerEx -> MutexLocker
- Atomic::add() reversed order of args after 11
- CLDG moved out of classLoaderData.hpp into classLoaderDataGraph.hpp
- the syntax for command line args in globals.hpp changed
- thread.hpp was split into multiple include files
- os::sleep changed

Manually fixed all those. Manually ran Vitals jtreg tests and gtests (Linux).

fixes #820

