### PR TITLE
SapMachine #1124: Vitals: Add Container information

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -306,7 +306,7 @@ bool platform_columns_initialize() {
   // with /proc/meminfo and also root cgroup cannot have resource limits, so its less interesting.
   // In the future we also may omit if we run inside systemd, but I am not sure if systemd can limit
   // memory usage, and then those limits would be interesting
-  g_show_cgroup_info = !(context == ctx_unknown || context == ctx_root);
+  g_show_cgroup_info = (context != ctx_root);
 
   // System
 

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -26,6 +26,7 @@
 
 #include "precompiled.hpp"
 #include "jvm_io.h"
+//#include "osContainer_linux.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
@@ -73,6 +74,26 @@ public:
 
   const char* text() const { return _buf; }
 
+  // Utility function; parse a integral number as value_t
+  static value_t as_value(const char* text, size_t scale = 1) {
+    value_t value;
+    errno = 0;
+    char* endptr = NULL;
+    value = (value_t)::strtoll(text, &endptr, 10);
+    if (endptr == text || errno != 0) {
+      value = INVALID_VALUE;
+    } else {
+      value *= scale;
+    }
+    return value;
+  }
+
+  // Return the start of the file, as number. Useful for proc files which
+  // contain a single number. Returns INVALID_VALUE if value did not parse
+  value_t as_value(size_t scale = 1) const {
+    return as_value(_buf, scale);
+  }
+
   const char* get_prefixed_line(const char* prefix) const {
     return ::strstr(_buf, prefix);
   }
@@ -83,13 +104,7 @@ public:
     if (s != NULL) {
       errno = 0;
       const char* p = s + ::strlen(prefix);
-      char* endptr = NULL;
-      value = (value_t)::strtoll(p, &endptr, 10);
-      if (p == endptr || errno != 0) {
-        value = INVALID_VALUE;
-      } else {
-        value *= scale;
-      }
+      return as_value(p, scale);
     }
     return value;
   }
@@ -207,6 +222,14 @@ static Column* g_col_system_num_threads = NULL;
 static Column* g_col_system_num_procs_running = NULL;
 static Column* g_col_system_num_procs_blocked = NULL;
 
+static bool g_show_cgroup_info = false;
+static Column* g_col_system_cgrp_limit_in_bytes = NULL;
+static Column* g_col_system_cgrp_soft_limit_in_bytes = NULL;
+static Column* g_col_system_cgrp_usage_in_bytes = NULL;
+static Column* g_col_system_cgrp_memsw_limit_in_bytes = NULL;
+static Column* g_col_system_cgrp_memsw_usage_in_bytes = NULL;
+static Column* g_col_system_cgrp_kmem_usage_in_bytes = NULL;
+
 static Column* g_col_system_cpu_user = NULL;
 static Column* g_col_system_cpu_system = NULL;
 static Column* g_col_system_cpu_idle = NULL;
@@ -258,13 +281,42 @@ bool platform_columns_initialize() {
 
   // Order matters!
 
-  g_col_system_memavail = new MemorySizeColumn("system", NULL, "avail", "Memory available without swapping");
-  g_col_system_memcommitted = new MemorySizeColumn("system", NULL, "comm", "Committed memory");
-  g_col_system_memcommitted_ratio = new PlainValueColumn("system", NULL, "crt", "Committed-to-Commit-Limit ratio (percent)");
-  g_col_system_swap = new MemorySizeColumn("system", NULL, "swap", "Swap space used");
+  // Find out if we run inside docker or lxc or systemd or baremetal or other
+  enum { ctx_root, ctx_docker, ctx_lxc, ctx_systemd, ctx_other, ctx_unknown } context = ctx_unknown;
+  {
+    FILE* f = ::fopen("/proc/self/cgroup", "r");
+    if (f != NULL) {
+      char line[256];
+      while (context == ctx_unknown && ::fgets(line, sizeof(line), f) != NULL) {
+        if (::strstr(line, "memory:/docker") != NULL) {
+          context = ctx_docker;
+        } else if (::strstr(line, "memory:/lxc") != NULL) {
+          context = ctx_lxc;
+        } else if (::strstr(line, "memory:/user.slice") != NULL) {
+          context = ctx_systemd;
+        } else if (::strstr(line, "memory:/\n") != NULL) {
+          context = ctx_root;
+        }
+      }
+      ::fclose(f);
+    }
+  }
 
-  g_col_system_pages_swapped_in = new DeltaValueColumn("system", NULL, "si", "Number of pages swapped in");
-  g_col_system_pages_swapped_out = new DeltaValueColumn("system", NULL, "so", "Number of pages pages swapped out");
+  // We omit c-group info if we run inside a root memory controller, since then the info is redundant
+  // with /proc/meminfo and also root cgroup cannot have resource limits, so its less interesting.
+  // In the future we also may omit if we run inside systemd, but I am not sure if systemd can limit
+  // memory usage, and then those limits would be interesting
+  g_show_cgroup_info = !(context == ctx_unknown || context == ctx_root);
+
+  // System
+
+  g_col_system_memavail = new MemorySizeColumn("system", NULL, "avail", "Memory available without swapping [*]");
+  g_col_system_memcommitted = new MemorySizeColumn("system", NULL, "comm", "Committed memory [*]");
+  g_col_system_memcommitted_ratio = new PlainValueColumn("system", NULL, "crt", "Committed-to-Commit-Limit ratio (percent) [*]");
+  g_col_system_swap = new MemorySizeColumn("system", NULL, "swap", "Swap space used [*]");
+
+  g_col_system_pages_swapped_in = new DeltaValueColumn("system", NULL, "si", "Number of pages swapped in [*]");
+  g_col_system_pages_swapped_out = new DeltaValueColumn("system", NULL, "so", "Number of pages pages swapped out [*]");
 
   g_col_system_num_procs = new PlainValueColumn("system", NULL, "p", "Number of processes");
   g_col_system_num_threads = new PlainValueColumn("system", NULL, "t", "Number of threads");
@@ -272,11 +324,22 @@ bool platform_columns_initialize() {
   g_col_system_num_procs_running = new PlainValueColumn("system", NULL, "pr", "Number of processes running");
   g_col_system_num_procs_blocked = new PlainValueColumn("system", NULL, "pb", "Number of processes blocked");
 
-  g_col_system_cpu_user =     new CPUTimeColumn("system", "cpu", "us", "Global cpu user time");
-  g_col_system_cpu_system =   new CPUTimeColumn("system", "cpu", "sy", "Global cpu system time");
-  g_col_system_cpu_idle =     new CPUTimeColumn("system", "cpu", "id", "Global cpu idle time");
-  g_col_system_cpu_steal =    new CPUTimeColumn("system", "cpu", "st", "Global cpu time stolen");
-  g_col_system_cpu_guest =    new CPUTimeColumn("system", "cpu", "gu", "Global cpu time spent on guest");
+  g_col_system_cpu_user =     new CPUTimeColumn("system", "cpu", "us", "CPU user time [*]");
+  g_col_system_cpu_system =   new CPUTimeColumn("system", "cpu", "sy", "CPU system time [*]");
+  g_col_system_cpu_idle =     new CPUTimeColumn("system", "cpu", "id", "CPU idle time [*]");
+  g_col_system_cpu_steal =    new CPUTimeColumn("system", "cpu", "st", "CPU time stolen [*]");
+  g_col_system_cpu_guest =    new CPUTimeColumn("system", "cpu", "gu", "CPU time spent on guest [*]");
+
+  if (g_show_cgroup_info) {
+    g_col_system_cgrp_limit_in_bytes = new MemorySizeColumn("system", "cgroup", "lim", "cgroup memory limit");
+    g_col_system_cgrp_memsw_limit_in_bytes = new MemorySizeColumn("system", "cgroup", "limsw", "cgroup memory+swap limit");
+    g_col_system_cgrp_soft_limit_in_bytes = new MemorySizeColumn("system", "cgroup", "slim", "cgroup memory soft limit");
+    g_col_system_cgrp_usage_in_bytes = new MemorySizeColumn("system", "cgroup", "usg", "cgroup memory usage");
+    g_col_system_cgrp_memsw_usage_in_bytes = new MemorySizeColumn("system", "cgroup", "usgsw", "cgroup memory+swap usage");
+    g_col_system_cgrp_kmem_usage_in_bytes = new MemorySizeColumn("system", "cgroup", "kusg", "cgroup kernel memory usage");
+  }
+
+  // Process
 
   g_col_process_virt = new MemorySizeColumn("process", NULL, "virt", "Virtual size");
 
@@ -394,6 +457,37 @@ void sample_platform_values(Sample* sample) {
         bf.parsed_prefixed_value("procs_running"));
     set_value_in_sample(g_col_system_num_procs_blocked, sample,
         bf.parsed_prefixed_value("procs_blocked"));
+  }
+
+  // cgroups business
+  if (g_show_cgroup_info) {
+    if (bf.read("/sys/fs/cgroup/memory/memory.usage_in_bytes")) {
+      set_value_in_sample(g_col_system_cgrp_usage_in_bytes, sample, bf.as_value(1));
+    }
+    if (bf.read("/sys/fs/cgroup/memory/memory.memsw.usage_in_bytes")) {
+      set_value_in_sample(g_col_system_cgrp_memsw_usage_in_bytes, sample, bf.as_value(1));
+    }
+    if (bf.read("/sys/fs/cgroup/memory/memory.kmem.usage_in_bytes")) {
+      set_value_in_sample(g_col_system_cgrp_kmem_usage_in_bytes, sample, bf.as_value(1));
+    }
+    // Cgroup limits defaults to PAGE_COUNTER_MAX in the kernel; on 64-bit, its LONG_MAX aligned down to pagesize;
+    // but since I am not sure this is always true, just assume a very high value.
+    const size_t very_high_value = LP64_ONLY(128 * K * G) NOT_LP64(4 * G);
+    if (bf.read("/sys/fs/cgroup/memory/memory.limit_in_bytes")) {
+      value_t v = bf.as_value(1);
+      set_value_in_sample(g_col_system_cgrp_limit_in_bytes, sample,
+                         (v > very_high_value ? INVALID_VALUE : v)); // very large numbers mean unlimited
+    }
+    if (bf.read("/sys/fs/cgroup/memory/memory.soft_limit_in_bytes")) {
+      value_t v = bf.as_value(1);
+      set_value_in_sample(g_col_system_cgrp_soft_limit_in_bytes, sample,
+                         (v > very_high_value ? INVALID_VALUE : v)); // very large numbers mean unlimited
+    }
+    if (bf.read("/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes")) {
+      value_t v = bf.as_value(1);
+      set_value_in_sample(g_col_system_cgrp_memsw_limit_in_bytes, sample,
+                         (v > very_high_value ? INVALID_VALUE : v)); // very large numbers mean unlimited
+    }
   }
 
   if (bf.read("/proc/self/status")) {

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -26,7 +26,6 @@
 
 #include "precompiled.hpp"
 #include "jvm_io.h"
-//#include "osContainer_linux.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
@@ -74,7 +73,7 @@ public:
 
   const char* text() const { return _buf; }
 
-  // Utility function; parse a integral number as value_t
+  // Utility function; parse a number string as value_t
   static value_t as_value(const char* text, size_t scale = 1) {
     value_t value;
     errno = 0;

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -587,14 +587,6 @@ static void print_one_sample(outputStream* st, const Sample* sample,
     st->print("\"");
   }
 
-  // For analysis, print sample numbers
-#ifdef ASSERT
-  if (pi->raw) {
-    st->print(",%d,%d", sample->num(),
-              last_sample != NULL ? last_sample->num() : -1);
-  }
-#endif
-
   if (pi->csv == false) {
     ostream_put_n(st, ' ', TIMESTAMP_DIVIDER_LEN);
   } else {

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -392,6 +392,7 @@ static void print_legend(outputStream* st, const print_info_t* pi) {
   }
   st->cr();
   st->print_cr("[delta] values refer to the previous measurement.");
+  st->print_cr("[*] values are host-global (not containerized).");
   if (pi->scale != 0) {
     const char* display_unit = NULL;
     switch (pi->scale) {

--- a/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
+++ b/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import java.util.ArrayList;
 import java.util.Hashtable;
 
@@ -193,15 +216,3 @@ public class CSVParser {
     }
 
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
+++ b/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
@@ -1,0 +1,207 @@
+import java.util.ArrayList;
+import java.util.Hashtable;
+
+public class CSVParser {
+
+    public final static class CSVHeader {
+        ArrayList<String> columns = new ArrayList<>();
+        Hashtable<String, Integer> columnPositions = new Hashtable<>();
+
+        int size() {
+            return columns.size();
+        }
+
+        String at(int position) {
+            return columns.get(position);
+        }
+
+        int findColumn(String name) {
+            Integer i = columnPositions.get(name);
+            return (i == null) ? -1 : i;
+        }
+
+        void addColumn(String name) {
+            if (columnPositions.contains(name)) {
+                throw new RuntimeException("Already have column " + name);
+            }
+            columns.add(name);
+            columnPositions.put(name, columns.size() - 1);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            for (String s : columns) {
+                bld.append(s);
+                bld.append(",");
+            }
+            return bld.toString();
+        }
+    }
+
+    public final static class CSVDataLine {
+        ArrayList<String> data = new ArrayList<>();
+
+        int size() {
+            return data.size();
+        }
+
+        String at(int position) {
+            return data.get(position);
+        }
+
+        boolean isEmpty(int position) {
+            return at(position).length() == 0;
+        }
+
+        long numberAt(int position) {
+            if (isEmpty(position)) {
+                throw new RuntimeException("no data at position " + position);
+            }
+            return Long.parseLong(at(position));
+        }
+
+        void addData(String s) {
+            // If data was surrounded by quotes, remove quotes
+            if (s.startsWith("\"") && s.endsWith("\"")) {
+                s = s.substring(1, s.length() - 1);
+            }
+            s = s.trim();
+            data.add(s);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            for (String s : data) {
+                bld.append(s);
+                bld.append(",");
+            }
+            return bld.toString();
+        }
+    }
+
+    public final static class CSV {
+        public CSVHeader header;
+        public CSVDataLine[] lines;
+
+        // Convenience function. Given a column name and a data line number, return value for that column in that line
+        String getContentOfCell(String columnname, int lineno) {
+            return lines[lineno].at(header.findColumn(columnname));
+        }
+
+        long getContentOfCellAsNumber(String columnname, int lineno) {
+            return Long.parseLong(getContentOfCell(columnname, lineno));
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("CSV: " + header.size() + " columns, " + lines.length + " data lines.\n");
+            builder.append(header);
+            builder.append("\n");
+            for (CSVDataLine line : lines) {
+                builder.append(line);
+                builder.append("\n");
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class CSVParseException extends Exception {
+        public CSVParseException(String message) {
+            super("CSV parse error " + ": " + message);
+        }
+        public CSVParseException(String message, int errorLine) {
+            super("CSV parse error at line " + errorLine + ": " + message);
+        }
+    }
+
+    /**
+     * Parses the given lines as CSV. The first lines must be the header, all subsequent lines
+     * valid data.
+     * @param lines
+     * @return
+     */
+    public static final CSV parseCSV(String [] lines) throws CSVParseException {
+
+        if (lines.length < 2) {
+            throw new CSVParseException("Not enough data", -1);
+        }
+
+        System.out.println("--- CSV parser input: ---");
+        for (String s : lines) {
+            System.out.println(s);
+        }
+        System.out.println("--- /CSV parser input: ---");
+
+        int lineno = 0;
+        CSVHeader header = new CSVHeader();
+        ArrayList<CSVDataLine> datalines = new ArrayList<>();
+
+        try {
+            // Parse header line
+            String[] parts = lines[lineno].split(",");
+            for (String s : parts) {
+                header.addColumn(s);
+            }
+
+            lineno ++;
+
+            // Parse Data
+            while (lineno < lines.length) {
+                CSVDataLine dataLine = new CSVDataLine();
+                parts = lines[lineno].split(",");
+                for (String s : parts) {
+                    dataLine.addData(s);
+                }
+                if (dataLine.size() != header.size()) {
+                    // We have more or less data than columns. Print some helpful message to stderr, then abort.
+                    String s = "Line " + lineno + ": expected " + header.size() + " entries, found " + dataLine.size() + ".";
+                    System.err.println(s);
+                    System.err.println("Header: " + header.toString());
+                    System.err.println("Data: " + dataLine.toString());
+                    for (int i = 0; i < header.size() || i < dataLine.size(); i ++) {
+                        String col = (i < header.size() ? header.at(i) : "<NULL>");
+                        String dat = (i < dataLine.size() ? dataLine.at(i) : "<NULL>");
+                        System.err.println("pos: " + i + " column: " + col + " data: " + dat);
+                    }
+                    throw new CSVParseException(s, lineno);
+                }
+                datalines.add(dataLine);
+                lineno ++;
+            }
+
+        } catch (Exception e) {
+            System.err.println("--- CSV parse error : " + e.getMessage() + "---");
+            e.printStackTrace();
+            System.err.println("--- /CSV parse error : " + e.getMessage() + "---");
+            throw new CSVParseException(e.getMessage(), lineno);
+        }
+
+        CSV csv = new CSV();
+        csv.header = header;
+        CSVDataLine[] arr = new CSVDataLine[datalines.size()];
+        csv.lines = datalines.toArray(arr);
+
+        System.out.println("---- parsed ----");
+        System.out.println(csv);
+        System.out.println("---- /parsed ----");
+
+        return csv;
+
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
@@ -25,11 +25,88 @@
  * @test
  * @summary Test of diagnostic command VM.vitals
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.compiler
- *          java.management
- *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=1 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=2 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=3 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=4 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=5 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=6 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=7 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=8 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=9 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=10 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=11 -XX:VitalsSampleInterval=1 VitalsDCmdTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -41,43 +118,82 @@ public class VitalsDCmdTest {
 
     public void run(CommandExecutor executor) {
 
-        OutputAnalyzer output = executor.execute("VM.vitals");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldMatch("\\d+[gkm]"); // we print by default in "dynamic" scale which should show some values as k or m or g
-        output.shouldNotContain("Now"); // off by default
+        try {
 
-        output = executor.execute("VM.vitals reverse");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+            int testnumber = Integer.parseInt(System.getProperties().getProperty("sapmachine.vitalstest"));
 
-        output = executor.execute("VM.vitals scale=m");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+            switch (testnumber) {
+                case 1:
+                    OutputAnalyzer output = executor.execute("VM.vitals");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldMatch("\\d+[gkm]"); // we print by default in "dynamic" scale which should show some values as k or m or g
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 2:
+                    output = executor.execute("VM.vitals reverse");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 3:
+                    output = executor.execute("VM.vitals scale=m");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 4:
+                    output = executor.execute("VM.vitals scale=1");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 5:
+                    output = executor.execute("VM.vitals raw");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 6:
+                    output = executor.execute("VM.vitals now");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldContain("Now");
+                    break;
+                case 7:
+                    output = executor.execute("VM.vitals reverse now");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldContain("Now");
+                    break;
+                case 8:
+                    output = executor.execute("VM.vitals csv");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    VitalsTestHelper.parseAndCheckCSV(output, false);
+                    break;
+                case 9:
+                    output = executor.execute("VM.vitals csv reverse");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    VitalsTestHelper.parseAndCheckCSV(output, false);
+                    break;
+                case 10:
+                    output = executor.execute("VM.vitals csv reverse raw");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    VitalsTestHelper.parseAndCheckCSV(output, true);
+                    break;
+                case 11:
+                    output = executor.execute("VM.vitals csv now reverse raw");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldContain("Now");
+                    // no extensive checks for now since Now sample confuses parser
+                    break;
+                default:
+                    throw new RuntimeException("unknown test number " + testnumber);
+            }
 
-        output = executor.execute("VM.vitals scale=1");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
 
-        output = executor.execute("VM.vitals raw");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals now");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals reverse now");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals csv");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-        output.shouldNotContain("Now"); // off always in csv mode
-
-        output = executor.execute("VM.vitals csv reverse");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-
-        output = executor.execute("VM.vitals csv reverse raw");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-
-        output = executor.execute("VM.vitals csv now reverse raw");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
     }
 
     @Test

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, SAP SE. All rights reserved.
+ * Copyright (c) 2020,2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 
 public class VitalsTestHelper {
 
-
     // Example output:
     // Last 60 minutes:
     //                      ---------------------------system--------------------------- ------------------------process------------------------ --------------------------------------jvm---------------------------------------

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -1,3 +1,4 @@
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 import java.io.File;
@@ -5,31 +6,29 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 
 public class VitalsTestHelper {
 
-    // Example output:
-    // Last 60 minutes:
-    //                      ---------------------------system--------------------------- ------------------------process------------------------ --------------------------------------jvm---------------------------------------
-    //                                                                -------cpu--------       -------rss--------          -cpu- ----io-----     --heap--- ----------meta----------           ----jthr----- --cldg-- ----cls-----
-    //                      avail comm  crt swap si so p   t    pr pb us sy id  wa st gu virt  all  anon file shm swdo hp  us sy of rd   wr  thr comm used comm used csc  csu  gctr code mlc  num nd cr st  num anon num  ld  uld
-    //2022-03-10 07:41:27   55,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0 100  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k  0k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
-    //2022-03-10 07:41:17   55,0g 11,5g  34   0k  0  0 538 1267  1  0  1  0  99  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k 21k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
-    //2022-03-10 07:41:07   55,0g 11,5g  34   0k  0  0 538 1268  1  0  3  0  96  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  3  0  4 128k  8k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  1 37m  27   24 1286   0   0
-    //2022-03-10 07:40:57   56,9g 11,6g  34   0k  0  0 539 1279  4  0  2  0  98  0  0  0 21,2g 1,7g 1,7g  36m  0k   0k 92k  2  0  3 131k <1k  38 1,0g 530m   3m   2m 320k 222k  21m   8m 604m  12  1  1 37m  27   24 1286   0   0
-    //2022-03-10 07:40:47   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
-    //2022-03-10 07:40:37   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
-    //2022-03-10 07:40:27   58,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0  99  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 998k <1k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  5 36m  27   24 1286 842   0
-    //2022-03-10 07:40:17   58,5g 11,5g  34   0k       537 1254  4  0                    18,9g  95m  65m  31m  0k   0k 92k        2           18 1,0g  10m 128k  55k  64k   2k  21m   7m  42m   9  1    16m   3    0  444
+//    Last 60 minutes:
+//                                  ---------------------------------------system---------------------------------------- -------------------------process-------------------------- ----------------------------------------jvm-----------------------------------------
+//                                                                        ------cpu------ ------------cgroup-------------      -------rss--------      -cheap-- -cpu- ----io----     --heap--- ----------meta----------      --nmt--- ----jthr----- --cldg-- ----cls-----
+//                                  avail comm  crt swap si so p t  pr pb us sy id  st gu lim  limsw slim usg  usgsw kusg virt all  anon file shm swdo usd free us sy of rd   wr thr comm used comm used csc  csu  gctr code mlc map  num nd cr st  num anon num  ld  uld
+//            2022-05-14 14:52:36   54.4g 21.7g  65   0k  0  0 2 22  2  0  3  0  96  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:26   54.4g 21.9g  65   0k  0  0 2 22  4  1  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:16   54.4g 21.8g  65   0k  0  0 2 22  3  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:06   54.4g 21.8g  65   0k  0  0 2 22  1  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:56   54.4g 21.7g  64   0k  0  0 2 22  2  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:46   54.4g 21.5g  64   0k  0  0 2 22  1  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:36   54.4g 21.5g  64   0k  0  0 2 22  1  0  1  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
 
-    // Note: all platforms should have the --jvm-- section. Some platforms have more. Above printout is from linux.
-    // For now, we just test for the stuff which is in all platforms.
-    public static final String jvm_header_line1_textmode = ".*heap.*meta.*";
-    public static final String jvm_header_line2_textmode = ".*comm.*used.*comm.*used.*";
-
-    public static final String jvm_header_line_csvmode = ".*jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used.*";
+    // JVM section: this one is valid on all platforms
+    // (Note: no compressed class space on 32bit platforms)
+    public static final String jvm_header_line1_textmode = ".*heap[ -]+meta[ -]+nmt[ -]+jthr[ -]+cldg[ -]+cls.*";
+    public static final String jvm_header_line2_textmode = ".*comm[ -]+used[ -]+comm[ -]+used[ -]+.*gctr[ -]+code[ -]+mlc[ -]+map[ -]+num[ -]+nd[ -]+cr[ -]+st[ -]+num[ -]+anon[ -]+num[ -]+ld[ -]+uld.*";
+    public static final String jvm_header_line_csvmode = ".*jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used.*jvm-meta-gctr,jvm-code,jvm-nmt-mlc,jvm-nmt-map,jvm-jthr-num,jvm-jthr-nd,jvm-jthr-cr,jvm-jthr-st,jvm-cldg-num,jvm-cldg-anon,jvm-cls-num,jvm-cls-ld,jvm-cls-uld,";
 
     public static final String timestamp_regex = "\\d{4}+-\\d{2}+-\\d{2}.*\\d{2}:\\d{2}:\\d{2}";
 
@@ -111,6 +110,123 @@ public class VitalsTestHelper {
         String[] lines = output.asLines().toArray(new String[0]);
         if (!findMatchesInStrings(lines, expected_output_csvmode)) {
             throw new RuntimeException("Expected output not found (see error output)");
+        }
+    }
+
+    // Some more extensive sanity checks are possible in CSV mode
+    public static CSVParser.CSV parseAndCheckCSV(OutputAnalyzer output, boolean outputIsRaw) throws CSVParser.CSVParseException {
+        String[] lines = output.asLines().toArray(new String[0]);
+
+        // Search for the beginning of the CSV output
+        int firstline = -1;
+        int lastline = -1;
+        Pattern headerLinePattern = Pattern.compile(jvm_header_line_csvmode);
+        Pattern csvDataLinePattern = Pattern.compile(sample_line_regex_minimal_csvmode);
+        for (int lineno = 0; lineno < lines.length && firstline == -1 && lastline == -1; lineno ++) {
+            String line = lines[lineno];
+            if (firstline == -1) {
+                if (headerLinePattern.matcher(line).matches()) {
+                    firstline = lineno;
+                }
+            } else {
+                if (headerLinePattern.matcher(line).matches()) {
+                    throw new CSVParser.CSVParseException("Found header twice", lineno);
+                }
+                if (!csvDataLinePattern.matcher(line).matches()) {
+                    lastline = lineno - 1;
+                    break;
+                }
+            }
+        }
+        if (lastline == -1) {
+            lastline = lines.length - 1;
+        }
+
+        if (firstline == -1) {
+            throw new CSVParser.CSVParseException("Could not find CSV header line");
+        }
+
+        String [] csvlines = Arrays.copyOfRange(lines, firstline, lastline + 1);
+
+        CSVParser.CSV csv;
+        csv = CSVParser.parseCSV(csvlines);
+
+        if (outputIsRaw) {
+            csvSanityChecks(csv);
+        }
+
+        return csv;
+    }
+
+    /**
+     * does some more extensive tests on a csv raw output
+     * @param csv
+     */
+    static void csvSanityChecks(CSVParser.CSV csv) throws CSVParser.CSVParseException {
+
+        // The following columns are allowed to be empty (they are delta columns, or their values depend on runtime
+        // conditions not always given)
+        String colsThatCanBeEmpty =
+                  "|jvm-jthr-cr"  // delta column
+                + "|syst-si|syst-so" // deltas
+                + "|jvm-cls-ld" // delta
+                + "|jvm-cls-uld" // delta
+                + "|jvm-nmt.*" // only available if nmt is on
+                ;
+
+        String colsThatCanBeEmpty_WINDOWS =
+                  "|jvm-jthr-st"; // NMT stack size display switched off deliberately on Windows
+
+        String colsThatCanBeEmpty_OSX =
+                  "|jvm-jthr-st"; // NMT stack size display switched off deliberately on Mac
+
+        String colsThatCanBeEmpty_LINUX =
+                  "|syst-avail" // depends on kernel version
+                + "|syst-cpu.*" // CPU values may be omitted in containers; also they are all deltas
+                + "|syst-cgr.*" // Cgroup values may be omitted in root cgroup
+                + "|proc-chea-usd|proc-chea-free" // cannot be shown if RSS is > 4g and glibc is too old
+                + "|proc-rss-anon|proc-rss-file|proc-rss-shm" // depend on kernel
+                + "|proc-cpu-us|proc-cpu-sy" // deltas
+                ;
+
+        String regexCanBeEmpty = "(x" + colsThatCanBeEmpty;
+        if (Platform.isLinux()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_LINUX;
+        } else if (Platform.isWindows()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_WINDOWS;
+        } else if (Platform.isOSX()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_OSX;
+        }
+        regexCanBeEmpty += ")";
+
+        System.out.println("Columns allowed to be empty: " + regexCanBeEmpty);
+        Pattern canBeEmptyPattern = Pattern.compile(regexCanBeEmpty);
+
+        for (int lineno = 0; lineno < csv.lines.length; lineno ++) {
+            CSVParser.CSVDataLine line = csv.lines[lineno];
+            // Iterate through all columns and do some basic checks.
+            // In raw mode, all but the first column are longs. The first column is a time stamp.
+            for (int i = 1; i < csv.header.size(); i ++) {
+                String col = csv.header.at(i);
+                String val = line.at(i);
+                if (val.equals("?")) {
+                    // aka empty
+                    if (!canBeEmptyPattern.matcher(col).matches()) {
+                        throw new CSVParser.CSVParseException("Column " + col + " must not have empty value.", lineno + 1);
+                    }
+                } else {
+                    long l = 0;
+                    try {
+                        l = Long.parseLong(val);
+                    } catch (NumberFormatException e) {
+                        throw new CSVParser.CSVParseException("Column " + col + ": cannot parse value as long (" + val + ")", lineno + 1);
+                    }
+                    long highestReasonableRawValue = 0x00800000_00000000l;
+                    if (l < 0 || l > highestReasonableRawValue) {
+                        throw new CSVParser.CSVParseException("Column " + col + ": Suspiciously high or low value:" + val, lineno + 1);
+                    }
+                }
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, SAP SE. All rights reserved.
+ * Copyright (c) 2022, SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2020, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseSerialGC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=summary -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+/*
+ * @test
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseG1GC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=summary -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+/*
+ * @test
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseShenandoahGC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=summary -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+import org.testng.annotations.Test;
+
+public class VitalsValuesSanityCheck {
+
+    final long M = 1024 * 1024;
+
+    // total size of what we will allocate from the cheap in the main function
+    final long cheapAllocationSize = 32 * M;
+    // individual block size, small enough to be guaranteed touched and counting toward rss
+    final long cheapAllocationBlockSize = 1024;
+    final long numCheapAllocations = cheapAllocationSize / cheapAllocationBlockSize;
+
+    private static long findHighestValueForColumn(CSVParser.CSV csv, String colname) {
+        int index = csv.header.findColumn(colname);
+        if (index == -1) {
+            throw new RuntimeException("column not found: "  + colname);
+        }
+        long l = 0;
+        int i = 0;
+        for (i = 0; i < csv.lines.length; i ++) {
+            CSVParser.CSVDataLine line = csv.lines[i];
+            long l2 = line.numberAt(index);
+            if (l2 > l) {
+                l = l2;
+            }
+        }
+        System.out.println("Found highest value for " + colname + " in line " + i + ": " + l);
+        return l;
+    }
+
+    public void run(CommandExecutor executor) {
+
+        try {
+
+            // We read the vitals in csv form and get the parsed output.
+            // The heap (64m) should show up as full committed. It is also touched, so it should contribute to RSS unless we swap
+            // The VM will have allocated 32M C-heap as well, in 1KB chunks. These should show up in NMT, in the cheap columns
+            // as well as in rss.
+            OutputAnalyzer output = executor.execute("VM.vitals csv raw");
+            VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+            output.shouldNotContain("Now"); // off by default
+            CSVParser.CSV csv = VitalsTestHelper.parseAndCheckCSV(output, true);
+
+            // Java heap
+            long highest_jvm_heap_comm = findHighestValueForColumn(csv, "jvm-heap-comm");
+            long highest_jvm_heap_used = findHighestValueForColumn(csv, "jvm-heap-used");
+            if (highest_jvm_heap_comm < (M * 58)) {
+                throw new RuntimeException("jvm-heap-comm too low");
+            }
+            if (highest_jvm_heap_comm > (M * 68)) {
+                throw new RuntimeException("jvm-heap-comm too high");
+            }
+            if (highest_jvm_heap_used <= 0 || highest_jvm_heap_used > highest_jvm_heap_comm) {
+                throw new RuntimeException("jvm-heap-used looks off");
+            }
+
+            // Class+nonclass metaspace
+            long highest_jvm_meta_comm = findHighestValueForColumn(csv, "jvm-meta-comm");
+            long highest_jvm_meta_used = findHighestValueForColumn(csv, "jvm-meta-used");
+            if (highest_jvm_meta_comm <= 0 || highest_jvm_meta_used <= 0 || highest_jvm_meta_used > highest_jvm_meta_comm) {
+                throw new RuntimeException("jvm-meta-comm or jvm-meta-used look off");
+            }
+
+            // Class space
+            if (Platform.is64bit()) {
+                long highest_jvm_meta_csc = findHighestValueForColumn(csv, "jvm-meta-csc");
+                long highest_jvm_meta_csu = findHighestValueForColumn(csv, "jvm-meta-csu");
+                // Class space size is contained within jvm-meta-comm, and non-class should be != 0
+                if (highest_jvm_meta_csc <= 0 || highest_jvm_meta_csc >= highest_jvm_meta_comm) {
+                    throw new RuntimeException("jvm-meta-csc looks off");
+                }
+                if (highest_jvm_meta_csu > highest_jvm_meta_csc) {
+                    throw new RuntimeException("jvm-meta-csu looks off");
+                }
+            }
+
+            // Code cache
+            long highest_jvm_code_cache = findHighestValueForColumn(csv, "jvm-code");
+            if (highest_jvm_code_cache <= 0) {
+                throw new RuntimeException("jvm-code looks off");
+            }
+
+            // NMT
+            long highest_jvm_nmt_mlc = findHighestValueForColumn(csv, "jvm-nmt-mlc");
+            long highest_jvm_nmt_map = findHighestValueForColumn(csv, "jvm-nmt-map");
+            // NMT mlc should contain all committed space done by malloc. We only know for sure that
+            // the heap is fully committed, and that we used some code cache. So it should show at least that.
+            if (highest_jvm_nmt_map < (highest_jvm_heap_comm + highest_jvm_code_cache)) {
+                throw new RuntimeException("jvm-nmt-map looks off");
+            }
+            // We malloced at least 64M, and the VM also uses some.
+            long expected_minimal_cheap_usage_jvm = 2 * M;
+            long expected_minimal_cheap_usage = cheapAllocationSize + expected_minimal_cheap_usage_jvm;
+            if (highest_jvm_nmt_mlc < expected_minimal_cheap_usage) {
+                throw new RuntimeException("jvm-nmt-mlc too low");
+            }
+            // ... but not much more than ten times that
+            if (highest_jvm_nmt_mlc > (expected_minimal_cheap_usage * 10)) {
+                throw new RuntimeException("jvm-nmt-mlc seems high");
+            }
+
+            // Number of jvm threads: we expect at least 4-5 in total, with at least one non-deamon thread (the one we run in right now)
+            long min_expected_java_threads = 5; // probably more
+            long max_expected_java_threads = 1000; // probably way less, but lets go with this.
+            long highest_jvm_jthr_num = findHighestValueForColumn(csv, "jvm-jthr-num");
+            long highest_jvm_jthr_nd = findHighestValueForColumn(csv, "jvm-jthr-nd");
+            if (highest_jvm_jthr_num < min_expected_java_threads || highest_jvm_jthr_num > max_expected_java_threads) {
+                throw new RuntimeException("jvm-jthr-num seems off");
+            }
+            if (highest_jvm_jthr_nd < 1 || highest_jvm_jthr_nd > highest_jvm_jthr_num) {
+                throw new RuntimeException("jvm-jthr-nd seems off");
+            }
+
+            // Classes:
+            long min_expected_classes_base = 300; // probably more
+            long max_expected_classes_base = 60000; // probably way less
+            long highest_jvm_cls_num = findHighestValueForColumn(csv, "jvm-cls-num");
+            if (highest_jvm_cls_num < min_expected_classes_base || highest_jvm_cls_num > max_expected_classes_base) {
+                throw new RuntimeException("jvm_cls_num seems off");
+            }
+            // We do not test highest_jvm_cls_ld and ul since those are delta cols and may not show in all samples
+
+            // Linux specific platform columns
+            if (Platform.isLinux()) {
+
+                // Check --- system --- cols on Linux
+
+                // Number of processes and kernel threads. In containers shows the local processes only. But we should have
+                // at least one, us, and multiple kernel threads, since we are multithreaded.
+                long min_expected_processes = 1;
+                long max_expected_processes = 1000000000; // Anything above a billion would surprise me
+                long min_expected_kernel_threads = min_expected_java_threads;
+                long max_expected_kernel_threads = 1000000000; // same here
+                long highest_proc_p = findHighestValueForColumn(csv, "syst-p");
+                long highest_proc_t = findHighestValueForColumn(csv, "syst-t");
+                if (highest_proc_p < min_expected_processes || highest_proc_p > max_expected_processes) {
+                    throw new RuntimeException("proc-p seems off");
+                }
+                if (highest_proc_t < min_expected_kernel_threads || highest_proc_t > max_expected_kernel_threads) {
+                    throw new RuntimeException("proc-t seems off");
+                }
+                if (highest_proc_p > highest_proc_t) {
+                    throw new RuntimeException("cannot have more processes than kernel threads");
+                }
+
+                // processes running, processes blocked.
+                long highest_proc_pr = findHighestValueForColumn(csv, "syst-pr");
+                long highest_proc_pb = findHighestValueForColumn(csv, "syst-pb");
+                if (highest_proc_pr > highest_proc_p || highest_proc_pb > highest_proc_p) {
+                    throw new RuntimeException("proc-p(r|b) seem off");
+                }
+                // Sum of running and blocked should be at least 1 since we are running
+                if (highest_proc_pr == 0 && highest_proc_pb == 0) {
+                    throw new RuntimeException("At least one process should show up (proc-p and proc-t both 0)");
+                }
+
+                // Cgroup
+                // We may not always show this. But if we do, at least the usage numbers should be checked
+                if (csv.header.findColumn("syst-cgro-usg") != -1) {
+                    if (findHighestValueForColumn(csv, "syst-cgro-usg") <= 0) {
+                        throw new RuntimeException("syst-cgro-usg seems off");
+                    }
+                }
+                if (csv.header.findColumn("syst-cgro-usgsw") != -1) {
+                    if (findHighestValueForColumn(csv, "syst-cgro-usgsw") <= 0) {
+                        throw new RuntimeException("syst-cgro-usgsw seems off");
+                    }
+                }
+                if (csv.header.findColumn("syst-cgro-kusg") != -1) {
+                    if (findHighestValueForColumn(csv, "syst-cgro-kusg") <= 0) {
+                        throw new RuntimeException("syst-cgro-kusg seems off");
+                    }
+                }
+
+                // Check --- process --- cols on Linux
+                long highest_proc_virt = findHighestValueForColumn(csv, "proc-virt");
+                long highest_proc_rss_all = findHighestValueForColumn(csv, "proc-rss-all");
+                long highest_proc_proc_swdo = findHighestValueForColumn(csv, "proc-swdo");
+                long highest_rss_plus_swap = highest_proc_rss_all + highest_proc_proc_swdo;
+                long min_expected_proc_virt = 128 * M; // probably way more
+                long max_expected_proc_virt = 128 * 1024 * M; // probably way less
+                long min_expected_proc_rss = expected_minimal_cheap_usage;   // since we touch the malloced 64*m, we should see at least that.
+                long max_expected_proc_rss = 8 * 1024 * M; // probably way less
+                if (highest_proc_virt < min_expected_proc_virt || highest_proc_virt > max_expected_proc_virt) {
+                    throw new RuntimeException("proc-virt seems off");
+                }
+                if (highest_rss_plus_swap < min_expected_proc_rss || highest_rss_plus_swap > max_expected_proc_rss) {
+                    throw new RuntimeException("proc-rss-all + swap seems off");
+                }
+                if (highest_rss_plus_swap > highest_proc_virt) {
+                    throw new RuntimeException("rss+swap cannot be larger than virt");
+                }
+
+                // -cheap--
+                // We know we allocated 64M, those should show up in the cheap used display
+                long highest_proc_chea_usd = findHighestValueForColumn(csv, "proc-chea-usd");
+                long highest_proc_chea_free = findHighestValueForColumn(csv, "proc-chea-free");
+                if (highest_proc_chea_usd < expected_minimal_cheap_usage) {
+                    throw new RuntimeException("proc-chea-usd seems low");
+                }
+                if (highest_proc_chea_usd > max_expected_proc_rss) {
+                    throw new RuntimeException("proc-chea-usd seems high");
+                }
+                if (highest_proc_chea_free < 0 || highest_proc_chea_free > max_expected_proc_rss) {
+                    throw new RuntimeException("proc-chea-free seems off");
+                }
+
+                // Number of open file descriptors
+                long highest_io_proc_of = findHighestValueForColumn(csv, "proc-io-of");
+                if (highest_io_proc_of < 0 || highest_io_proc_of > 1 * M) {
+                    throw new RuntimeException("proc-io-of seems off");
+                }
+
+                // Number of threads in this process (should be larger than java threads, but lets go with at least equal to)
+                long highest_proc_thr = findHighestValueForColumn(csv, "proc-thr");
+                if (highest_proc_thr < highest_jvm_jthr_num || highest_proc_thr > 1 * M) {
+                    throw new RuntimeException("proc-thr seems off");
+                }
+
+            } // end: linux specific sanity tests
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void jmx() {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        for (int i = 0; i < numCheapAllocations; i ++) {
+            long p = wb.NMTMalloc(cheapAllocationBlockSize);
+        }
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        run(new JMXExecutor());
+    }
+
+}


### PR DESCRIPTION
This patch adds cgroup information to the SapMachine Vitals.

We now print limits (memory, mem+swap, kernel mem) and usage (user space, kernel usage).

Note: we omit this information if the VM is assigned to the root cgroup memory controller. This is because in that case, no limits can be established, so printing out the cgroup info is kind of pointless and should closely resemble whatever is in `/proc/meminfo` anyway.

Also note that since most modern Linux distros use systemd, and systemd has its own memory controller, in almost all cases we will actually see the cgroup information.

Looks like this (in this example, docker was run with -m 8G, and it establishes a memory limit of 8g and - apparently - a mem+swap limit of 16g):

```
     cgroup-lim: cgroup memory limit
     cgroup-limsw: cgroup memory+swap limit
     cgroup-slim: cgroup memory soft limit
     cgroup-usg: cgroup memory usage
     cgroup-usgsw: cgroup memory+swap usage
     cgroup-kusg: cgroup kernel memory usage
```

```
------------cgroup------------
lim  limsw slim usg usgsw kusg
8.0g 16.0g      67m   67m   2m
8.0g 16.0g      67m   67m   2m
8.0g 16.0g      32m   32m   2m
8.0g 16.0g      19m   19m   2m
```

This PR also contains a large test addition. I added tests to better check the Vitals values for validity.


fixes #1124

