### PR TITLE
Add jcmd to jre11

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -126,10 +126,12 @@ ifeq ($(OPENJDK_TARGET_OS), solaris)
   PLATFORM_MODULES += jdk.crypto.ucrypto
 endif
 
+# SapMachine 2021-09-28 : add jcmd to JRE
 JRE_TOOL_MODULES += \
     jdk.jdwp.agent \
     jdk.pack \
     jdk.scripting.nashorn.shell \
+    jdk.jcmd \
     #
 
 ################################################################################


### PR DESCRIPTION
This adds jcmd to the legacy JRE 11.

fixes #960
