### PR TITLE
Vitals: SapMachine11: sleep time too long

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -931,7 +931,7 @@ public:
     record_stack_base_and_size();
     for (;;) {
       take_sample();
-      os::sleep(this, get_sample_interval_ms() * 1000, false);
+      os::sleep(this, get_sample_interval_ms(), false);
       if (_stop) {
         break;
       }


### PR DESCRIPTION
With the integration of the last vitals changes into SapMachine11 (#820, 0aad4b7) an error crept in (SapMachine11 only):

SapMachine/src/hotspot/share/vitals/vitals.cpp

Line 934 in ca09513

 os::sleep(this, get_sample_interval_ms() * 1000, false); 
sleep time is too long. os::sleep() takes ms, not seconds.

Tests: manual tests, Vitals jtreg tests (which obviously need pimping up, but that's for another day)

fixes #896

