### PR TITLE
SapMachine #923: Run test jdk/nio/zipfs/TestPosix.java in tier1 for SapMachine 11

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -52,6 +52,7 @@ tier1_part3 = \
 tier1_sapmachine = \
     com/sun/jdi/FileSocketTransportTest.java \
     java/net/Socket/ExceptionText.java \
+    jdk/nio/zipfs/TestPosix.java \
     jdk/security/JavaDotSecurity/TestJDKIncludeInExceptions.java \
     sap/java/lang/CreateNewProcessGroupOnSpawnTest.java \
     sun/security/lib/cacerts/VerifyCACerts.java


### PR DESCRIPTION
The non existing test jdk/nio/zipfs/TestPosixPerms.java was removed with #924. However, there was a reason to run the zipfs Posix testing in tier1 for SapMachine: Posix support is not in OpenJDK 11 mainline and we want to test the feature in tier1 to spot potential issues eary. TestPosixPerms was renamed to TestPosix at some time and TEST.groups was not adapted. So this should be the final fix for #923. 😄

fixes #923
