### PR TITLE
#1095: runtime/malloctrace/MallocTraceDcmdTest.java fails on Alpine

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4652,6 +4652,10 @@ jint os::init_2(void) {
   if (EnableMallocTrace) {
     sap::MallocTracer::enable();
   }
+#else
+  if (!FLAG_IS_DEFAULT(EnableMallocTrace)) {
+    warning("Not a glibc system. EnableMallocTrace ignored.");
+  }
 #endif // __GLIBC__
 
   return JNI_OK;

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
@@ -152,7 +152,19 @@ public class MallocTraceDcmdTest {
         }
     }
 
+    // aka, Alpine
+    private static boolean NotAGlibcSystem() throws Exception {
+        OutputAnalyzer output = testCommand("print");
+        return output.getStdout().contains("Not a glibc system");
+    }
+
     public static void main(String args[]) throws Exception {
+
+        if (NotAGlibcSystem()) {
+            System.out.println("Not a glibc system, skipping test");
+            return; // skip on Alpine and friends
+        }
+
         MallocStresser stresser = new MallocStresser(3);
         stresser.start();
         Thread.sleep(1000);

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
@@ -54,6 +54,13 @@ public class MallocTraceTest {
                     option, "-XX:+PrintMallocTraceAtExit", "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);
+
+            // Ignore output for Alpine
+            if (output.getStderr().contains("Not a glibc system")) {
+                System.out.println("Not a glibc system, skipping test");
+                return;
+            }
+
             if (active) {
                 String stdout = output.getStdout();
                 // Checking for the correct frames is a whack-the-mole game since we cannot be sure how frames


### PR DESCRIPTION
Make runtime/malloctrace/MallocTraceDcmdTest.java and runtime/malloctrace/MallocTraceTest.java work on Alpine.

Tested on Alpine, manually, and on Ubuntu 20.04.

fixes #1095

