### PR TITLE
SapMachine #1119: Vitals: Housekeeping May 22 (18)

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1366,7 +1366,7 @@ void VMError::print_vm_info(outputStream* st) {
   sapmachine_vitals::default_settings(&info);
   info.sample_now = false;
   st->print_cr("Vitals:");
-  sapmachine_vitals::print_report(st);
+  sapmachine_vitals::print_report(st, &info);
 
   // STEP("printing system")
 


### PR DESCRIPTION
Clean downport to SapMachine 18

(cherry picked from commit beecee77cabc6abecb7d4acaac80ec13a992f86f)

* Fix bug where for jcmd VM.info the Vitals report settings were ignored and default was used instead

* CPU times can overflow on long running machines

* Remove CPU-waiting column since it turns out to be unreliable

* Remove BRK column; it was of questionable use and for that quite expensive to get

* Remove code for older Linux kernels < 3.14

(cherry picked from commit 1af292ea6626d87361ae777ed7b84b0cbabdb9a4)

The description of this pull request goes here.

fixes #1119

