### PR TITLE
#1085: Vitals: glibc: add C-Heap information

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -33,6 +33,7 @@
 #include "utilities/ostream.hpp"
 #include "vitals/vitals_internals.hpp"
 
+#include <malloc.h>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -269,6 +270,9 @@ static Column* g_col_process_rssfile = NULL;
 static Column* g_col_process_rssshmem = NULL;
 static Column* g_col_process_swapped_out = NULL;
 static Column* g_col_process_heap = NULL;
+static Column* g_col_process_chp_used = NULL;
+static Column* g_col_process_chp_free = NULL;
+static Column* g_col_process_chp_trimcap = NULL;
 
 static Column* g_col_process_cpu_user = NULL;
 static Column* g_col_process_cpu_system = NULL;
@@ -278,6 +282,29 @@ static Column* g_col_process_io_bytes_read = NULL;
 static Column* g_col_process_io_bytes_written = NULL;
 
 static Column* g_col_process_num_threads = NULL;
+
+
+// Try to obtain mallinfo2. That replacement of mallinf is 64-bit capable and its values won't wrap.
+// Only exists in glibc 2.33 and later.
+#ifdef __GLIBC__
+struct glibc_mallinfo2 {
+  size_t arena;
+  size_t ordblks;
+  size_t smblks;
+  size_t hblks;
+  size_t hblkhd;
+  size_t usmblks;
+  size_t fsmblks;
+  size_t uordblks;
+  size_t fordblks;
+  size_t keepcost;
+};
+typedef struct glibc_mallinfo2 (*mallinfo2_func_t)(void);
+static mallinfo2_func_t g_mallinfo2 = NULL;
+static void mallinfo2_init() {
+  g_mallinfo2 = CAST_TO_FN_PTR(mallinfo2_func_t, dlsym(RTLD_DEFAULT, "mallinfo2"));
+}
+#endif // __GLIBC__
 
 bool platform_columns_initialize() {
 
@@ -342,8 +369,20 @@ bool platform_columns_initialize() {
 
   // If we manage to locate the heap segment once, and calc its size, we assume it can be done always.
   if (get_process_heap_size() != INVALID_VALUE) {
-    g_col_process_heap = new MemorySizeColumn("process", NULL, "hp", "Process heap segment (brk), resident + swap");
+    // Note: this is useful for the case when MALLOC_ARENA_MAX is 1, because then the glibc uses this segment for its
+    // one and only arena. Note however that if the brk segment cannot grow, glibc heap will switch to a new arena
+    g_col_process_heap = new MemorySizeColumn("process", NULL, "brk", "Process heap segment size (brk), resident + swap");
   }
+
+#ifdef __GLIBC__
+  mallinfo2_init();
+  g_col_process_chp_used = new MemorySizeColumn("process", "cheap", "usd",
+      g_mallinfo2 != NULL ? "C-Heap, in-use allocations" :
+                            "C-Heap, in-use allocations (unavailable if RSS > 4G)");
+  g_col_process_chp_free = new MemorySizeColumn("process", "cheap", "fr",
+      g_mallinfo2 != NULL ? "C-Heap, bytes in free blocks" :
+                            "C-Heap, bytes in free blocks (unavailable if RSS > 4G)");
+#endif // __GLIBC__
 
   g_col_process_cpu_user = new CPUTimeColumn("process", "cpu", "us", "Process cpu user time");
 
@@ -381,6 +420,8 @@ void sample_platform_values(Sample* sample) {
 
   int idx = 0;
   value_t v = 0;
+
+  size_t rss_all = 0;
 
   ProcFile bf;
   if (bf.read("/proc/meminfo")) {
@@ -438,7 +479,8 @@ void sample_platform_values(Sample* sample) {
 
     set_value_in_sample(g_col_process_virt, sample, bf.parsed_prefixed_value("VmSize:", K));
     set_value_in_sample(g_col_process_swapped_out, sample, bf.parsed_prefixed_value("VmSwap:", K));
-    set_value_in_sample(g_col_process_rss, sample, bf.parsed_prefixed_value("VmRSS:", K));
+    rss_all = bf.parsed_prefixed_value("VmRSS:", K);
+    set_value_in_sample(g_col_process_rss, sample, rss_all);
 
     set_value_in_sample(g_col_process_rssanon, sample, bf.parsed_prefixed_value("RssAnon:", K));
     set_value_in_sample(g_col_process_rssfile, sample, bf.parsed_prefixed_value("RssFile:", K));
@@ -524,6 +566,25 @@ void sample_platform_values(Sample* sample) {
     set_value_in_sample(g_col_process_cpu_system, sample, cpu_stime);
   }
 
-}
+#ifdef __GLIBC__
+  // Collect some c-heap info using either one of mallinfo or mallinfo2.
+  if (g_mallinfo2 != NULL) {
+    struct glibc_mallinfo2 mi = g_mallinfo2();
+    set_value_in_sample(g_col_process_chp_used, sample, mi.uordblks);
+    set_value_in_sample(g_col_process_chp_free, sample, mi.fordblks);
+  } else {
+    // Omit printing values if we could conceivably have wrapped, since they are misleading.
+    if (rss_all < 4 * G) {
+      struct mallinfo mi = mallinfo();
+      set_value_in_sample(g_col_process_chp_used, sample, (size_t)(unsigned)mi.uordblks);
+      set_value_in_sample(g_col_process_chp_free, sample, (size_t)(unsigned)mi.fordblks);
+    } else {
+      set_value_in_sample(g_col_process_chp_used, sample, INVALID_VALUE);
+      set_value_in_sample(g_col_process_chp_free, sample, INVALID_VALUE);
+    }
+  }
+#endif // __GLIBC__
+
+} // end: sample_platform_values
 
 } // namespace sapmachine_vitals

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -270,9 +270,10 @@ static Column* g_col_process_rssfile = NULL;
 static Column* g_col_process_rssshmem = NULL;
 static Column* g_col_process_swapped_out = NULL;
 static Column* g_col_process_heap = NULL;
+#ifdef __GLIBC__
 static Column* g_col_process_chp_used = NULL;
 static Column* g_col_process_chp_free = NULL;
-static Column* g_col_process_chp_trimcap = NULL;
+#endif // __GLIBC__
 
 static Column* g_col_process_cpu_user = NULL;
 static Column* g_col_process_cpu_system = NULL;
@@ -377,11 +378,11 @@ bool platform_columns_initialize() {
 #ifdef __GLIBC__
   mallinfo2_init();
   g_col_process_chp_used = new MemorySizeColumn("process", "cheap", "usd",
-      g_mallinfo2 != NULL ? "C-Heap, in-use allocations" :
-                            "C-Heap, in-use allocations (unavailable if RSS > 4G)");
+      g_mallinfo2 != NULL ? "C-Heap, in-use allocations (glibc only)" :
+                            "C-Heap, in-use allocations (glibc only) (unavailable if RSS > 4G)");
   g_col_process_chp_free = new MemorySizeColumn("process", "cheap", "fr",
-      g_mallinfo2 != NULL ? "C-Heap, bytes in free blocks" :
-                            "C-Heap, bytes in free blocks (unavailable if RSS > 4G)");
+      g_mallinfo2 != NULL ? "C-Heap, bytes in free blocks (glibc only)" :
+                            "C-Heap, bytes in free blocks (glibc only) (unavailable if RSS > 4G)");
 #endif // __GLIBC__
 
   g_col_process_cpu_user = new CPUTimeColumn("process", "cpu", "us", "Process cpu user time");


### PR DESCRIPTION
This adds C-heap usage information from mallinfo2(), or - if that is not available (older glibc) - mallinfo().

Example output:

```
-----------process------------
...
       cheap-usd: C-Heap, in-use allocations
        cheap-fr: C-Heap, bytes in free blocks

Last 60 minutes:
                      -------------------------system------------------------- ----------------------------process----------------------------- --------------------------------------jvm---------------------------------------
                                                            -------cpu--------       -------rss--------          -cheap-- -cpu- ----io-----     --heap--- ----------meta----------           ----jthr----- --cldg-- ----cls-----
                      avail comm  crt swap si so p t  pr pb us sy id  wa st gu virt  all  anon file shm swdo brk usd  fr  us sy of rd   wr  thr comm used comm used csc  csu  gctr code mlc  num nd cr st  num anon num  ld  uld
2022-04-26 10:25:18   44.4g 23.5g  70   0k  0  0 2 40  2  0  3  0  96  0  0  0 27.2g 7.5g 7.5g  36m  0k   0k 96k 7.0g 10m  2  0  4  25k 10k  39 1.0g 531m   3m   3m 320k 233k  21m      3.5g  13  2  0 38m  35   32 1347   0   0
2022-04-26 10:25:08   46.3g 23.6g  70   0k  0  0 2 40  2  0  3  0  97  0  0  0 25.2g 5.6g 5.6g  36m  0k   0k 96k 5.0g 10m  2  0  4  25k  5k  39 1.0g 531m   3m   3m 320k 233k  21m      2.5g  13  2  0 38m  35   32 1347   0   0
2022-04-26 10:24:58   48.3g 23.6g  70   0k  0  0 2 40  1  0  1  0  99  0  0  0 23.3g 3.6g 3.6g  36m  0k   0k 96k 3.0g  9m  0  0  4  25k  5k  39 1.0g 531m   3m   3m 320k 233k  21m      1.5g  13  2  1 38m  35   32 1347   0   0
2022-04-26 10:24:48   48.3g 23.9g  71   0k  0  0 2 39  2  0  1  0  99  0  0  0 23.3g 3.6g 3.6g  36m  0k   0k 96k 3.0g  9m  0  0  3  25k  0k  38 1.0g 530m   3m   3m 320k 233k  21m      1.5g  12  2  0 37m  35   32 1347   0   0
2022-04-26 10:24:38   48.2g 23.7g  70   0k  0  0 2 39  2  0  0  0 100  0  0  0 23.3g 3.6g 3.6g  36m  0k   0k 96k 3.0g  9m  0  0  3  25k  0k  38 1.0g 530m   3m   3m 320k 233k  21m      1.5g  12  2  0 37m  35   32 1347   0   0
2022-04-26 10:24:28   48.2g 23.8g  71   0k  0  0 2 39  1  0  0  0  99  0  0  0 23.3g 3.6g 3.6g  36m  0k   0k 96k 3.0g  9m  0  0  3  25k  0k  38 1.0g 530m   3m   3m 320k 233k  21m      1.5g  12  2  0 37m  35   32 1347   0   0
2022-04-26 10:24:18   48.2g 23.6g  70   0k  0  0 2 39  2  0  2  0  97  0  0  0 23.3g 3.6g 3.6g  36m  0k   0k 96k 3.0g  9m  2  0  3  25k <1k  38 1.0g 530m   3m   3m 320k 233k  21m      1.5g  12  2  0 37m  35   32 1347   0   0
2022-04-26 10:24:08   49.9g 23.3g  69   0k  0  0 2 41  2  0  2  0  97  0  0  0 21.6g 2.0g 2.0g  36m  0k   0k 96k 1.4g  8m  2  0  3 991k <1k  40 1.0g 530m   3m   3m 320k 233k  21m      742m  14  2  7 39m  35   32 1347 888   0
2022-04-26 10:23:58   51.8g 23.3g  69   0k       2 20  3  0                    18.9g  94m  65m  30m  0k   0k 96k  42m  2m        2           18 1.0g  10m 128k  52k  64k  <1k  21m       42m   9  1    16m   3    0  459

```
fixes #1085 

