### PR TITLE
950: Print out all flags in hs-err file (11)

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -957,11 +957,14 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing flags")
 
     if (_verbose) {
+      // SapMachine 2021-09-07:
+      // - print all values, not only default
+      // - comments are unnecessary bloat
       JVMFlag::printFlags(
         st,
-        true, // with comments
+        false, // with comments
         false, // no ranges
-        true); // skip defaults
+        false); // skip defaults
       st->cr();
     }
 


### PR DESCRIPTION
(cherry picked from commit 6f0299770c357733d70cb28a73ae36a29d7907d5)

fixes #950 

