### PR TITLE
894: Vitals: printing to err file misses "now" value

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1055,7 +1055,7 @@ void VMError::report(outputStream* st, bool _verbose) {
        sapmachine_vitals::print_info_t info;
        sapmachine_vitals::default_settings(&info);
        info.sample_now = true; // About the only place where we do this apart from explicitly setting the "now" parm on jcmd
-       sapmachine_vitals::print_report(st);
+       sapmachine_vitals::print_report(st, &info);
      }
 
   STEP("printing system")
@@ -1240,8 +1240,8 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("Vitals")
   sapmachine_vitals::print_info_t info;
   sapmachine_vitals::default_settings(&info);
-  info.sample_now = false;
-  sapmachine_vitals::print_report(st);
+  info.sample_now = false; // lets play it safe in non-error hs-info printout
+  sapmachine_vitals::print_report(st, &info);
 
   // STEP("printing system")
 


### PR DESCRIPTION
Trivial change. When crashing, we accidentally omitted the "now" values from the vitals, so we would miss a development (e.g. spikes) in the last seconds before the crash.

fixes #894

