### PR TITLE
#895: Vitals: In SapMachine, we never shutdown the Vitals on VM exit (17)

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -557,6 +557,11 @@ void before_exit(JavaThread* thread) {
     }
   }
 
+  // SapMachine 2021-09-01: shutdown vitals thread
+  if (EnableVitals) {
+    sapmachine_vitals::cleanup();
+  }
+
   #undef BEFORE_EXIT_NOT_RUN
   #undef BEFORE_EXIT_RUNNING
   #undef BEFORE_EXIT_DONE


### PR DESCRIPTION
(cherry picked from commit e226ab1cab3f3b786d5bbcca7aa80a7b1397fc54)

Downported to 17

fixes #895 

