### PR TITLE
#1097: Vitals: April 22 Update

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -272,7 +272,6 @@ static Column* g_col_process_swapped_out = NULL;
 static Column* g_col_process_heap = NULL;
 static Column* g_col_process_chp_used = NULL;
 static Column* g_col_process_chp_free = NULL;
-static Column* g_col_process_chp_trimcap = NULL;
 
 static Column* g_col_process_cpu_user = NULL;
 static Column* g_col_process_cpu_system = NULL;

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1161,7 +1161,11 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   set_value_in_sample(g_col_metaspace_cap_until_gc, sample, MetaspaceGC::capacity_until_GC());
 
   // Code cache
-  const size_t codecache_committed = CodeCache::capacity();
+  size_t codecache_committed = INVALID_VALUE;
+  if (!avoid_locking) {
+    MutexLocker lck(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    codecache_committed = CodeCache::capacity();
+  }
   set_value_in_sample(g_col_codecache_committed, sample, codecache_committed);
 
   // bytes malloced by JVM. Prefer sapjvm mallstat if available (less overhead, always-on). Fall back to NMT

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1118,12 +1118,6 @@ public:
   }
 };
 
-static value_t get_bytes_malloced_by_jvm_via_sapjvm_mallstat() {
-  value_t result = INVALID_VALUE;
-  // SAPJVM plug in mallstat entry here.
-  return result;
-}
-
 #if INCLUDE_NMT
 static value_t get_bytes_malloced_by_jvm_via_nmt() {
   value_t result = INVALID_VALUE;
@@ -1182,18 +1176,10 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   }
   set_value_in_sample(g_col_codecache_committed, sample, codecache_committed);
 
-  // bytes malloced by JVM. Prefer sapjvm mallstat if available (less overhead, always-on). Fall back to NMT
-  // otherwise.
-  value_t bytes_malloced_by_jvm = get_bytes_malloced_by_jvm_via_sapjvm_mallstat();
-#if INCLUDE_NMT
-  if (bytes_malloced_by_jvm == INVALID_VALUE && !avoid_locking) {
-    bytes_malloced_by_jvm = get_bytes_malloced_by_jvm_via_nmt();
-  }
-#endif
-  set_value_in_sample(g_col_nmt_malloc, sample, bytes_malloced_by_jvm);
-
+  // NMT integration
 #if INCLUDE_NMT
   if (!avoid_locking) {
+    set_value_in_sample(g_col_nmt_malloc, sample, get_bytes_malloced_by_jvm_via_nmt());
     set_value_in_sample(g_col_nmt_mmap, sample, get_bytes_mmaped_by_jvm_via_nmt());
   }
 #endif

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1216,6 +1216,13 @@ bool initialize() {
 
   log_info(os)("Initializing vitals...");
 
+  // Adjust VitalsSampleInterval
+  if (VitalsSampleInterval == 0) {
+    log_warning(os)("Invalid VitalsSampleInterval (" UINTX_FORMAT ") specified. Vitals disabled.",
+                    VitalsSampleInterval);
+    return false;
+  }
+
   bool success = ColumnList::initialize();
 
   // Order matters. First platform columns, then jvm columns.

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestVitalsInvalidSampleInterval
+ * @summary Test verifies that -XX:-EnableVitals disables vitals
+ * @library /test/lib
+ * @run driver TestVitalsInvalidSampleInterval run
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestVitalsInvalidSampleInterval {
+
+    public static void main(String[] args) throws Exception {
+
+        // Invalid Sample interval prints a warning and runs with Vitals disabled
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:VitalsSampleInterval=0",
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xmx128m",
+                "-version"); // Note: explicitly omit Xlog:os, since the warning should always appear
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Invalid VitalsSampleInterval (0) specified. Vitals disabled.");
+
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestVitalsValidSampleInterval
+ * @summary Test verifies that -XX:-EnableVitals disables vitals
+ * @library /test/lib
+ * @run driver TestVitalsValidSampleInterval run
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+
+public class TestVitalsValidSampleInterval {
+
+    static void runTest(int interval) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:VitalsSampleInterval=" + interval,
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xlog:os",
+                "-Xmx128m",
+                "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Vitals intialized. Sample interval: " + interval + " sec");
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTest(1);
+        runTest(23);
+    }
+
+}


### PR DESCRIPTION
A collection of patches for the Vitals subsystem.

For easy review, broken down into individual topics:

### [Linux: print cheap used, free](https://github.com/SAP/SapMachine/commit/680ee8e46de25cfaca77f4503b3294d455a496ad)

Adds two new columns, process-cheap-used and process-cheap-free, displaying the current C-heap usage according to the glibc itself. Only available in Linux+glibc platforms

### [Vitals: lock codecache while sampling](https://github.com/SAP/SapMachine/commit/d70f38faf0afff0e0fca84ea2293248f890bf03a)

Codecache needs to be locked when we sample, since getting its size involves walking the segment chain

### [add column for nmt mmapped total](https://github.com/SAP/SapMachine/commit/ce1695f250189a518939a9677dcbd5557298eb7e)

We already had a column for NMT-malloced. Now, add a second column for NMT-mmaped memory. That way we see both sides of whatever NMT thinks is going on

### [Remove SAPJVM malloc stat integration](https://github.com/SAP/SapMachine/commit/cb890fce7bec92545bb6a4cc6e927436e9f487ba)

I removed the SAPJVM malloc stat integration stub since its not needed in SapMachine and not really useful either

### [VitalsSampleInterval=0 crashes VM](https://github.com/SAP/SapMachine/commit/5cc1597a9127e9b04cfd21815ef8c9cd4fdd52f9)

Fixes a small possible SIGFPE if vitals sample interval had been set to zero; also regression test.



fixes #1097

