### PR TITLE
SapMachine #1119: Vitals: Housekeeping May 22

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -261,7 +261,6 @@ static Column* g_col_system_num_procs_blocked = NULL;
 static Column* g_col_system_cpu_user = NULL;
 static Column* g_col_system_cpu_system = NULL;
 static Column* g_col_system_cpu_idle = NULL;
-static Column* g_col_system_cpu_waiting = NULL;
 static Column* g_col_system_cpu_steal = NULL;
 static Column* g_col_system_cpu_guest = NULL;
 
@@ -343,7 +342,6 @@ bool platform_columns_initialize() {
   g_col_system_cpu_user =     new CPUTimeColumn("system", "cpu", "us", "Global cpu user time");
   g_col_system_cpu_system =   new CPUTimeColumn("system", "cpu", "sy", "Global cpu system time");
   g_col_system_cpu_idle =     new CPUTimeColumn("system", "cpu", "id", "Global cpu idle time");
-  g_col_system_cpu_waiting =  new CPUTimeColumn("system", "cpu", "wa", "Global cpu time spent waiting for IO");
   g_col_system_cpu_steal =    new CPUTimeColumn("system", "cpu", "st", "Global cpu time stolen");
   g_col_system_cpu_guest =    new CPUTimeColumn("system", "cpu", "gu", "Global cpu time spent on guest");
 
@@ -466,7 +464,6 @@ void sample_platform_values(Sample* sample) {
     set_value_in_sample(g_col_system_cpu_user, sample, values.user + values.nice);
     set_value_in_sample(g_col_system_cpu_system, sample, values.system);
     set_value_in_sample(g_col_system_cpu_idle, sample, values.idle);
-    set_value_in_sample(g_col_system_cpu_waiting, sample, values.iowait);
     set_value_in_sample(g_col_system_cpu_steal, sample, values.steal);
     set_value_in_sample(g_col_system_cpu_guest, sample, values.guest + values.guest_nice);
 

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -193,8 +193,6 @@ public:
 
 };
 
-//static Column* g_col_system_memtotal = NULL;
-static Column* g_col_system_memfree = NULL;
 static Column* g_col_system_memavail = NULL;
 static Column* g_col_system_memcommitted = NULL;
 static Column* g_col_system_memcommitted_ratio = NULL;
@@ -259,23 +257,8 @@ static void mallinfo2_init() {
 bool platform_columns_initialize() {
 
   // Order matters!
-//  g_col_system_memtotal = new MemorySizeColumn("system", NULL, "total", "Total physical memory.");
 
-  // Since free and avail are kind of redundant, only display free if avail is not available (very old kernels)
-  bool have_avail = false;
-  {
-    ProcFile bf;
-    if (bf.read("/proc/meminfo")) {
-      have_avail = (bf.parsed_prefixed_value("MemAvailable:", 1) != INVALID_VALUE);
-    }
-  }
-
-  // To save horizontal space, we print either avail or free
-  if (have_avail) { //  (>=3.14)
-    g_col_system_memavail = new MemorySizeColumn("system", NULL, "avail", "Memory available without swapping");
-  } else {
-    g_col_system_memfree = new MemorySizeColumn("system", NULL, "free", "Unused memory");
-  }
+  g_col_system_memavail = new MemorySizeColumn("system", NULL, "avail", "Memory available without swapping");
   g_col_system_memcommitted = new MemorySizeColumn("system", NULL, "comm", "Committed memory");
   g_col_system_memcommitted_ratio = new PlainValueColumn("system", NULL, "crt", "Committed-to-Commit-Limit ratio (percent)");
   g_col_system_swap = new MemorySizeColumn("system", NULL, "swap", "Swap space used");
@@ -370,9 +353,6 @@ void sample_platform_values(Sample* sample) {
 
     // All values in /proc/meminfo are in KB
     const size_t scale = K;
-
-    set_value_in_sample(g_col_system_memfree, sample,
-        bf.parsed_prefixed_value("MemFree:", scale));
 
     set_value_in_sample(g_col_system_memavail, sample,
         bf.parsed_prefixed_value("MemAvailable:", scale));

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -160,9 +160,11 @@ void parse_proc_stat_cpu_line(const char* line, cpu_values_t* out) {
   // Note: existence of some of these values depends on kernel version
   out->user = out->nice = out->system = out->idle = out->iowait = out->steal = out->guest = out->guest_nice =
       INVALID_VALUE;
-  int user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice;
+  uint64_t user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice;
   int num = ::sscanf(line,
-      "cpu %d %d %d %d %d %d %d %d %d %d",
+      "cpu "
+      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " "
+      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " ",
       &user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal, &guest, &guest_nice);
   if (num >= 4) {
     out->user = user;

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1389,7 +1389,7 @@ void VMError::print_vm_info(outputStream* st) {
   sapmachine_vitals::default_settings(&info);
   info.sample_now = false;
   st->print_cr("Vitals:");
-  sapmachine_vitals::print_report(st);
+  sapmachine_vitals::print_report(st, &info);
 
   // STEP("printing system")
 


### PR DESCRIPTION
These are some tiny issues and cleanups which came up during recent Vitals development and reviews.

Split into individual commits for easier review.

--------------

- [Fix bug where for jcmd VM.info the Vitals report settings were ignored and default was used instead](https://github.com/SAP/SapMachine/commit/20806d9eefaa879f2f402975f70eda0e317b8ce9)

Forgot to pass in the prepared options into the report function which causes the report function to use default values instead.

- [CPU times can overflow on long running machines](https://github.com/SAP/SapMachine/commit/f9622e589c1fb16e395f3731e05fdf5ecb89fcb2)

CPU times are read from /proc/stat/cpu and those numbers can get larger than 32-bit irregardless the bitness of the OS. Use 64-bit ints to prevent that.

- [Remove CPU-waiting column since it turns out to be unreliable](https://github.com/SAP/SapMachine/commit/515ea096d3d4e99e48e743129a1a373072dc97ae)

Cleanup change. Don't read iowait from /proc/stat/cpu since it makes not much sense with modern CPUs. The values were usually confusing, most of the time 0.

- [Remove BRK column; it was of questionable use and for that quite expensive to get](https://github.com/SAP/SapMachine/commit/a92bba37cfc13f338d44a75c7c91427b0319cb5f)

Cleanup change. I decided to remove the BRK column that shows the size of the traditional Unix heap. Even though this sometimes (with MALLOC_ARENA_MAX=1 and a bit of luck) was useful to determine the size of the C-heap, we have a better mechanism now (see the "cheap" columns introduced with #1097). And since the value is difficult to get (parsing the maps file) I got rid of it.

- [Remove code for older Linux kernels < 3.14](https://github.com/SAP/SapMachine/commit/a413d7f56be5f82c1935e67066ed39bf7ac2c959)

This removes coding needed for kernels < 3.14; not really needed anymore. 

--------------

fixes #1119

