### PR TITLE
Remove no longer existing test from :tier1_sapmachine

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -52,7 +52,6 @@ tier1_part3 = \
 tier1_sapmachine = \
     com/sun/jdi/FileSocketTransportTest.java \
     java/net/Socket/ExceptionText.java \
-    jdk/nio/zipfs/TestPosixPerms.java \
     jdk/security/JavaDotSecurity/TestJDKIncludeInExceptions.java \
     sap/java/lang/CreateNewProcessGroupOnSpawnTest.java \
     sun/security/lib/cacerts/VerifyCACerts.java


### PR DESCRIPTION
Remove  no longer existing test from SAP specific testgroup :tier1_sapmachine.

fixes #923

