### PR TITLE
SapMachine #1097: Vitals: April 22 Update (18)

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -33,6 +33,7 @@
 #include "utilities/ostream.hpp"
 #include "vitals/vitals_internals.hpp"
 
+#include <malloc.h>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -269,6 +270,8 @@ static Column* g_col_process_rssfile = NULL;
 static Column* g_col_process_rssshmem = NULL;
 static Column* g_col_process_swapped_out = NULL;
 static Column* g_col_process_heap = NULL;
+static Column* g_col_process_chp_used = NULL;
+static Column* g_col_process_chp_free = NULL;
 
 static Column* g_col_process_cpu_user = NULL;
 static Column* g_col_process_cpu_system = NULL;
@@ -278,6 +281,29 @@ static Column* g_col_process_io_bytes_read = NULL;
 static Column* g_col_process_io_bytes_written = NULL;
 
 static Column* g_col_process_num_threads = NULL;
+
+
+// Try to obtain mallinfo2. That replacement of mallinf is 64-bit capable and its values won't wrap.
+// Only exists in glibc 2.33 and later.
+#ifdef __GLIBC__
+struct glibc_mallinfo2 {
+  size_t arena;
+  size_t ordblks;
+  size_t smblks;
+  size_t hblks;
+  size_t hblkhd;
+  size_t usmblks;
+  size_t fsmblks;
+  size_t uordblks;
+  size_t fordblks;
+  size_t keepcost;
+};
+typedef struct glibc_mallinfo2 (*mallinfo2_func_t)(void);
+static mallinfo2_func_t g_mallinfo2 = NULL;
+static void mallinfo2_init() {
+  g_mallinfo2 = CAST_TO_FN_PTR(mallinfo2_func_t, dlsym(RTLD_DEFAULT, "mallinfo2"));
+}
+#endif // __GLIBC__
 
 bool platform_columns_initialize() {
 
@@ -342,8 +368,20 @@ bool platform_columns_initialize() {
 
   // If we manage to locate the heap segment once, and calc its size, we assume it can be done always.
   if (get_process_heap_size() != INVALID_VALUE) {
-    g_col_process_heap = new MemorySizeColumn("process", NULL, "hp", "Process heap segment (brk), resident + swap");
+    // Note: this is useful for the case when MALLOC_ARENA_MAX is 1, because then the glibc uses this segment for its
+    // one and only arena. Note however that if the brk segment cannot grow, glibc heap will switch to a new arena
+    g_col_process_heap = new MemorySizeColumn("process", NULL, "brk", "Process heap segment size (brk), resident + swap");
   }
+
+#ifdef __GLIBC__
+  mallinfo2_init();
+  g_col_process_chp_used = new MemorySizeColumn("process", "cheap", "usd",
+      g_mallinfo2 != NULL ? "C-Heap, in-use allocations" :
+                            "C-Heap, in-use allocations (unavailable if RSS > 4G)");
+  g_col_process_chp_free = new MemorySizeColumn("process", "cheap", "free",
+      g_mallinfo2 != NULL ? "C-Heap, bytes in free blocks" :
+                            "C-Heap, bytes in free blocks (unavailable if RSS > 4G)");
+#endif // __GLIBC__
 
   g_col_process_cpu_user = new CPUTimeColumn("process", "cpu", "us", "Process cpu user time");
 
@@ -381,6 +419,8 @@ void sample_platform_values(Sample* sample) {
 
   int idx = 0;
   value_t v = 0;
+
+  value_t rss_all = 0;
 
   ProcFile bf;
   if (bf.read("/proc/meminfo")) {
@@ -438,7 +478,8 @@ void sample_platform_values(Sample* sample) {
 
     set_value_in_sample(g_col_process_virt, sample, bf.parsed_prefixed_value("VmSize:", K));
     set_value_in_sample(g_col_process_swapped_out, sample, bf.parsed_prefixed_value("VmSwap:", K));
-    set_value_in_sample(g_col_process_rss, sample, bf.parsed_prefixed_value("VmRSS:", K));
+    rss_all = bf.parsed_prefixed_value("VmRSS:", K);
+    set_value_in_sample(g_col_process_rss, sample, rss_all);
 
     set_value_in_sample(g_col_process_rssanon, sample, bf.parsed_prefixed_value("RssAnon:", K));
     set_value_in_sample(g_col_process_rssfile, sample, bf.parsed_prefixed_value("RssFile:", K));
@@ -524,6 +565,28 @@ void sample_platform_values(Sample* sample) {
     set_value_in_sample(g_col_process_cpu_system, sample, cpu_stime);
   }
 
-}
+#ifdef __GLIBC__
+  // Collect some c-heap info using either one of mallinfo or mallinfo2.
+  if (g_mallinfo2 != NULL) {
+    struct glibc_mallinfo2 mi = g_mallinfo2();
+    // (from experiments and glibc source code reading: the closest to "used" would be adding the mmaped data area size
+    //  (contains large allocations) to the small block sizes
+    set_value_in_sample(g_col_process_chp_used, sample, mi.uordblks + mi.hblkhd);
+    set_value_in_sample(g_col_process_chp_free, sample, mi.fordblks);
+  } else {
+    struct mallinfo mi = mallinfo();
+    set_value_in_sample(g_col_process_chp_used, sample, (size_t)(unsigned)mi.uordblks + (size_t)(unsigned)mi.hblkhd);
+    set_value_in_sample(g_col_process_chp_free, sample, (size_t)(unsigned)mi.fordblks);
+    // In 64-bit mode, omit printing values if we could conceivably have wrapped, since they are misleading.
+#ifdef _LP64
+    if (rss_all >= 4 * G) {
+      set_value_in_sample(g_col_process_chp_used, sample, INVALID_VALUE);
+      set_value_in_sample(g_col_process_chp_free, sample, INVALID_VALUE);
+    }
+#endif
+  }
+#endif // __GLIBC__
+
+} // end: sample_platform_values
 
 } // namespace sapmachine_vitals

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -986,6 +986,7 @@ static Column* g_col_metaspace_cap_until_gc = NULL;
 static Column* g_col_codecache_committed = NULL;
 
 static Column* g_col_nmt_malloc = NULL;
+static Column* g_col_nmt_mmap = NULL;
 
 static Column* g_col_number_of_java_threads = NULL;
 static Column* g_col_number_of_java_threads_non_demon = NULL;
@@ -1029,7 +1030,10 @@ static bool add_jvm_columns() {
       NULL, "code", "Code cache, committed");
 
   g_col_nmt_malloc = new MemorySizeColumn("jvm",
-      NULL, "mlc", "Memory malloced by hotspot (requires NMT)");
+      "nmt", "mlc", "Memory malloced by hotspot (requires NMT)");
+
+  g_col_nmt_mmap = new MemorySizeColumn("jvm",
+      "nmt", "map", "Memory mapped and committed by hotspot (requires NMT)");
 
   g_col_number_of_java_threads = new PlainValueColumn("jvm",
       "jthr", "num", "Number of java threads");
@@ -1114,18 +1118,22 @@ public:
   }
 };
 
-static value_t get_bytes_malloced_by_jvm_via_sapjvm_mallstat() {
-  value_t result = INVALID_VALUE;
-  // SAPJVM plug in mallstat entry here.
-  return result;
-}
-
 #if INCLUDE_NMT
 static value_t get_bytes_malloced_by_jvm_via_nmt() {
   value_t result = INVALID_VALUE;
   if (MemTracker::tracking_level() != NMT_off) {
     MutexLocker locker(MemTracker::query_lock());
     result = MallocMemorySummary::as_snapshot()->total();
+  }
+  return result;
+}
+static value_t get_bytes_mmaped_by_jvm_via_nmt() {
+  value_t result = INVALID_VALUE;
+  if (MemTracker::tracking_level() != NMT_off) {
+    MutexLocker locker(MemTracker::query_lock());
+    VirtualMemorySnapshot snapshot;
+    VirtualMemorySummary::snapshot(&snapshot);
+    result = snapshot.total_committed();
   }
   return result;
 }
@@ -1161,18 +1169,20 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   set_value_in_sample(g_col_metaspace_cap_until_gc, sample, MetaspaceGC::capacity_until_GC());
 
   // Code cache
-  const size_t codecache_committed = CodeCache::capacity();
+  value_t codecache_committed = INVALID_VALUE;
+  if (!avoid_locking) {
+    MutexLocker lck(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    codecache_committed = CodeCache::capacity();
+  }
   set_value_in_sample(g_col_codecache_committed, sample, codecache_committed);
 
-  // bytes malloced by JVM. Prefer sapjvm mallstat if available (less overhead, always-on). Fall back to NMT
-  // otherwise.
-  value_t bytes_malloced_by_jvm = get_bytes_malloced_by_jvm_via_sapjvm_mallstat();
+  // NMT integration
 #if INCLUDE_NMT
-  if (bytes_malloced_by_jvm == INVALID_VALUE && !avoid_locking) {
-    bytes_malloced_by_jvm = get_bytes_malloced_by_jvm_via_nmt();
+  if (!avoid_locking) {
+    set_value_in_sample(g_col_nmt_malloc, sample, get_bytes_malloced_by_jvm_via_nmt());
+    set_value_in_sample(g_col_nmt_mmap, sample, get_bytes_mmaped_by_jvm_via_nmt());
   }
 #endif
-  set_value_in_sample(g_col_nmt_malloc, sample, bytes_malloced_by_jvm);
 
   // Java threads
   set_value_in_sample(g_col_number_of_java_threads, sample, Threads::number_of_threads());
@@ -1205,6 +1215,13 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 bool initialize() {
 
   log_info(os)("Initializing vitals...");
+
+  // Adjust VitalsSampleInterval
+  if (VitalsSampleInterval == 0) {
+    log_warning(os)("Invalid VitalsSampleInterval (" UINTX_FORMAT ") specified. Vitals disabled.",
+                    VitalsSampleInterval);
+    return false;
+  }
 
   bool success = ColumnList::initialize();
 

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestVitalsInvalidSampleInterval
+ * @summary Test verifies that -XX:-EnableVitals disables vitals
+ * @library /test/lib
+ * @run driver TestVitalsInvalidSampleInterval run
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestVitalsInvalidSampleInterval {
+
+    public static void main(String[] args) throws Exception {
+
+        // Invalid Sample interval prints a warning and runs with Vitals disabled
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:VitalsSampleInterval=0",
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xmx128m",
+                "-version"); // Note: explicitly omit Xlog:os, since the warning should always appear
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Invalid VitalsSampleInterval (0) specified. Vitals disabled.");
+
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestVitalsValidSampleInterval
+ * @summary Test verifies that -XX:-EnableVitals disables vitals
+ * @library /test/lib
+ * @run driver TestVitalsValidSampleInterval run
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+
+public class TestVitalsValidSampleInterval {
+
+    static void runTest(int interval) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:VitalsSampleInterval=" + interval,
+                "-XX:MaxMetaspaceSize=16m",
+                "-Xlog:os",
+                "-Xmx128m",
+                "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Vitals intialized. Sample interval: " + interval + " sec");
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTest(1);
+        runTest(23);
+    }
+
+}


### PR DESCRIPTION
(Downport 18, clean)

* Linux: print cheap used, free (from mallinfo/mallinfo2)

(cherry picked from commit 6b235a9f02a3b3c6928dd647d6549ff92e38cac1)

* Vitals: lock codecache while sampling

(cherry picked from commit 8d29ee59ae42860e671e4b9889c9f40241ae7065)

* add column for nmt mmapped total

(cherry picked from commit 13d7b2817585d4be85451effcee29fe6cf5f02d0)

* Remove SAPJVM malloc stat integration

(cherry picked from commit c9fdf259d36a70145ae590ad8e7b0d57a01b10e2)

* VitalsSampleInterval=0 crashes VM

(cherry picked from commit 6d6621a851243e5c995e41343df7ff7fdc7d5d45)

* remove unused variable

(cherry picked from commit 4c14014f77625f18a5012581f51dd7901da33a9c)

The description of this pull request goes here.

fixes #1097

