### PR TITLE
#1095: runtime/malloctrace/MallocTraceDcmdTest.java fails on Alpine (18)

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4643,6 +4643,10 @@ jint os::init_2(void) {
   if (EnableMallocTrace) {
     sap::MallocTracer::enable();
   }
+#else
+  if (!FLAG_IS_DEFAULT(EnableMallocTrace)) {
+    warning("Not a glibc system. EnableMallocTrace ignored.");
+  }
 #endif // __GLIBC__
 
   return JNI_OK;

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
@@ -30,6 +30,8 @@ import sun.hotspot.WhiteBox;
 import java.util.ArrayList;
 import java.util.Random;
 
+import jtreg.SkippedException;
+
 // For now 64bit only, 32bit stack capturing still does not work that well
 
 /*
@@ -152,7 +154,18 @@ public class MallocTraceDcmdTest {
         }
     }
 
+    // aka, Alpine
+    private static boolean NotAGlibcSystem() throws Exception {
+        OutputAnalyzer output = testCommand("print");
+        return output.getStdout().contains("Not a glibc system");
+    }
+
     public static void main(String args[]) throws Exception {
+
+        if (NotAGlibcSystem()) {
+            throw new SkippedException("Not a glibc system, skipping test");
+        }
+
         MallocStresser stresser = new MallocStresser(3);
         stresser.start();
         Thread.sleep(1000);

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
@@ -23,6 +23,7 @@
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 
 // SapMachine 2021-08-01: malloctrace
 // For now 64bit only, 32bit stack capturing still does not work that well
@@ -54,6 +55,12 @@ public class MallocTraceTest {
                     option, "-XX:+PrintMallocTraceAtExit", "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);
+
+            // Ignore output for Alpine
+            if (output.getStderr().contains("Not a glibc system")) {
+                throw new SkippedException("Not a glibc system, skipping test");
+            }
+
             if (active) {
                 String stdout = output.getStdout();
                 // Checking for the correct frames is a whack-the-mole game since we cannot be sure how frames


### PR DESCRIPTION
Downport to 18. Clean.

* fix alpine

* use SkippedException

(cherry picked from commit 250d014522b04b6d19a6fab8ef3aa055ef48720b)

The description of this pull request goes here.

fixes #1095

