### PR TITLE
SapMachine 17 #1077: Cherry-Pick JDK-8283347

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1092,11 +1092,11 @@ static jobject sAccessibilityClass = NULL;
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     DECLARE_CLASS_RETURN(jc_Container, "java/awt/Container", nil);
     DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
                                  "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     // Make it into java screen coords
     point.y = [[[[self view] window] screen] frame].size.height - point.y;
 


### PR DESCRIPTION
[JDK-8283347](https://bugs.openjdk.java.net/browse/JDK-8283347) _[macos] Bad JNI lookup accessibilityHitTest is shown when Screen magnifier is enabled_

should be cherry-picked to SapMachine 17.0.3.

fixes #1077
