### PR TITLE
SapMachine17 - Add globalsignr2ca [jdk] to the list of expiring certificates. 

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -272,6 +272,8 @@ public class VerifyCACerts {
             add("quovadisrootca [jdk]");
             // Valid until: Thu Sep 30 14:01:15 GMT 2021
             add("identrustdstx3 [jdk]");
+             // Valid until Wed Dec 15 09:00:00 CET 2021
+            add("globalsignr2ca [jdk]");
         }
     };
 


### PR DESCRIPTION
Add globalsignr2ca [jdk] to the list of expiring certificates. 

This will silence the test until we remove the certificate (like it was done in OpenJDK head)

fixes #Issue

