### PR TITLE
Sapmachine #1058: Vitals: Integrate March 2022 updates (11)

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -241,6 +241,7 @@ public:
 //static Column* g_col_system_memtotal = NULL;
 static Column* g_col_system_memfree = NULL;
 static Column* g_col_system_memavail = NULL;
+static Column* g_col_system_memcommitted = NULL;
 static Column* g_col_system_memcommitted_ratio = NULL;
 static Column* g_col_system_swap = NULL;
 
@@ -297,6 +298,7 @@ bool platform_columns_initialize() {
   } else {
     g_col_system_memfree = new MemorySizeColumn("system", NULL, "free", "Unused memory");
   }
+  g_col_system_memcommitted = new MemorySizeColumn("system", NULL, "comm", "Committed memory");
   g_col_system_memcommitted_ratio = new PlainValueColumn("system", NULL, "crt", "Committed-to-Commit-Limit ratio (percent)");
   g_col_system_swap = new MemorySizeColumn("system", NULL, "swap", "Swap space used");
 
@@ -401,6 +403,7 @@ void sample_platform_values(Sample* sample) {
     value_t commitlimit = bf.parsed_prefixed_value("CommitLimit:", scale);
     value_t committed = bf.parsed_prefixed_value("Committed_AS:", scale);
     if (commitlimit != INVALID_VALUE && commitlimit != 0 && committed != INVALID_VALUE) {
+      set_value_in_sample(g_col_system_memcommitted, sample, committed);
       value_t ratio = (committed * 100) / commitlimit;
       set_value_in_sample(g_col_system_memcommitted_ratio, sample, ratio);
     }

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -398,6 +398,7 @@ void print_statistics() {
     sapmachine_vitals::dump_reports();
   }
   if (PrintVitalsAtExit) {
+    tty->print_cr("Vitals:");
     sapmachine_vitals::print_report(tty);
   }
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1012,7 +1012,8 @@ void VMError::report(outputStream* st, bool _verbose) {
      if (_verbose) {
        sapmachine_vitals::print_info_t info;
        sapmachine_vitals::default_settings(&info);
-       info.sample_now = true; // About the only place where we do this apart from explicitly setting the "now" parm on jcmd
+       info.sample_now = true;
+       st->print_cr("Vitals:");
        sapmachine_vitals::print_report(st, &info);
      }
 
@@ -1202,8 +1203,9 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("Vitals")
   sapmachine_vitals::print_info_t info;
   sapmachine_vitals::default_settings(&info);
-  info.sample_now = false; // lets play it safe in non-error hs-info printout
-  sapmachine_vitals::print_report(st, &info);
+  info.sample_now = false;
+  st->print_cr("Vitals:");
+  sapmachine_vitals::print_report(st);
 
   // STEP("printing system")
 

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -34,7 +34,6 @@
 #include "memory/metaspace.hpp"
 #include "memory/universe.hpp"
 #include "runtime/os.hpp"
-#include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/thread.hpp"
 #include "services/memTracker.hpp"
@@ -45,14 +44,15 @@
 #include "utilities/ostream.hpp"
 #include "vitals/vitals.hpp"
 #include "vitals/vitals_internals.hpp"
+#include "vitals/vitalsLocker.hpp"
 
 #include <locale.h>
 #include <time.h>
 
 
-static Mutex* g_vitals_lock = NULL;
-
 namespace sapmachine_vitals {
+
+static Lock g_vitals_lock("VitalsLock");
 
 namespace counters {
 
@@ -90,6 +90,7 @@ size_t Sample::size_in_bytes() {
   return sizeof(Sample) + sizeof(value_t) * (num_values() - 1); // -1 since Sample::values is size 1 to shut up compilers about zero length arrays
 }
 
+// Note: this is not to be used for regular samples, which live in a preallocated table.
 Sample* Sample::allocate() {
   Sample* s = (Sample*) NEW_C_HEAP_ARRAY(char, size_in_bytes(), mtInternal);
   s->reset();
@@ -650,7 +651,6 @@ public:
   bool is_empty() const { return _head == -1; }
 
   void add_sample(const Sample* sample) {
-    assert_lock_strong(g_vitals_lock);
     // Advance head
     _head ++;
     if (_head == _num_entries) {
@@ -689,7 +689,6 @@ public:
   }
 
   void walk_table_locked(Closure* closure, bool youngest_to_oldest = true) const {
-    assert_lock_strong(g_vitals_lock);
 
     if (_head == -1) {
       return;
@@ -776,6 +775,10 @@ class SampleTables: public CHeapObj<mtInternal> {
 
   int _count;
 
+  // A pre-allocated buffer for printing reports. We preallocate this since
+  // when we want to print the report we may be in no condition to allocate memory.
+  char _temp_buffer[196 * K];
+
   static void print_table(const SampleTable* table, outputStream* st,
                           const ColumnWidths* widths, const print_info_t* pi) {
     if (table->is_empty()) {
@@ -821,7 +824,9 @@ public:
   {}
 
   void add_sample(const Sample* sample) {
-    MutexLockerEx ml(g_vitals_lock, Mutex::_no_safepoint_check_flag);
+    AutoLock autolock(&g_vitals_lock);
+    // Nothing we do in here blocks: the sample values are already taken,
+    // we only modify existing data structures (no memory is allocated either).
     _short_term_table.add_sample(sample);
     // Feed downsample tables too, but increment first, so the down-sample tables
     // are only fed after an initial sample interval has passed. This prevents
@@ -835,46 +840,62 @@ public:
     }
   }
 
-  void print_all(outputStream* st, const print_info_t* pi, const Sample* sample_now) const {
+  void print_all(outputStream* external_stream, const print_info_t* pi, const Sample* sample_now) {
 
-    MutexLockerEx ml(g_vitals_lock, Mutex::_no_safepoint_check_flag);
+    // We are paranoid about blocking inside a lock. So we print to a preallocated buffer under
+    // lock protection, and copy ot the outside stream when out of the lock.
+    stringStream sstrm(_temp_buffer, sizeof(_temp_buffer));
 
-    // Pre-calc column widths needed to display all tables and values nicely aligned
-    ColumnWidths widths;
+    { // lock start
+      AutoLock autolock(&g_vitals_lock);
 
-    MeasureColumnWidthsClosure mcwclos(pi, &widths);
-    _short_term_table.walk_table_locked(&mcwclos);
-    _mid_term_table.walk_table_locked(&mcwclos);
-    _long_term_table.walk_table_locked(&mcwclos);
-    if (sample_now != NULL) {
-      widths.update_from_sample(sample_now, NULL, pi);
-    }
+      outputStream* st = &sstrm;
 
-    // Now print
-    if (sample_now != NULL) {
-      st->print_cr("Now:");
+      // Pre-calc column widths needed to display all tables and values nicely aligned
+      ColumnWidths widths;
+
+      MeasureColumnWidthsClosure mcwclos(pi, &widths);
+      _short_term_table.walk_table_locked(&mcwclos);
+      _mid_term_table.walk_table_locked(&mcwclos);
+      _long_term_table.walk_table_locked(&mcwclos);
+      if (sample_now != NULL) {
+        widths.update_from_sample(sample_now, NULL, pi);
+      }
+
+      // Now print
+      if (sample_now != NULL) {
+        st->print_cr("Now:");
+        print_headers(st, &widths, pi);
+        print_one_sample(st, sample_now, NULL, &widths, pi);
+      }
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * short_term_num_samples);
       print_headers(st, &widths, pi);
-      print_one_sample(st, sample_now, NULL, &widths, pi);
+      print_table(&_short_term_table, st, &widths, pi);
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * mid_term_interval_ratio * mid_term_num_samples);
+      print_headers(st, &widths, pi);
+      print_table(&_mid_term_table, st, &widths, pi);
+      st->cr();
+
+      print_time_span(st, VitalsSampleInterval * long_term_interval_ratio * long_term_num_samples);
+      print_headers(st, &widths, pi);
+      print_table(&_long_term_table, st, &widths, pi);
+      st->cr();
+
+      st->cr();
+
+    } // lock end
+
+    // If this fires, enlarge the buffer size. Since the table sizes are static, output here cannot be endless,
+    // so there must be a number large enough to fit every possible report.
+    external_stream->print_raw(_temp_buffer);
+    if (sstrm.size() >= sizeof(_temp_buffer) - 1) {
+      external_stream->cr();
+      external_stream->print_cr("-- Buffer overflow, truncated (total: " SIZE_FORMAT ").", (size_t)sstrm.count());
     }
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * short_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_short_term_table, st, &widths, pi);
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * mid_term_interval_ratio * mid_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_mid_term_table, st, &widths, pi);
-    st->cr();
-
-    print_time_span(st, VitalsSampleInterval * long_term_interval_ratio * long_term_num_samples);
-    print_headers(st, &widths, pi);
-    print_table(&_long_term_table, st, &widths, pi);
-    st->cr();
-
-    st->cr();
-
   }
 
 };
@@ -1193,8 +1214,6 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 }
 
 bool initialize() {
-
-  g_vitals_lock = new Mutex(Mutex::leaf, "Vitals Lock", true, Mutex::_safepoint_check_never);
 
   if (!ColumnList::initialize()) {
     return false;

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,6 +28,12 @@
 #define HOTSPOT_SHARE_VITALS_VITALS_HPP
 
 #include "utilities/globalDefinitions.hpp"
+
+// Configure for different JDK versions
+//#define JDK_MAINLINE
+//#define JDK18u
+//#define JDK17u
+#define JDK11u
 
 class outputStream;
 class Thread;

--- a/src/hotspot/share/vitals/vitalsDCmd.cpp
+++ b/src/hotspot/share/vitals/vitalsDCmd.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -94,6 +94,7 @@ void VitalsDCmd::execute(DCmdSource source, TRAPS) {
   info.raw = _raw.value();
   info.sample_now = _sample_now.value();
 
+  output()->print_cr("Vitals:");
   sapmachine_vitals::print_report(output(), &info);
 }
 

--- a/src/hotspot/share/vitals/vitalsDCmd.hpp
+++ b/src/hotspot/share/vitals/vitalsDCmd.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/vitals/vitalsLocker.cpp
+++ b/src/hotspot/share/vitals/vitalsLocker.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+
+#include "precompiled.hpp"
+#include "vitals/vitalsLocker.hpp"
+
+
+namespace sapmachine_vitals {
+
+#ifdef _WIN32
+
+Lock::Lock(const char* name) : _name(name) {
+  ::InitializeCriticalSection(&_lock);
+}
+
+void Lock::lock() {
+  ::EnterCriticalSection(&_lock);
+}
+
+void Lock::unlock() {
+  ::LeaveCriticalSection(&_lock);
+}
+
+#else
+
+Lock::Lock(const char* name) : _name(name), _lock(PTHREAD_MUTEX_INITIALIZER) {}
+
+void Lock::lock() {
+  int rc = ::pthread_mutex_lock(&_lock);
+  assert(rc == 0, "%s: failed to grab lock (%d).", _name, errno);
+}
+
+void Lock::unlock() {
+  int rc = ::pthread_mutex_unlock(&_lock);
+  assert(rc == 0, "%s: failed to release lock (%d).", _name, errno);
+}
+
+#endif
+
+
+}; // namespace sapmachine_vitals

--- a/src/hotspot/share/vitals/vitalsLocker.cpp
+++ b/src/hotspot/share/vitals/vitalsLocker.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,10 +24,14 @@
  *
  */
 
-
 #include "precompiled.hpp"
 #include "vitals/vitalsLocker.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/debug.hpp"
 
+#ifndef _WIN32
+#include <errno.h>
+#endif
 
 namespace sapmachine_vitals {
 
@@ -47,7 +51,11 @@ void Lock::unlock() {
 
 #else
 
-Lock::Lock(const char* name) : _name(name), _lock(PTHREAD_MUTEX_INITIALIZER) {}
+// JDK11: cannot use PTHREAD_MUTEX_INITIALIZER in init list
+// "extended initializer lists only available with -std=c++11 or -std=gnu++11"
+Lock::Lock(const char* name) : _name(name) {
+  ::pthread_mutex_init(&_lock, NULL);
+}
 
 void Lock::lock() {
   int rc = ::pthread_mutex_lock(&_lock);

--- a/src/hotspot/share/vitals/vitalsLocker.hpp
+++ b/src/hotspot/share/vitals/vitalsLocker.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, 2021 SAP SE. All rights reserved.
+  *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef HOTSPOT_SHARE_VITALS_VITALSLOCKER_HPP
+#define HOTSPOT_SHARE_VITALS_VITALSLOCKER_HPP
+
+#include "utilities/globalDefinitions.hpp"
+
+namespace sapmachine_vitals {
+
+// SapMachine  2021-10-14: I need a simple critical section. I don't
+// need hotspot mutex error checking here, and I want to be independent of
+// upstream changes to hotspot mutexes.
+
+#ifdef _WIN32
+  #include <windows.h>
+#else
+  #include <pthread.h>
+#endif
+
+class Lock {
+  const char* const _name;
+  WINDOWS_ONLY(CRITICAL_SECTION) NOT_WINDOWS(pthread_mutex_t) _lock;
+public:
+  Lock(const char* name);
+  void lock();
+  void unlock();
+};
+
+class AutoLock {
+  Lock* const _lock;
+public:
+  AutoLock(Lock* lock)
+    : _lock(lock)
+  {
+    _lock->lock();
+  }
+  ~AutoLock() {
+    _lock->unlock();
+  }
+};
+
+};
+
+#endif /* HOTSPOT_SHARE_VITALS_VITALS_HPP */

--- a/src/hotspot/share/vitals/vitals_internals.hpp
+++ b/src/hotspot/share/vitals/vitals_internals.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 SAP SE. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,8 +31,6 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "vitals/vitals.hpp"
-
-
 
 namespace sapmachine_vitals {
 

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsAtExit.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsAtExit.java
@@ -25,37 +25,39 @@
  * @test TestVitalsAtExit
  * @summary Test verifies that -XX:+PrintVitalsAtExit prints vitals at exit.
  * @library /test/lib
- * @run driver TestVitalsAtExit run print
+ * @run driver TestVitalsAtExit print
  */
 
 /*
  * @test TestVitalsAtExit
  * @summary Test verifies that -XX:+DumpVitalsAtExit works
  * @library /test/lib
- * @run driver TestVitalsAtExit run dump
+ * @run driver TestVitalsAtExit dump
  */
 
 import jdk.test.lib.Asserts;
-import jdk.test.lib.Platform;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 
 public class TestVitalsAtExit {
 
+
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
             try {
-		Thread.sleep(2000);
+                Thread.sleep(5000); // we start with interval=1, so give us some secs to gather samples
             } catch (InterruptedException err) {
             }
             return;
         }
         if (args[0].equals("print")) {
             testPrint();
-        } else {
+        } else if (args[0].equals("dump")) {
             testDump();
+        } else {
+            throw new RuntimeException("invalid argument " + args[0]);
         }
     }
 
@@ -63,13 +65,15 @@ public class TestVitalsAtExit {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:+EnableVitals",
                 "-XX:+PrintVitalsAtExit",
+                "-XX:VitalsSampleInterval=1",
                 "-XX:MaxMetaspaceSize=16m",
                 "-Xmx128m",
                 TestVitalsAtExit.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         output.stdoutShouldNotBeEmpty();
-        output.shouldContain("--jvm--");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
     }
 
     static void testDump() throws Exception {
@@ -77,20 +81,25 @@ public class TestVitalsAtExit {
                 "-XX:+EnableVitals",
                 "-XX:+DumpVitalsAtExit",
                 "-XX:VitalsFile=abcd",
+                "-XX:VitalsSampleInterval=1",
                 "-XX:MaxMetaspaceSize=16m",
                 "-Xmx128m",
                 TestVitalsAtExit.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         output.stdoutShouldNotBeEmpty();
         output.shouldContain("Dumping Vitals to abcd.txt");
         output.shouldContain("Dumping Vitals csv to abcd.csv");
-        File dump = new File("abcd.txt");
-        Asserts.assertTrue(dump.exists() && dump.isFile(),
+        File text_dump = new File("abcd.txt");
+        Asserts.assertTrue(text_dump.exists() && text_dump.isFile(),
                 "Could not find abcd.txt");
-        File dump2 = new File("abcd.csv");
-        Asserts.assertTrue(dump2.exists() && dump2.isFile(),
+        File csv_dump = new File("abcd.csv");
+        Asserts.assertTrue(csv_dump.exists() && csv_dump.isFile(),
                 "Could not find abcd.csv");
+
+        VitalsTestHelper.fileMatchesVitalsTextMode(text_dump);
+        VitalsTestHelper.fileMatchesVitalsCSVMode(csv_dump);
     }
 
 }

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsinHSerr.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsinHSerr.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that Vitals report appears in hs-err file
+ * @library /test/lib
+ * @requires vm.debug
+ * @author Thomas Stuefe (SAP)
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver TestVitalsinHSerr
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+
+// Test that, when we crash, we have Vitals as expected in the hs-err file
+public class TestVitalsinHSerr {
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-Xmx100M",
+                "-XX:-CreateCoredumpOnCrash",
+                "-XX:ErrorHandlerTest=14", // sigsegv
+                "-XX:+ErrorFileToStdout",
+                "-version");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
+
+        output.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+        // We want to see the Now value too. Dumping crash reports is about the only place we want
+        // the sample exactly when we report.
+        output.shouldContain("Now");        // hs-err file (in this case, dumped to stdout) should contain vitals
+
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdStressTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdStressTest.java
@@ -43,9 +43,7 @@ public class VitalsDCmdStressTest {
 
     public void run_once(CommandExecutor executor, boolean silent) {
         OutputAnalyzer output = executor.execute("VM.vitals now", silent);
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
         output.shouldContain("Now");
     }
 

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
@@ -32,84 +32,58 @@
  * @run testng/othervm -XX:VitalsSampleInterval=1 VitalsDCmdTest
  */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
+import org.testng.annotations.Test;
 
 public class VitalsDCmdTest {
 
     public void run(CommandExecutor executor) {
 
         OutputAnalyzer output = executor.execute("VM.vitals");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+        output.shouldMatch("\\d+[gkm]"); // we print by default in "dynamic" scale which should show some values as k or m or g
         output.shouldNotContain("Now"); // off by default
 
         output = executor.execute("VM.vitals reverse");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldNotContain("Now"); // off by default
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
 
         output = executor.execute("VM.vitals scale=m");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldNotContain("Now"); // off by default
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
 
         output = executor.execute("VM.vitals scale=1");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldNotContain("Now"); // off by default
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
 
         output = executor.execute("VM.vitals raw");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldNotContain("Now"); // off by default
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
 
         output = executor.execute("VM.vitals now");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldContain("Now");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
 
         output = executor.execute("VM.vitals reverse now");
-        output.shouldContain("--jvm--");
-        output.shouldContain("--heap--");
-        output.shouldContain("--meta--");
-        output.shouldContain("Now");
+        VitalsTestHelper.outputMatchesVitalsTextMode(output);
 
         output = executor.execute("VM.vitals csv");
-        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
-
-        output = executor.execute("VM.vitals csv now");
-        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
-        output.shouldContain("Now");
+        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+        output.shouldNotContain("Now"); // off always in csv mode
 
         output = executor.execute("VM.vitals csv reverse");
-        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
+        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
 
         output = executor.execute("VM.vitals csv reverse raw");
-        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
+        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
 
         output = executor.execute("VM.vitals csv now reverse raw");
-        output.shouldContain("jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used");
-        output.shouldContain("Now");
-
+        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
     }
 
     @Test
     public void jmx() {
-        run(new JMXExecutor());
-        // wait two seconds to collect some samples, then repeat with filled tables
         try {
-            Thread.sleep(2000);
+            Thread.sleep(3000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -1,0 +1,117 @@
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+
+public class VitalsTestHelper {
+
+
+    // Example output:
+    // Last 60 minutes:
+    //                      ---------------------------system--------------------------- ------------------------process------------------------ --------------------------------------jvm---------------------------------------
+    //                                                                -------cpu--------       -------rss--------          -cpu- ----io-----     --heap--- ----------meta----------           ----jthr----- --cldg-- ----cls-----
+    //                      avail comm  crt swap si so p   t    pr pb us sy id  wa st gu virt  all  anon file shm swdo hp  us sy of rd   wr  thr comm used comm used csc  csu  gctr code mlc  num nd cr st  num anon num  ld  uld
+    //2022-03-10 07:41:27   55,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0 100  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k  0k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
+    //2022-03-10 07:41:17   55,0g 11,5g  34   0k  0  0 538 1267  1  0  1  0  99  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k 21k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
+    //2022-03-10 07:41:07   55,0g 11,5g  34   0k  0  0 538 1268  1  0  3  0  96  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  3  0  4 128k  8k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  1 37m  27   24 1286   0   0
+    //2022-03-10 07:40:57   56,9g 11,6g  34   0k  0  0 539 1279  4  0  2  0  98  0  0  0 21,2g 1,7g 1,7g  36m  0k   0k 92k  2  0  3 131k <1k  38 1,0g 530m   3m   2m 320k 222k  21m   8m 604m  12  1  1 37m  27   24 1286   0   0
+    //2022-03-10 07:40:47   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
+    //2022-03-10 07:40:37   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
+    //2022-03-10 07:40:27   58,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0  99  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 998k <1k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  5 36m  27   24 1286 842   0
+    //2022-03-10 07:40:17   58,5g 11,5g  34   0k       537 1254  4  0                    18,9g  95m  65m  31m  0k   0k 92k        2           18 1,0g  10m 128k  55k  64k   2k  21m   7m  42m   9  1    16m   3    0  444
+
+    // Note: all platforms should have the --jvm-- section. Some platforms have more. Above printout is from linux.
+    // For now, we just test for the stuff which is in all platforms.
+    public static final String jvm_header_line1_textmode = ".*heap.*meta.*";
+    public static final String jvm_header_line2_textmode = ".*comm.*used.*comm.*used.*";
+
+    public static final String jvm_header_line_csvmode = ".*jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used.*";
+
+    public static final String timestamp_regex = "\\d{4}+-\\d{2}+-\\d{2}.*\\d{2}:\\d{2}:\\d{2}";
+
+    // sample line: a timestamp, followed by some numbers
+    public static final String sample_line_regex_minimal_textmode = timestamp_regex + ".*\\d+.*\\d+.*\\d+.*\\d+.*";
+    public static final String sample_line_regex_minimal_csvmode = "\"" + timestamp_regex + "\".*\"\\d+\".*";
+
+    private static void printLinesWithLineNo(String[] lines) {
+        int lineno = 0;
+        for (String s : lines) {
+            System.err.println(lineno + ": " + s);
+            lineno++;
+        }
+    }
+
+    static final boolean alwaysPrint = true;
+
+    private static boolean findMatchesInStrings(String[] lines, String[] regexes) {
+        boolean success = false;
+        Pattern[] pat = new Pattern[regexes.length];
+        for (int i = 0; i < regexes.length; i ++) {
+            pat[i] = Pattern.compile(regexes[i]);
+        }
+        int numMatches = 0;
+        int lineNo = 0;
+        while (lineNo < lines.length && numMatches < pat.length) {
+            if (pat[numMatches].matcher(lines[lineNo]).matches()) {
+                numMatches ++;
+            }
+            lineNo ++;
+        }
+        success = (numMatches == pat.length);
+        if (!success) {
+            System.err.println("Matched " + numMatches + "/" + pat.length + " pattern. First unmatched: " + pat[numMatches]);
+        } else {
+            System.err.println("Matched " + numMatches + "/" + pat.length + " pattern. OK!");
+        }
+        if (!success || alwaysPrint) {
+            System.err.println("Lines: ");
+            printLinesWithLineNo(lines);
+            System.err.println("Pattern: ");
+            printLinesWithLineNo(regexes);
+        }
+        return success;
+    }
+
+    static final String[] expected_output_textmode = new String[] {
+            jvm_header_line1_textmode, jvm_header_line2_textmode, sample_line_regex_minimal_textmode
+    };
+
+    static final String[] expected_output_csvmode = new String[] {
+            jvm_header_line_csvmode, sample_line_regex_minimal_csvmode
+    };
+
+    static void fileShouldMatch(File f, String[] expected) throws IOException {
+        Path path = Paths.get(f.getAbsolutePath());
+        String[] lines = Files.readAllLines(path).toArray(new String[0]);
+        if (!findMatchesInStrings(lines, expected)) {
+            throw new RuntimeException("Expected output not found (see error output)");
+        }
+    }
+
+    public static void fileMatchesVitalsTextMode(File f) throws IOException {
+        fileShouldMatch(f, expected_output_textmode);
+    }
+
+    public static void fileMatchesVitalsCSVMode(File f) throws IOException {
+        fileShouldMatch(f, expected_output_csvmode);
+    }
+
+    public static void outputMatchesVitalsTextMode(OutputAnalyzer output) {
+        String[] lines = output.asLines().toArray(new String[0]);
+        if (!findMatchesInStrings(lines, expected_output_textmode)) {
+            throw new RuntimeException("Expected output not found (see error output)");
+        }
+    }
+
+    public static void outputMatchesVitalsCSVMode(OutputAnalyzer output) {
+        String[] lines = output.asLines().toArray(new String[0]);
+        if (!findMatchesInStrings(lines, expected_output_csvmode)) {
+            throw new RuntimeException("Expected output not found (see error output)");
+        }
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/SAP/SapMachine/issues/1058 to SapMachine 11.

Mostly unexciting, but I needed to integrate https://github.com/SAP/SapMachine/issues/975 first, which I had not done for 17 and 11. For simplicity, I kept these two in this one PR.

I needed to change the initialization of the pthread-mutex-based Locker class (vitalsLocker.cpp), since in jdk11 we don't support std++11 and therefore cannot use PTHREAD_MUTEX_LIST in member initializer lists (its a compound type at least on glibc).

fixes #1058 

