### PR TITLE
#963: Vitals: lock creation asserts after JDK-8273915 was merged

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1193,7 +1193,7 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 
 bool initialize() {
 
-  g_vitals_lock = new Mutex(Mutex::leaf, "Vitals Lock", Mutex::_safepoint_check_never);
+  g_vitals_lock = new Mutex(Mutex::nosafepoint, "Vitals Lock", Mutex::_safepoint_check_never);
 
   if (!ColumnList::initialize()) {
     return false;


### PR DESCRIPTION
Oracle runtime groups rewrites Mutex rank checking etc. One of the changes was JDK-8273915 "Create 'nosafepoint' rank". Since then, the Vitals assert when initializing the Vitals lock.

For now, I changed the rank of the lock accordingly. I may have to rethink this further, but I believe this is fine for now.

Tests:
- runtime/Vitals jtreg tests locally
- manually tested that PrintVitalsAtExit works
- ... and that we still get Vitals when we crash.

fixes #963

