### PR TITLE
SapMachine #894: Vitals: printing to err file misses "now" value (17)

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1052,7 +1052,7 @@ void VMError::report(outputStream* st, bool _verbose) {
        sapmachine_vitals::print_info_t info;
        sapmachine_vitals::default_settings(&info);
        info.sample_now = true; // About the only place where we do this apart from explicitly setting the "now" parm on jcmd
-       sapmachine_vitals::print_report(st);
+       sapmachine_vitals::print_report(st, &info);
      }
 
   STEP("printing system")
@@ -1237,8 +1237,8 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("Vitals")
   sapmachine_vitals::print_info_t info;
   sapmachine_vitals::default_settings(&info);
-  info.sample_now = false;
-  sapmachine_vitals::print_report(st);
+  info.sample_now = false; // lets play it safe in non-error hs-info printout
+  sapmachine_vitals::print_report(st, &info);
 
   // STEP("printing system")
 


### PR DESCRIPTION
(cherry picked from commit 034fe69fd5f4c51f3f8e9310c18e2abeed337e66)


fixes #894

