### PR TITLE
SapMachine (18) #1079: Use SapMachine as Boot JDK in GHA

### DIFF
--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -25,19 +25,19 @@
 
 # Versions and download locations for dependencies used by pre-submit testing.
 
-BOOT_JDK_VERSION=17
+BOOT_JDK_VERSION=18
 JTREG_VERSION=6.1
 JTREG_BUILD=1
 GTEST_VERSION=1.8.1
 
-LINUX_X64_BOOT_JDK_FILENAME=openjdk-17.0.1_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=1c0a73cbb863aad579b967316bf17673b8f98a9bb938602a140ba2e5c38f880a
+LINUX_X64_BOOT_JDK_FILENAME=sapmachine-18_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-18/sapmachine-jdk-18_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=65082c74154b7633007cf7573d26ea07820b38f84114720c896373b0a200a765
 
-WINDOWS_X64_BOOT_JDK_FILENAME=openjdk-17.0.1_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=329900a6673b237b502bdcf77bc334da34bc91355c5fd2d457fc00f53fd71ef1
+WINDOWS_X64_BOOT_JDK_FILENAME=sapmachine-18_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-18/sapmachine-jdk-18_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=769ae659cacdb227027078dac8e5c827064f895489f1c98377269e403eb662f5
 
-MACOS_X64_BOOT_JDK_FILENAME=openjdk-17.0.1_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=6ccb35800e723cabe15af60e67099d1a07c111d2d3208aa75523614dde68bee1
+MACOS_X64_BOOT_JDK_FILENAME=sapmachine-18_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-18/sapmachine-jdk-18_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=930e6ab1d4452a16ef73aa519f4a47c1c06a5d21a1233a1e68e2459fb0a5d8cd


### PR DESCRIPTION
fixes #1079
