### PR TITLE
895: Vitals: In SapMachine, we never shutdown the Vitals on VM exit

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -549,6 +549,11 @@ void before_exit(JavaThread* thread) {
     }
   }
 
+  // SapMachine 2021-09-01: shutdown vitals thread
+  if (EnableVitals) {
+    sapmachine_vitals::cleanup();
+  }
+
   #undef BEFORE_EXIT_NOT_RUN
   #undef BEFORE_EXIT_RUNNING
   #undef BEFORE_EXIT_DONE


### PR DESCRIPTION
Trivial, benign "error", mostly done for parity with SAP JVM.

fixes #895

