### PR TITLE
#975: Vitals: use native lock instead of hotspot Mutex

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -35,7 +35,6 @@
 #include "memory/metaspaceUtils.hpp"
 #include "memory/universe.hpp"
 #include "runtime/os.hpp"
-#include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/thread.hpp"
@@ -47,14 +46,15 @@
 #include "utilities/ostream.hpp"
 #include "vitals/vitals.hpp"
 #include "vitals/vitals_internals.hpp"
+#include "vitals/vitalsLocker.hpp"
 
 #include <locale.h>
 #include <time.h>
 
 
-static Mutex* g_vitals_lock = NULL;
-
 namespace sapmachine_vitals {
+
+static Lock g_vitals_lock("VitalsLock");
 
 namespace counters {
 
@@ -92,6 +92,7 @@ size_t Sample::size_in_bytes() {
   return sizeof(Sample) + sizeof(value_t) * (num_values() - 1); // -1 since Sample::values is size 1 to shut up compilers about zero length arrays
 }
 
+// Note: this is not to be used for regular samples, which live in a preallocated table.
 Sample* Sample::allocate() {
   Sample* s = (Sample*) NEW_C_HEAP_ARRAY(char, size_in_bytes(), mtInternal);
   s->reset();
@@ -652,7 +653,6 @@ public:
   bool is_empty() const { return _head == -1; }
 
   void add_sample(const Sample* sample) {
-    assert_lock_strong(g_vitals_lock);
     // Advance head
     _head ++;
     if (_head == _num_entries) {
@@ -691,7 +691,6 @@ public:
   }
 
   void walk_table_locked(Closure* closure, bool youngest_to_oldest = true) const {
-    assert_lock_strong(g_vitals_lock);
 
     if (_head == -1) {
       return;
@@ -778,6 +777,10 @@ class SampleTables: public CHeapObj<mtInternal> {
 
   int _count;
 
+  // A pre-allocated buffer for printing reports. We preallocate this since
+  // when we want to print the report we may be in no condition to allocate memory.
+  char _temp_buffer[196 * K];
+
   static void print_table(const SampleTable* table, outputStream* st,
                           const ColumnWidths* widths, const print_info_t* pi) {
     if (table->is_empty()) {
@@ -823,7 +826,9 @@ public:
   {}
 
   void add_sample(const Sample* sample) {
-    MutexLocker ml(g_vitals_lock, Mutex::_no_safepoint_check_flag);
+    AutoLock autolock(&g_vitals_lock);
+    // Nothing we do in here blocks: the sample values are already taken,
+    // we only modify existing data structures (no memory is allocated either).
     _short_term_table.add_sample(sample);
     // Feed downsample tables too, but increment first, so the down-sample tables
     // are only fed after an initial sample interval has passed. This prevents
@@ -837,46 +842,62 @@ public:
     }
   }
 
-  void print_all(outputStream* st, const print_info_t* pi, const Sample* sample_now) const {
+  void print_all(outputStream* external_stream, const print_info_t* pi, const Sample* sample_now) {
 
-    MutexLocker ml(g_vitals_lock, Mutex::_no_safepoint_check_flag);
+    // We are paranoid about blocking inside a lock. So we print to a preallocated buffer under
+    // lock protection, and copy ot the outside stream when out of the lock.
+    stringStream sstrm(_temp_buffer, sizeof(_temp_buffer));
 
-    // Pre-calc column widths needed to display all tables and values nicely aligned
-    ColumnWidths widths;
+    { // lock start
+      AutoLock autolock(&g_vitals_lock);
 
-    MeasureColumnWidthsClosure mcwclos(pi, &widths);
-    _short_term_table.walk_table_locked(&mcwclos);
-    _mid_term_table.walk_table_locked(&mcwclos);
-    _long_term_table.walk_table_locked(&mcwclos);
-    if (sample_now != NULL) {
-      widths.update_from_sample(sample_now, NULL, pi);
-    }
+      outputStream* st = &sstrm;
 
-    // Now print
-    if (sample_now != NULL) {
-      st->print_cr("Now:");
+      // Pre-calc column widths needed to display all tables and values nicely aligned
+      ColumnWidths widths;
+
+      MeasureColumnWidthsClosure mcwclos(pi, &widths);
+      _short_term_table.walk_table_locked(&mcwclos);
+      _mid_term_table.walk_table_locked(&mcwclos);
+      _long_term_table.walk_table_locked(&mcwclos);
+      if (sample_now != NULL) {
+        widths.update_from_sample(sample_now, NULL, pi);
+      }
+
+      // Now print
+      if (sample_now != NULL) {
+        st->print_cr("Now:");
+        print_headers(st, &widths, pi);
+        print_one_sample(st, sample_now, NULL, &widths, pi);
+      }
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * short_term_num_samples);
       print_headers(st, &widths, pi);
-      print_one_sample(st, sample_now, NULL, &widths, pi);
+      print_table(&_short_term_table, st, &widths, pi);
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * mid_term_interval_ratio * mid_term_num_samples);
+      print_headers(st, &widths, pi);
+      print_table(&_mid_term_table, st, &widths, pi);
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * long_term_interval_ratio * long_term_num_samples);
+      print_headers(st, &widths, pi);
+      print_table(&_long_term_table, st, &widths, pi);
+      st->cr();
+
+      st->cr();
+
+    } // lock end
+
+    // If this fires, enlarge the buffer size. Since the table sizes are static, output here cannot be endless,
+    // so there must be a number large enough to fit every possible report.
+    external_stream->print_raw(_temp_buffer);
+    if (sstrm.size() >= sizeof(_temp_buffer) - 1) {
+      external_stream->cr();
+      external_stream->print_cr("-- Buffer overflow, truncated (total: " SIZE_FORMAT ").", (size_t)sstrm.count());
     }
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * short_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_short_term_table, st, &widths, pi);
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * mid_term_interval_ratio * mid_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_mid_term_table, st, &widths, pi);
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * long_term_interval_ratio * long_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_long_term_table, st, &widths, pi);
-    st->cr();
-
-    st->cr();
-
   }
 
 };
@@ -1192,8 +1213,6 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 }
 
 bool initialize() {
-
-  g_vitals_lock = new Mutex(Mutex::nosafepoint, "Vitals Lock", Mutex::_safepoint_check_never);
 
   if (!ColumnList::initialize()) {
     return false;

--- a/src/hotspot/share/vitals/vitalsLocker.cpp
+++ b/src/hotspot/share/vitals/vitalsLocker.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+
+#include "precompiled.hpp"
+#include "vitals/vitalsLocker.hpp"
+
+
+namespace sapmachine_vitals {
+
+#ifdef _WIN32
+
+Lock::Lock(const char* name) : _name(name) {
+  ::InitializeCriticalSection(&_lock);
+}
+
+void Lock::lock() {
+  ::EnterCriticalSection(&_lock);
+}
+
+void Lock::unlock() {
+  ::LeaveCriticalSection(&_lock);
+}
+
+#else
+
+Lock::Lock(const char* name) : _name(name), _lock(PTHREAD_MUTEX_INITIALIZER) {}
+
+void Lock::lock() {
+  int rc = ::pthread_mutex_lock(&_lock);
+  assert(rc == 0, "%s: failed to grab lock (%d).", _name, errno);
+}
+
+void Lock::unlock() {
+  int rc = ::pthread_mutex_unlock(&_lock);
+  assert(rc == 0, "%s: failed to release lock (%d).", _name, errno);
+}
+
+#endif
+
+
+}; // namespace sapmachine_vitals

--- a/src/hotspot/share/vitals/vitalsLocker.hpp
+++ b/src/hotspot/share/vitals/vitalsLocker.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, 2021 SAP SE. All rights reserved.
+  *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef HOTSPOT_SHARE_VITALS_VITALSLOCKER_HPP
+#define HOTSPOT_SHARE_VITALS_VITALSLOCKER_HPP
+
+#include "utilities/globalDefinitions.hpp"
+
+namespace sapmachine_vitals {
+
+// SapMachine  2021-10-14: I need a simple critical section. I don't
+// need hotspot mutex error checking here, and I want to be independent of
+// upstream changes to hotspot mutexes.
+
+#ifdef _WIN32
+  #include <windows.h>
+#else
+  #include <pthread.h>
+#endif
+
+class Lock {
+  const char* const _name;
+  WINDOWS_ONLY(CRITICAL_SECTION) NOT_WINDOWS(pthread_mutex_t) _lock;
+public:
+  Lock(const char* name);
+  void lock();
+  void unlock();
+};
+
+class AutoLock {
+  Lock* const _lock;
+public:
+  AutoLock(Lock* lock)
+    : _lock(lock)
+  {
+    _lock->lock();
+  }
+  ~AutoLock() {
+    _lock->unlock();
+  }
+};
+
+};
+
+#endif /* HOTSPOT_SHARE_VITALS_VITALS_HPP */


### PR DESCRIPTION
Hi,
can I have reviews for the following patch. It is supposed to solve current merge problems with jdk18-19 (https://github.com/SAP/SapMachine/pull/974) as well as prevent future problems, since hotspot mutexes will continue to change upstream.

Changes in detail:
- Added a new native lock implementation, super simple, for Posix and Windows.
  - Error handling is minimal: on Windows I use critical sections which have no error conditions, and on Posix I use a posix mutex where all possible error conditions are programming errors, hence the asserts.
- Removed the lock asserts since the new locks can't do this reliably and its not worth the complexity
- When printing the sample tables (which is one of the two lock regions) I got paranoid since the outputStream is unknown and may lock too (ttyLock etc). Therefore I first print to memory, then - outside the lock region - to the real stream. The memory is preallocated when Vitals are enabled, so no allocation happens when printing (which may be e.g. during error reporting).

The patch looks worse than it is due to indentation, use hide whitespace to minimize that.

Tests: 
- gtests & runtime/Vitals jtreg tests for debug, release, 32bit
- manual tests
- hotspot:tier1 is on the way.
- GHAs on the way.

fixes #975

