### PR TITLE
950: Print out all flags in hs-err file

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1008,11 +1008,14 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing flags")
 
     if (_verbose) {
+      // SapMachine 2021-09-07:
+      // - print all values, not only default
+      // - comments are unnecessary bloat
       JVMFlag::printFlags(
         st,
-        true, // with comments
+        false, // with comments
         false, // no ranges
-        true); // skip defaults
+        false); // skip defaults
       st->cr();
     }
 


### PR DESCRIPTION
Small change:
- print *all* flags, not just non-default flags, in the hs-err file
- but omit comments, they just bloat the hs-err file

Changes of doing this upstream are slim since Oracle prefers its hs-err file brief and succinct, while we don't care much for size but want to simplify error analysis as much as possible. It's a matter of taste.

fixes #950

