### PR TITLE
SapMachine #1124: Vitals: June 22 package (SapMachine 18)

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -82,6 +82,36 @@
           "resulting in file-backed shared mappings of the process to " \
           "be dumped into the corefile.")                               \
                                                                         \
+  /* SapMachine 2022-05-01: HiMemReport */                              \
+  product(bool, HiMemReport, false,                                     \
+         "VM writes a high memory report and optionally execute "       \
+         "additional jcmds if its rss+swap reaches 66%, 75% or 90% of " \
+         "a maximum. If the VM is containerized, that maximum is the "  \
+         "container memory limit at VM start. If the VM is not "        \
+         "containerized, that maximum is half of the total physical "   \
+         "memory. The maximum can be overridden with "                  \
+         "-XX:HiMemReportMaximum=<size>. Per default, the report is "   \
+         "printed to stderr. If HiMemReportDir is specified, that "     \
+         "report is redirected to \"<report directory>/"                \
+         "<sapmachine_himemalert>_pid<pid>_<timestamp>.log\".")         \
+  product(size_t, HiMemReportMax, 0,                                    \
+         "Overrides the maximum reference size for HiMemReport.")       \
+  product(ccstr, HiMemReportDir, NULL,                                  \
+         "Specifies a directory into which reports are written. Gets "  \
+         "created (one level only) if it does not exist.")              \
+  product(ccstr, HiMemReportExec, NULL,                                 \
+         "Specifies one or more jcmds to be executed after a high "     \
+         "memory report has been written. Multiple commands are "       \
+         "separated by ';'. Command output is written to stderr. If "   \
+         "HiMemReportDir is specified, command output is redirected to " \
+         "\"<report directory>/<command>_pid<pid>_timestamp.(out|err)\"." \
+         "If one of the commands is \"GC.heap_dump\" and its "         \
+         "arguments are omitted, the heap dump is written as "         \
+         "\"GC.heap_dump_pid<pid>_timestamp\" to either report "       \
+         "directory or current directory if HiMemReportDir is "        \
+         "omitted.\n"                                                  \
+         "Example: \"-XX:HiMemReportExec=GC.class_histogram -all;GC.heap_dump\"") \
+                                                                        \
   product(bool, UseCpuAllocPath, false, DIAGNOSTIC,                     \
           "Use CPU_ALLOC code path in os::active_processor_count ")     \
                                                                         \

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -36,6 +36,24 @@ bool  OSContainer::_is_initialized   = false;
 bool  OSContainer::_is_containerized = false;
 CgroupSubsystem* cgroup_subsystem;
 
+// SapMachine 2022-05-01 Vitals
+// This is an ugly hack aimed at having as little merge surface as possible across JDK versions.
+// We use the OsContainer class just for its ability to figure out the controller path; we expose
+// that and read the data ourselves (since OsContainer omits certain data and does things I don't
+// want to happen in the Vitals sampler thread).
+extern const char* sapmachine_get_memory_controller_path() {
+  if (cgroup_subsystem != NULL) {
+    CachingCgroupController* cc = cgroup_subsystem->memory_controller();
+    if (cc != NULL) {
+      CgroupController* c = cc->controller();
+      if (c != NULL) {
+        return c->subsystem_path();
+      }
+    }
+  }
+  return NULL;
+}
+
 /* init
  *
  * Initialize the container support and determine if

--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -26,6 +26,9 @@
 
 #include "precompiled.hpp"
 #include "jvm_io.h"
+#include "osContainer_linux.hpp"
+#include "vitals_linux_oswrapper.hpp"
+#include "logging/log.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
@@ -33,110 +36,7 @@
 #include "utilities/ostream.hpp"
 #include "vitals/vitals_internals.hpp"
 
-#include <malloc.h>
-#include <fcntl.h>
-#include <string.h>
-#include <errno.h>
-
 namespace sapmachine_vitals {
-
-class ProcFile {
-  char* _buf;
-
-  // To keep the code simple, I just use a fixed sized buffer.
-  enum { bufsize = 64*K };
-
-public:
-
-  ProcFile() : _buf(NULL) {
-    _buf = (char*)os::malloc(bufsize, mtInternal);
-  }
-
-  ~ProcFile () {
-    os::free(_buf);
-  }
-
-  bool read(const char* filename) {
-
-    FILE* f = ::fopen(filename, "r");
-    if (f == NULL) {
-      return false;
-    }
-
-    size_t bytes_read = ::fread(_buf, 1, bufsize, f);
-    _buf[bufsize - 1] = '\0';
-
-    ::fclose(f);
-
-    return bytes_read > 0 && bytes_read < bufsize;
-  }
-
-  const char* text() const { return _buf; }
-
-  const char* get_prefixed_line(const char* prefix) const {
-    return ::strstr(_buf, prefix);
-  }
-
-  value_t parsed_prefixed_value(const char* prefix, size_t scale = 1) const {
-    value_t value = INVALID_VALUE;
-    const char* const s = get_prefixed_line(prefix);
-    if (s != NULL) {
-      errno = 0;
-      const char* p = s + ::strlen(prefix);
-      char* endptr = NULL;
-      value = (value_t)::strtoll(p, &endptr, 10);
-      if (p == endptr || errno != 0) {
-        value = INVALID_VALUE;
-      } else {
-        value *= scale;
-      }
-    }
-    return value;
-  }
-
-};
-
-struct cpu_values_t {
-  value_t user;
-  value_t nice;
-  value_t system;
-  value_t idle;
-  value_t iowait;
-  value_t steal;
-  value_t guest;
-  value_t guest_nice;
-};
-
-void parse_proc_stat_cpu_line(const char* line, cpu_values_t* out) {
-  // Note: existence of some of these values depends on kernel version
-  out->user = out->nice = out->system = out->idle = out->iowait = out->steal = out->guest = out->guest_nice =
-      INVALID_VALUE;
-  uint64_t user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice;
-  int num = ::sscanf(line,
-      "cpu "
-      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " "
-      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " ",
-      &user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal, &guest, &guest_nice);
-  if (num >= 4) {
-    out->user = user;
-    out->nice = nice;
-    out->system = system;
-    out->idle = idle;
-    if (num >= 5) { // iowait (5) (since Linux 2.5.41)
-      out->iowait = iowait;
-      if (num >= 8) { // steal (8) (since Linux 2.6.11)
-        out->steal = steal;
-        if (num >= 9) { // guest (9) (since Linux 2.6.24)
-          out->guest = guest;
-          if (num >= 10) { // guest (9) (since Linux 2.6.33)
-            out->guest_nice = guest_nice;
-          }
-        }
-      }
-    }
-  }
-}
-
 
 /////// Columns ////////
 
@@ -185,7 +85,7 @@ class CPUTimeColumn: public Column {
 
 public:
   CPUTimeColumn(const char* category, const char* header, const char* name, const char* description)
-    : Column(category, header, name, description, true)
+    : Column(category, header, name, description)
   {
     _clk_tck = ::sysconf(_SC_CLK_TCK);
     _num_cores = os::active_processor_count();
@@ -207,6 +107,12 @@ static Column* g_col_system_num_threads = NULL;
 static Column* g_col_system_num_procs_running = NULL;
 static Column* g_col_system_num_procs_blocked = NULL;
 
+static bool g_show_cgroup_info = false;
+static Column* g_col_system_cgrp_limit_in_bytes = NULL;
+static Column* g_col_system_cgrp_soft_limit_in_bytes = NULL;
+static Column* g_col_system_cgrp_usage_in_bytes = NULL;
+static Column* g_col_system_cgrp_kmem_usage_in_bytes = NULL;
+
 static Column* g_col_system_cpu_user = NULL;
 static Column* g_col_system_cpu_system = NULL;
 static Column* g_col_system_cpu_idle = NULL;
@@ -214,11 +120,15 @@ static Column* g_col_system_cpu_steal = NULL;
 static Column* g_col_system_cpu_guest = NULL;
 
 static Column* g_col_process_virt = NULL;
+
+static bool g_show_rss_detail_info = false;
 static Column* g_col_process_rss = NULL;
 static Column* g_col_process_rssanon = NULL;
 static Column* g_col_process_rssfile = NULL;
 static Column* g_col_process_rssshmem = NULL;
+
 static Column* g_col_process_swapped_out = NULL;
+
 static Column* g_col_process_chp_used = NULL;
 static Column* g_col_process_chp_free = NULL;
 
@@ -231,96 +141,114 @@ static Column* g_col_process_io_bytes_written = NULL;
 
 static Column* g_col_process_num_threads = NULL;
 
-
-// Try to obtain mallinfo2. That replacement of mallinf is 64-bit capable and its values won't wrap.
-// Only exists in glibc 2.33 and later.
-#ifdef __GLIBC__
-struct glibc_mallinfo2 {
-  size_t arena;
-  size_t ordblks;
-  size_t smblks;
-  size_t hblks;
-  size_t hblkhd;
-  size_t usmblks;
-  size_t fsmblks;
-  size_t uordblks;
-  size_t fordblks;
-  size_t keepcost;
-};
-typedef struct glibc_mallinfo2 (*mallinfo2_func_t)(void);
-static mallinfo2_func_t g_mallinfo2 = NULL;
-static void mallinfo2_init() {
-  g_mallinfo2 = CAST_TO_FN_PTR(mallinfo2_func_t, dlsym(RTLD_DEFAULT, "mallinfo2"));
-}
-#endif // __GLIBC__
-
 bool platform_columns_initialize() {
 
-  // Order matters!
+  const char* const system_cat = "system";
+  const char* const process_cat = "process";
 
-  g_col_system_memavail = new MemorySizeColumn("system", NULL, "avail", "Memory available without swapping");
-  g_col_system_memcommitted = new MemorySizeColumn("system", NULL, "comm", "Committed memory");
-  g_col_system_memcommitted_ratio = new PlainValueColumn("system", NULL, "crt", "Committed-to-Commit-Limit ratio (percent)");
-  g_col_system_swap = new MemorySizeColumn("system", NULL, "swap", "Swap space used");
+  Legend::the_legend()->add_footnote("   [host]: values are host-global (not containerized).");
+  Legend::the_legend()->add_footnote("   [cgrp]: if containerized or running in systemd slice");
+  Legend::the_legend()->add_footnote("    [krn]: depends on kernel version");
+  Legend::the_legend()->add_footnote("   [glibc]: only shown for glibc-based distros");
 
-  g_col_system_pages_swapped_in = new DeltaValueColumn("system", NULL, "si", "Number of pages swapped in");
-  g_col_system_pages_swapped_out = new DeltaValueColumn("system", NULL, "so", "Number of pages pages swapped out");
+  // Update values once, to get up-to-date readings. Some of those we need to decide whether to show or hide certain columns
+  OSWrapper::initialize();
+  OSWrapper::update_if_needed();
 
-  g_col_system_num_procs = new PlainValueColumn("system", NULL, "p", "Number of processes");
-  g_col_system_num_threads = new PlainValueColumn("system", NULL, "t", "Number of threads");
+  g_col_system_memavail =
+      define_column<MemorySizeColumn>(system_cat, NULL, "avail", "Memory available without swapping [host]", true);
+  g_col_system_memcommitted =
+      define_column<MemorySizeColumn>(system_cat, NULL, "comm", "Committed memory [host]", true);
+  g_col_system_memcommitted_ratio =
+      define_column<PlainValueColumn>(system_cat, NULL, "crt", "Committed-to-Commit-Limit ratio (percent) [host]", true);
+  g_col_system_swap =
+      define_column<MemorySizeColumn>(system_cat, NULL, "swap", "Swap space used [host]", true);
 
-  g_col_system_num_procs_running = new PlainValueColumn("system", NULL, "pr", "Number of processes running");
-  g_col_system_num_procs_blocked = new PlainValueColumn("system", NULL, "pb", "Number of processes blocked");
+  g_col_system_pages_swapped_in =
+      define_column<DeltaValueColumn>(system_cat, NULL, "si", "Number of pages swapped in [host] [delta]", true);
+  g_col_system_pages_swapped_out =
+      define_column<DeltaValueColumn>(system_cat, NULL, "so", "Number of pages pages swapped out [host] [delta]", true);
 
-  g_col_system_cpu_user =     new CPUTimeColumn("system", "cpu", "us", "Global cpu user time");
-  g_col_system_cpu_system =   new CPUTimeColumn("system", "cpu", "sy", "Global cpu system time");
-  g_col_system_cpu_idle =     new CPUTimeColumn("system", "cpu", "id", "Global cpu idle time");
-  g_col_system_cpu_steal =    new CPUTimeColumn("system", "cpu", "st", "Global cpu time stolen");
-  g_col_system_cpu_guest =    new CPUTimeColumn("system", "cpu", "gu", "Global cpu time spent on guest");
+  g_col_system_num_procs =
+      define_column<PlainValueColumn>(system_cat, NULL, "p", "Number of processes", true);
+  g_col_system_num_threads =
+      define_column<PlainValueColumn>(system_cat, NULL, "t", "Number of threads", true);
 
-  g_col_process_virt = new MemorySizeColumn("process", NULL, "virt", "Virtual size");
+  g_col_system_num_procs_running =
+      define_column<PlainValueColumn>(system_cat, NULL, "tr", "Number of threads running", true);
+  g_col_system_num_procs_blocked =
+      define_column<PlainValueColumn>(system_cat, NULL, "tb", "Number of threads blocked on disk IO", true);
 
-  bool have_rss_detail_info = false;
-  {
-    ProcFile bf;
-    if (bf.read("/proc/self/status")) {
-      have_rss_detail_info = bf.parsed_prefixed_value("RssAnon:", 1) != INVALID_VALUE;
-    }
-  }
-  if (have_rss_detail_info) {
-    // Linux 4.5 ++
-    g_col_process_rss = new MemorySizeColumn("process", "rss", "all", "Resident set size, total");
-    g_col_process_rssanon = new MemorySizeColumn("process", "rss", "anon", "Resident set size, anonymous memory (>=4.5)");
-    g_col_process_rssfile = new MemorySizeColumn("process", "rss", "file", "Resident set size, file mappings (>=4.5)");
-    g_col_process_rssshmem = new MemorySizeColumn("process", "rss", "shm", "Resident set size, shared memory (>=4.5)");
-  } else {
-    g_col_process_rss = new MemorySizeColumn("process", NULL, "rss", "Resident set size, total");
-  }
+  g_col_system_cpu_user =
+      define_column<CPUTimeColumn>(system_cat, "cpu", "us", "CPU user time [host]", true);
+  g_col_system_cpu_system =
+      define_column<CPUTimeColumn>(system_cat, "cpu", "sy", "CPU system time [host]", true);
+  g_col_system_cpu_idle =
+        define_column<CPUTimeColumn>(system_cat, "cpu", "id", "CPU idle time [host]", true);
+  g_col_system_cpu_steal =
+        define_column<CPUTimeColumn>(system_cat, "cpu", "st", "CPU time stolen [host]", true);
+  g_col_system_cpu_guest =
+        define_column<CPUTimeColumn>(system_cat, "cpu", "gu", "CPU time spent on guest [host]", true);
 
-  g_col_process_swapped_out = new MemorySizeColumn("process", NULL, "swdo", "Memory swapped out");
+  // I show cgroup information if the container layer thinks we are containerized OR we have limits established
+  // (which should come out as the same, but you never know
+  g_show_cgroup_info = OSContainer::is_containerized() || (OSWrapper::syst_cgro_lim() != INVALID_VALUE || OSWrapper::syst_cgro_limsw() != INVALID_VALUE);
+  g_col_system_cgrp_limit_in_bytes =
+        define_column<MemorySizeColumn>(system_cat, "cgroup", "lim", "cgroup memory limit [cgrp]", g_show_cgroup_info);
+  g_col_system_cgrp_soft_limit_in_bytes =
+        define_column<MemorySizeColumn>(system_cat, "cgroup", "slim", "cgroup memory soft limit [cgrp]", g_show_cgroup_info);
+  g_col_system_cgrp_usage_in_bytes =
+        define_column<MemorySizeColumn>(system_cat, "cgroup", "usg", "cgroup memory usage [cgrp]", g_show_cgroup_info);
+  g_col_system_cgrp_kmem_usage_in_bytes =
+        define_column<MemorySizeColumn>(system_cat, "cgroup", "kusg", "cgroup kernel memory usage (cgroup v1 only) [cgrp]", g_show_cgroup_info);
 
+  // Process
+
+  g_col_process_virt =
+    define_column<MemorySizeColumn>(process_cat, NULL, "virt", "Virtual size", true);
+
+  // RSS detail needs kernel >= 4.5
+  g_show_rss_detail_info = OSWrapper::proc_rss_anon() != INVALID_VALUE;
+  g_col_process_rss =
+      define_column<MemorySizeColumn>(process_cat, "rss", "all", "Resident set size, total", true);
+  g_col_process_rssanon =
+      define_column<MemorySizeColumn>(process_cat, "rss", "anon", "Resident set size, anonymous memory [krn]", g_show_rss_detail_info);
+  g_col_process_rssfile =
+      define_column<MemorySizeColumn>(process_cat, "rss", "file", "Resident set size, file mappings [krn]", g_show_rss_detail_info);
+  g_col_process_rssshmem =
+      define_column<MemorySizeColumn>(process_cat, "rss", "shm", "Resident set size, shared memory [krn]", g_show_rss_detail_info);
+
+  g_col_process_swapped_out =
+      define_column<MemorySizeColumn>(process_cat, NULL, "swdo", "Memory swapped out", true);
+
+  // glibc heap info depends on, obviously, glibc.
 #ifdef __GLIBC__
-  mallinfo2_init();
-  g_col_process_chp_used = new MemorySizeColumn("process", "cheap", "usd",
-      g_mallinfo2 != NULL ? "C-Heap, in-use allocations" :
-                            "C-Heap, in-use allocations (unavailable if RSS > 4G)");
-  g_col_process_chp_free = new MemorySizeColumn("process", "cheap", "free",
-      g_mallinfo2 != NULL ? "C-Heap, bytes in free blocks" :
-                            "C-Heap, bytes in free blocks (unavailable if RSS > 4G)");
-#endif // __GLIBC__
+  const bool show_glibc_heap_info = true;
+#else
+  const bool show_glibc_heap_info = false;
+#endif
+  g_col_process_chp_used =
+      define_column<MemorySizeColumn>(process_cat, "cheap", "usd", "C-Heap, in-use allocations (may be unavailable if RSS > 4G) [glibc]", show_glibc_heap_info);
+  g_col_process_chp_free =
+      define_column<MemorySizeColumn>(process_cat, "cheap", "free", "C-Heap, bytes in free blocks (may be unavailable if RSS > 4G) [glibc]", show_glibc_heap_info);
 
-  g_col_process_cpu_user = new CPUTimeColumn("process", "cpu", "us", "Process cpu user time");
+  g_col_process_cpu_user =
+      define_column<CPUTimeColumn>(process_cat, "cpu", "us", "Process cpu user time", true);
 
-  g_col_process_cpu_system = new CPUTimeColumn("process", "cpu", "sy", "Process cpu system time");
+  g_col_process_cpu_system =
+    define_column<CPUTimeColumn>(process_cat, "cpu", "sy", "Process cpu system time", true);
 
-  g_col_process_num_of = new PlainValueColumn("process", "io", "of", "Number of open files");
+  g_col_process_num_of =
+      define_column<PlainValueColumn>(process_cat, "io", "of", "Number of open files", true);
 
-  g_col_process_io_bytes_read = new DeltaMemorySizeColumn("process", "io", "rd", "IO bytes read from storage or cache");
+  g_col_process_io_bytes_read =
+    define_column<DeltaMemorySizeColumn>(process_cat, "io", "rd", "IO bytes read from storage or cache", true);
 
-  g_col_process_io_bytes_written = new DeltaMemorySizeColumn("process", "io", "wr", "IO bytes written");
+  g_col_process_io_bytes_written =
+      define_column<DeltaMemorySizeColumn>(process_cat, "io", "wr", "IO bytes written", true);
 
-  g_col_process_num_threads = new PlainValueColumn("process", NULL, "thr", "Number of native threads");
-
+  g_col_process_num_threads =
+      define_column<PlainValueColumn>(process_cat, NULL, "thr", "Number of native threads", true);
 
   return true;
 }
@@ -332,179 +260,65 @@ static void set_value_in_sample(Column* col, Sample* sample, value_t val) {
   }
 }
 
-// Helper function, returns true if string is a numerical id
-static bool is_numerical_id(const char* s) {
-  const char* p = s;
-  while(*p >= '0' && *p <= '9') {
-    p ++;
-  }
-  return *p == '\0' ? true : false;
-}
-
 void sample_platform_values(Sample* sample) {
 
   int idx = 0;
-  value_t v = 0;
 
-  value_t rss_all = 0;
+  OSWrapper::update_if_needed();
 
-  ProcFile bf;
-  if (bf.read("/proc/meminfo")) {
+  set_value_in_sample(g_col_system_memavail, sample, OSWrapper::syst_avail());
+  set_value_in_sample(g_col_system_swap, sample, OSWrapper::syst_swap());
 
-    // All values in /proc/meminfo are in KB
-    const size_t scale = K;
+  set_value_in_sample(g_col_system_memcommitted, sample, OSWrapper::syst_comm());
+  set_value_in_sample(g_col_system_memcommitted_ratio, sample, OSWrapper::syst_crt());
 
-    set_value_in_sample(g_col_system_memavail, sample,
-        bf.parsed_prefixed_value("MemAvailable:", scale));
+  set_value_in_sample(g_col_system_pages_swapped_in, sample, OSWrapper::syst_si());
+  set_value_in_sample(g_col_system_pages_swapped_out, sample, OSWrapper::syst_so());
 
-    value_t swap_total = bf.parsed_prefixed_value("SwapTotal:", scale);
-    value_t swap_free = bf.parsed_prefixed_value("SwapFree:", scale);
-    if (swap_total != INVALID_VALUE && swap_free != INVALID_VALUE) {
-      set_value_in_sample(g_col_system_swap, sample, swap_total - swap_free);
-    }
+  set_value_in_sample(g_col_system_cpu_user, sample, OSWrapper::syst_cpu_us());
+  set_value_in_sample(g_col_system_cpu_system, sample, OSWrapper::syst_cpu_sy());
+  set_value_in_sample(g_col_system_cpu_idle, sample, OSWrapper::syst_cpu_id());
+  set_value_in_sample(g_col_system_cpu_steal, sample, OSWrapper::syst_cpu_st());
+  set_value_in_sample(g_col_system_cpu_guest, sample, OSWrapper::syst_cpu_gu());
 
-    // Calc committed ratio. Values > 100% indicate overcommitment.
-    value_t commitlimit = bf.parsed_prefixed_value("CommitLimit:", scale);
-    value_t committed = bf.parsed_prefixed_value("Committed_AS:", scale);
-    if (commitlimit != INVALID_VALUE && commitlimit != 0 && committed != INVALID_VALUE) {
-      set_value_in_sample(g_col_system_memcommitted, sample, committed);
-      value_t ratio = (committed * 100) / commitlimit;
-      set_value_in_sample(g_col_system_memcommitted_ratio, sample, ratio);
-    }
+  set_value_in_sample(g_col_system_num_procs_running, sample, OSWrapper::syst_tr());
+  set_value_in_sample(g_col_system_num_procs_blocked, sample, OSWrapper::syst_tb());
+
+  // cgroups business
+  if (g_show_cgroup_info) {
+    set_value_in_sample(g_col_system_cgrp_usage_in_bytes, sample, OSWrapper::syst_cgro_usg());
+    // set_value_in_sample(g_col_system_cgrp_memsw_usage_in_bytes, sample, OSWrapper::syst_cgro_usgsw());
+    set_value_in_sample(g_col_system_cgrp_kmem_usage_in_bytes, sample, OSWrapper::syst_cgro_kusg());
+    set_value_in_sample(g_col_system_cgrp_limit_in_bytes, sample, OSWrapper::syst_cgro_lim());
+    set_value_in_sample(g_col_system_cgrp_soft_limit_in_bytes, sample, OSWrapper::syst_cgro_slim());
+    // set_value_in_sample(g_col_system_cgrp_memsw_limit_in_bytes, sample, OSWrapper::syst_cgro_limsw());
   }
 
-  if (bf.read("/proc/vmstat")) {
-    set_value_in_sample(g_col_system_pages_swapped_in, sample, bf.parsed_prefixed_value("pswpin"));
-    set_value_in_sample(g_col_system_pages_swapped_out, sample, bf.parsed_prefixed_value("pswpout"));
+  set_value_in_sample(g_col_system_num_procs, sample, OSWrapper::syst_p());
+  set_value_in_sample(g_col_system_num_threads, sample, OSWrapper::syst_t());
+
+  set_value_in_sample(g_col_process_virt, sample, OSWrapper::proc_virt());
+  set_value_in_sample(g_col_process_swapped_out, sample, OSWrapper::proc_swdo());
+  set_value_in_sample(g_col_process_rss, sample, OSWrapper::proc_rss_all());
+
+  if (g_show_rss_detail_info) {
+    set_value_in_sample(g_col_process_rssanon, sample, OSWrapper::proc_rss_anon());
+    set_value_in_sample(g_col_process_rssfile, sample, OSWrapper::proc_rss_file());
+    set_value_in_sample(g_col_process_rssshmem, sample, OSWrapper::proc_rss_shm());
   }
 
-  if (bf.read("/proc/stat")) {
-    // Read and parse global cpu values
-    cpu_values_t values;
-    const char* line = bf.get_prefixed_line("cpu");
-    parse_proc_stat_cpu_line(line, &values);
+  set_value_in_sample(g_col_process_num_threads, sample, OSWrapper::proc_thr());
+  set_value_in_sample(g_col_process_num_of, sample, OSWrapper::proc_io_of());
 
-    set_value_in_sample(g_col_system_cpu_user, sample, values.user + values.nice);
-    set_value_in_sample(g_col_system_cpu_system, sample, values.system);
-    set_value_in_sample(g_col_system_cpu_idle, sample, values.idle);
-    set_value_in_sample(g_col_system_cpu_steal, sample, values.steal);
-    set_value_in_sample(g_col_system_cpu_guest, sample, values.guest + values.guest_nice);
+  set_value_in_sample(g_col_process_io_bytes_read, sample, OSWrapper::proc_io_rd());
+  set_value_in_sample(g_col_process_io_bytes_written, sample, OSWrapper::proc_io_wr());
 
-    set_value_in_sample(g_col_system_num_procs_running, sample,
-        bf.parsed_prefixed_value("procs_running"));
-    set_value_in_sample(g_col_system_num_procs_blocked, sample,
-        bf.parsed_prefixed_value("procs_blocked"));
-  }
-
-  if (bf.read("/proc/self/status")) {
-
-    set_value_in_sample(g_col_process_virt, sample, bf.parsed_prefixed_value("VmSize:", K));
-    set_value_in_sample(g_col_process_swapped_out, sample, bf.parsed_prefixed_value("VmSwap:", K));
-    rss_all = bf.parsed_prefixed_value("VmRSS:", K);
-    set_value_in_sample(g_col_process_rss, sample, rss_all);
-
-    set_value_in_sample(g_col_process_rssanon, sample, bf.parsed_prefixed_value("RssAnon:", K));
-    set_value_in_sample(g_col_process_rssfile, sample, bf.parsed_prefixed_value("RssFile:", K));
-    set_value_in_sample(g_col_process_rssshmem, sample, bf.parsed_prefixed_value("RssShmem:", K));
-
-    set_value_in_sample(g_col_process_num_threads, sample,
-        bf.parsed_prefixed_value("Threads:"));
-
-  }
-
-  // Number of open files: iterate over /proc/self/fd and count.
-  {
-    DIR* d = ::opendir("/proc/self/fd");
-    if (d != NULL) {
-      value_t v = 0;
-      struct dirent* en = NULL;
-      do {
-        en = ::readdir(d);
-        if (en != NULL) {
-          if (::strcmp(".", en->d_name) == 0 || ::strcmp("..", en->d_name) == 0 ||
-              ::strcmp("0", en->d_name) == 0 || ::strcmp("1", en->d_name) == 0 || ::strcmp("2", en->d_name) == 0) {
-            // omit
-          } else {
-            v ++;
-          }
-        }
-      } while(en != NULL);
-      ::closedir(d);
-      set_value_in_sample(g_col_process_num_of, sample, v);
-    }
-  }
-
-  // Number of processes: iterate over /proc/<pid> and count.
-  // Number of threads: read "num_threads" from /proc/<pid>/stat
-  {
-    DIR* d = ::opendir("/proc");
-    if (d != NULL) {
-      value_t v_p = 0;
-      value_t v_t = 0;
-      struct dirent* en = NULL;
-      do {
-        en = ::readdir(d);
-        if (en != NULL) {
-          if (is_numerical_id(en->d_name)) {
-            v_p ++;
-            char tmp[128];
-            jio_snprintf(tmp, sizeof(tmp), "/proc/%s/stat", en->d_name);
-            if (bf.read(tmp)) {
-              const char* text = bf.text();
-              // See man proc(5)
-              // (20) num_threads  %ld
-              long num_threads = 0;
-              ::sscanf(text, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %*u %*u %*d %*d %*d %*d %ld", &num_threads);
-              v_t += num_threads;
-            }
-          }
-        }
-      } while(en != NULL);
-      ::closedir(d);
-      set_value_in_sample(g_col_system_num_procs, sample, v_p);
-      set_value_in_sample(g_col_system_num_threads, sample, v_t);
-    }
-  }
-
-  if (bf.read("/proc/self/io")) {
-    set_value_in_sample(g_col_process_io_bytes_read, sample,
-        bf.parsed_prefixed_value("rchar:"));
-    set_value_in_sample(g_col_process_io_bytes_written, sample,
-        bf.parsed_prefixed_value("wchar:"));
-  }
-
-  if (bf.read("/proc/self/stat")) {
-    const char* text = bf.text();
-    // See man proc(5)
-    // (14) utime  %lu
-    // (15) stime  %lu
-    long unsigned cpu_utime = 0;
-    long unsigned cpu_stime = 0;
-    ::sscanf(text, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu", &cpu_utime, &cpu_stime);
-    set_value_in_sample(g_col_process_cpu_user, sample, cpu_utime);
-    set_value_in_sample(g_col_process_cpu_system, sample, cpu_stime);
-  }
+  set_value_in_sample(g_col_process_cpu_user, sample, OSWrapper::proc_cpu_us());
+  set_value_in_sample(g_col_process_cpu_system, sample, OSWrapper::proc_cpu_sy());
 
 #ifdef __GLIBC__
-  // Collect some c-heap info using either one of mallinfo or mallinfo2.
-  if (g_mallinfo2 != NULL) {
-    struct glibc_mallinfo2 mi = g_mallinfo2();
-    // (from experiments and glibc source code reading: the closest to "used" would be adding the mmaped data area size
-    //  (contains large allocations) to the small block sizes
-    set_value_in_sample(g_col_process_chp_used, sample, mi.uordblks + mi.hblkhd);
-    set_value_in_sample(g_col_process_chp_free, sample, mi.fordblks);
-  } else {
-    struct mallinfo mi = mallinfo();
-    set_value_in_sample(g_col_process_chp_used, sample, (size_t)(unsigned)mi.uordblks + (size_t)(unsigned)mi.hblkhd);
-    set_value_in_sample(g_col_process_chp_free, sample, (size_t)(unsigned)mi.fordblks);
-    // In 64-bit mode, omit printing values if we could conceivably have wrapped, since they are misleading.
-#ifdef _LP64
-    if (rss_all >= 4 * G) {
-      set_value_in_sample(g_col_process_chp_used, sample, INVALID_VALUE);
-      set_value_in_sample(g_col_process_chp_free, sample, INVALID_VALUE);
-    }
-#endif
-  }
+  set_value_in_sample(g_col_process_chp_used, sample, OSWrapper::proc_chea_usd());
+  set_value_in_sample(g_col_process_chp_free, sample, OSWrapper::proc_chea_free());
 #endif // __GLIBC__
 
 } // end: sample_platform_values

--- a/src/hotspot/os/linux/vitals_linux_himemreport.cpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.cpp
@@ -1,0 +1,925 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "jvm_io.h"
+#include "vitals_linux_himemreport.hpp"
+#include "vitals_linux_oswrapper.hpp"
+#include "logging/log.hpp"
+#include "memory/allStatic.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/globals_extension.hpp"
+#include "runtime/os.hpp"
+#include "runtime/vmOperations.hpp"
+#include "runtime/vmThread.hpp"
+#include "runtime/vm_version.hpp"
+#include "services/memBaseline.hpp"
+#include "services/memReporter.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+#include "vitals/vitals_internals.hpp"
+
+#include <unistd.h>
+#include <spawn.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+// Logging and output:
+// We log during initialization phase to UL using the "vitals" tag.
+// In the high memory detection thread itself, when triggering the report, we write strictly to
+// stderr, directly. We don't use tty since we want to bypass ttylock. Sub command output also
+// gets written to stderr.
+
+// We print to the stderr stream directly in this code (since we want to bypass ttylock)
+static fdStream stderr_stream(2);
+
+namespace sapmachine_vitals {
+
+static const int HiMemReportDecaySeconds = 60 * 5;
+
+//////////// pretty printing stuff //////////////////////////////////
+
+#define STRFTIME_FROM_TIME_T(st, fmt, t)                    \
+  char buf[32];                                             \
+  struct tm timeinfo;                                       \
+  if (::localtime_r(&t, &timeinfo) != NULL &&               \
+      ::strftime(buf, sizeof(buf), fmt, &timeinfo) != 0) {  \
+    st->print_raw(buf);                                     \
+  } else {                                                  \
+    st->print_raw("unknown_date");                          \
+  }
+
+
+static void print_date_and_time(outputStream *st, time_t t) {
+  STRFTIME_FROM_TIME_T(st, "%F %T", t);
+}
+
+// For use in file names
+static void print_date_and_time_underscored(outputStream *st, time_t t) {
+  STRFTIME_FROM_TIME_T(st, "%Y_%m_%d_%H_%M_%S", t);
+}
+
+static void print_current_date_and_time(outputStream *st) {
+  time_t t;
+  time(&t);
+  print_date_and_time(st, t);
+}
+
+//////////// Alert state ////////////////////////////////////////////
+
+class AlertState : public CHeapObj<mtInternal> {
+
+  // this is 100%
+  const size_t _maximum;
+
+  // Alert percentages per level
+  static const int _alvl_perc[5];
+
+  // alert level: 0: all is well, 1..6: we are at x percent
+  int _alvl;
+
+  // time when alert level was increased last (for decay)
+  time_t _last_avlv_increase;
+
+  // We count spikes. A spike is a single increase to at least the lowest
+  // alert level, followed by a reset because we recovered.
+  int _spike_no;
+
+  int calc_percentage(size_t size) const {
+    return (int)((100.0f * (double)size)/(double)_maximum);
+  }
+
+  int calc_alvl(int percentage) const {
+    int i = 0;
+    while ((_alvl_perc[i + 1] != -1) && (_alvl_perc[i + 1] <= percentage)) {
+      i ++;
+    }
+    return i;
+  }
+
+public:
+
+  AlertState(size_t maximum) :
+    _maximum(maximum), _alvl(0), _last_avlv_increase(0), _spike_no(0) {
+    assert(_maximum > 0, "sanity");
+  }
+
+  size_t maximum() const {
+    return _maximum;
+  }
+
+  int current_spike_no() const {
+    return _spike_no;
+  }
+
+  int current_alert_level() const {
+    return _alvl;
+  }
+
+  static int alert_level_percentage(int alvl) {
+    assert(alvl >= 0 && alvl < (int)(sizeof(_alvl_perc) / sizeof(int)), "oob");
+    return _alvl_perc[alvl];
+  }
+
+  int current_alert_level_percentage() const {
+    return alert_level_percentage(_alvl);
+  }
+
+  // Update the state.
+  // If we changed the alert level (either increased it or reset it after decay),
+  // return true.
+  bool update(size_t current_size) {
+    const int percentage = calc_percentage(current_size);
+    const int new_alvl = calc_alvl(percentage);
+    // If we reached a new alert level, hold information and inform caller.
+    if (new_alvl > _alvl) {
+      // If we increased from zero, it means we entered a new spike, so
+      // increase spike number
+      if (_alvl == 0) {
+        _spike_no ++;
+      }
+      _alvl = new_alvl;
+      ::time(&_last_avlv_increase);
+      return true;
+    }
+    // If all is well now, but we had an alert situation before, and enough
+    // time has passed, reset alert level
+    if (new_alvl == 0 && _alvl > 0) {
+      time_t t;
+      time(&t);
+      if ((t - _last_avlv_increase) >= HiMemReportDecaySeconds) {
+        _alvl = 0;
+        _last_avlv_increase = 0;
+        return true;
+      }
+    }
+    return false;
+  }
+
+};
+
+const int AlertState::_alvl_perc[5] = { 0, 66, 75, 90, -1 };
+
+static AlertState* g_alert_state = NULL;
+
+// What do we test?
+enum class compare_type {
+  compare_rss_vs_phys = 0,          // We compare rss+swap vs total physical memory
+  compare_rss_vs_cgroup_limit = 1,  // We compare rss+swap vs the cgroup limit
+  compare_rss_vs_manual_limit = 2,  // HiMemReportMaximum is set, we compare rss+swap with that limit
+  compare_none
+};
+
+static compare_type g_compare_what = compare_type::compare_none;
+
+static const char* describe_maximum_by_compare_type(compare_type t) {
+  const char* s = "";
+  switch (g_compare_what) {
+  case compare_type::compare_rss_vs_cgroup_limit: s = "cgroup memory limit"; break;
+  case compare_type::compare_rss_vs_phys: s = "the half of total physical memory"; break;
+  case compare_type::compare_rss_vs_manual_limit: s = "HiMemReportMaximum"; break;
+  default: ShouldNotReachHere();
+  }
+  return s;
+}
+
+//////////// NMT stuff //////////////////////////////////////////////
+
+// NMT is nice, but the interface is unnecessary convoluted. For now, to keep merge surface small,
+// we work with what we have
+
+class NMTStuff : public AllStatic {
+
+  static MemBaseline _baseline;
+  static time_t _baseline_time;
+
+  // Fill a given baseline
+  static void fill_baseline(MemBaseline& baseline) {
+    const NMT_TrackingLevel lvl = MemTracker::tracking_level();
+    if (lvl >= NMT_summary) {
+      const bool summary_only = (lvl == NMT_summary);
+      baseline.baseline(summary_only);
+    }
+  }
+
+public:
+
+  static bool is_enabled() {
+    const NMT_TrackingLevel lvl = MemTracker::tracking_level();
+    // Note: I avoid assumptions about numerical values of NMT_TrackingLevel
+    // (e.g. "lvl >= NMT_summary") since their order changed over time and we
+    // want to be JDK-version-agnostic here.
+    return lvl == NMT_summary || lvl == NMT_detail;
+  }
+
+  // Capture a baseline right now
+  static void capture_baseline() {
+    fill_baseline(_baseline);
+    time(&_baseline_time);
+  }
+
+  // Do the best possible report with the given NMT tracking level.
+  // If we are at summary level, do a summary level report
+  // If we are at detail level, do a detail level report
+  // If we have a baseline captured, do a diff level report
+  static void report_as_best_as_possible(outputStream* st) {
+
+    if (NMTStuff::is_enabled()) {
+
+      // Get the state now
+      MemBaseline baseline_now;
+      fill_baseline(baseline_now);
+
+      // prepare and print suitable report
+      if (_baseline.baseline_type() == baseline_now.baseline_type()) {
+        // We already captured a baseline, and its type fits us (nobody changed NMT levels inbetween calls)
+        time_t t;
+        time(&t);
+        st->print("(diff against baseline taken at ");
+        print_date_and_time(st, _baseline_time);
+        st->print_cr(", %d seconds ago)", (int)(t - _baseline_time));
+        st->cr();
+        const bool summary_only = (baseline_now.baseline_type() == MemBaseline::Summary_baselined);
+        if (summary_only) {
+          MemSummaryDiffReporter rpt(_baseline, baseline_now, st, K);
+          rpt.report_diff();
+        } else {
+          MemDetailDiffReporter rpt(_baseline, baseline_now, st, K);
+          rpt.report_diff();
+        }
+      } else {
+        // We don't have a baseline yet. Just report the raw numbers
+        const bool summary_only = (baseline_now.baseline_type() == MemBaseline::Summary_baselined);
+        if (summary_only) {
+          MemSummaryReporter rpt(baseline_now, st, K);
+          rpt.report();
+        } else {
+          MemDetailReporter rpt(baseline_now, st, K);
+          rpt.report();
+        }
+      }
+    } else {
+      st->print_cr("NMT is disabled, nothing to print");
+    }
+
+  }
+
+  // If the situation calmed down, reset (clear the base line)
+  static void reset() {
+    _baseline_time = 0;
+    _baseline.reset();
+  }
+
+};
+
+MemBaseline NMTStuff::_baseline;
+time_t NMTStuff::_baseline_time = 0;
+
+
+//////////// Reporting //////////////////////////////////////////////
+
+class ReportDir : public CHeapObj<mtInternal> {
+  // absolute, always ends with slash
+  stringStream _dir;
+
+public:
+
+  const char* path() const { return _dir.base(); }
+
+  ReportDir(const char* d) {
+    assert(d != NULL && strlen(d) > 0, "sanity");
+    if (d[0] != '/') { // relative?
+      char* p = ::get_current_dir_name();
+      _dir.print("%s/", p);
+      ::free(p); // [sic]
+    }
+    _dir.print_raw(d);
+    const size_t l = ::strlen(d);
+    if (d[l - 1] != '/') {
+      _dir.put('/');
+    }
+  }
+
+  bool create_if_needed() {
+    // Create the report directory (just the leaf dir, I don't bother creating the whole hierarchy)
+    struct stat s;
+    if (::stat(path(), &s) == -1) {
+      if (::mkdir(path(), S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) != -1) {
+        log_info(vitals)("HiMemReportDir: Created report directory \"%s\"", path());
+      } else {
+        log_warning(vitals)("HiMemReportDir: Failed to create report directory \"%s\" (%d)", path(), errno);
+        return false;
+      }
+    } else {
+      if (S_ISDIR(s.st_mode)) {
+        log_info(vitals)("HiMemReportDir: Found existing report directory at \"%s\"", path());
+      } else {
+        log_warning(vitals)("HiMemReportDir: \"%s\" exists, but its not a directory.", path());
+        return false;
+      }
+    }
+    // Test access by touching a file in this dir. For convenience, we leave the touched file in it
+    // and write the VM start time and some other info into it.
+    stringStream testfile;
+    testfile.print("%sVM_start.pid%d.log", path(), os::current_process_id());
+    fileStream fs(testfile.base());
+    if (!fs.is_open()) {
+      log_warning(os)("HiMemReportDir: Cannot write to \"%s\" (%d)", testfile.base(), errno);
+      return false;
+    }
+    print_current_date_and_time(&fs);
+    return true;
+  }
+};
+
+static ReportDir* g_report_dir = NULL;
+
+static void print_high_memory_report_header(outputStream* st, const char* message, int pid, time_t t) {
+  char tmp[255];
+  st->print_cr("############");
+  st->print_cr("#");
+  st->print_cr("# High Memory Report:");
+  st->print_cr("# pid: %d thread id: " INTX_FORMAT, pid, os::current_thread_id());
+  st->print_cr("# %s", message);
+  st->print_raw("# "); print_date_and_time(st, t); st->cr();
+  st->print_cr("# Spike number: %d", g_alert_state->current_spike_no());
+  st->print_cr("#");
+  st->flush();
+}
+
+static void print_high_memory_report(outputStream* st) {
+
+  // Note that this report may be interrupted by VM death, e.g. OOM killed.
+  // Therefore we frequently flush, and print the most important things first.
+
+  char buf[O_BUFLEN];
+
+  st->print_cr("vm_info: %s", VM_Version::internal_vm_info_string());
+
+  st->cr();
+  st->cr();
+  st->flush();
+
+  Arguments::print_summary_on(st);
+  st->cr();
+  st->cr();
+  st->flush();
+
+  st->print_cr("--- Vitals ---");
+  sapmachine_vitals::print_info_t info;
+  sapmachine_vitals::default_settings(&info);
+  info.sample_now = true;
+  info.no_legend = true;
+  sapmachine_vitals::print_report(st, &info);
+  st->print_cr("--- /Vitals ---");
+
+  st->cr();
+  st->cr();
+  st->flush();
+
+  st->cr();
+  st->print_cr("--- NMT report ---");
+  NMTStuff::report_as_best_as_possible(st);
+  st->print_cr("--- /NMT report ---");
+
+  st->cr();
+  st->cr();
+  st->flush();
+
+  st->print_cr("#");
+  st->print_cr("# END: High Memory Report");
+  st->print_cr("#");
+
+  st->flush();
+}
+
+// Create a file name into the report directory: <reportdir or cwd>/<name>.<pid>_<spike>_<percentage>.<suffix>
+// (leave dir NULL to just get a file name)
+static void print_file_name(stringStream* ss, const char* name, int pid, time_t timestamp, const char* suffix) {
+  const char* dir = g_report_dir != NULL ? g_report_dir->path() : NULL;
+  if (dir != NULL) {
+    if (dir[0] != '/') {
+      char* cwd = ::get_current_dir_name(); // glibc speciality, return ptr is malloced
+      ss->print("%s/", cwd);
+      ::free(cwd); // yes, use raw free here
+    }
+    ss->print("%s", dir);
+    if (dir[::strlen(dir) - 1] != '/') {
+      ss->put('/');
+    }
+  }
+  ss->print("%s_pid%d_", name, pid);
+  print_date_and_time_underscored(ss, timestamp);
+  ss->print("%s", suffix);
+}
+
+///////////////////// JCmd support //////////////////////////////////////////
+
+class ParsedCommand {
+
+  stringStream _name; // command name without args
+  stringStream _args; // arguments
+
+public:
+
+  ParsedCommand(const char* command) {
+    // trim front
+    const char* p = command;
+    while (isspace(*p)) {
+      p ++;
+    }
+    if ((*p) != '\0') {
+      // read name
+      while (!isspace(*p) && (*p) != '\0') {
+        _name.put(*p);
+        p++;
+      }
+      // find start of args; read args
+      while (isspace(*p)) {
+        p ++;
+      }
+      _args.print_raw(p);
+    }
+  }
+
+  bool is_empty() const { return _name.size() == 0; }
+  const char* name() const { return _name.base(); }
+
+  bool has_arguments() const { return _args.size() > 0; }
+  const char* args() const { return _args.base(); }
+
+  // Unfortunately, the DCmd framework lacks the ability to check DCmd without
+  // executing them. Here, we do some simple basic checks. Failing them will
+  // exit the VM right away, but passing them does still not mean the command
+  // is well formed since we don't check the arguments.
+  bool is_valid() const {
+    static const char* valid_prefixes[] = { "Compiler", "GC", "JFR", "JVMTI",
+                                            "Management", "System", "Thread",
+                                            "VM",  "help", NULL };
+    if (_name.size() > 0) {
+      for (const char** p = valid_prefixes; (*p) != NULL; p ++) {
+        if (::strncasecmp(_name.base(), *p, ::strlen(*p)) == 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+};
+
+// Helper structures for posix_spawn_file_actions_t and posix_spawnattr_t where
+// cleanup depends on successful initialization.
+// Helper structures for posix_spawn_file_actions_t and posix_spawnattr_t where
+// cleanup depends on successful initialization.
+struct PosixSpawnFileActions {
+  posix_spawn_file_actions_t v;
+  const bool ok;
+  PosixSpawnFileActions() : ok(::posix_spawn_file_actions_init(&v) == 0) {}
+  ~PosixSpawnFileActions() { ok && ::posix_spawn_file_actions_destroy(&v); }
+};
+
+struct PosixSpawnAttr {
+  posix_spawnattr_t v;
+  const bool ok;
+  PosixSpawnAttr() : ok(::posix_spawnattr_init(&v) == 0) {}
+  ~PosixSpawnAttr() { ok && ::posix_spawnattr_destroy(&v); }
+};
+
+// Call jcmd. If outFile and errFile are not Null, redirect stdout and stderr, otherwise
+// print both stdout and stderr to VMs stderr.
+// Returns true if command was executed successfully and exitcode was 0, false otherwise.
+// If command failed, err_msg will contain an error string.
+static bool spawn_command(const char** argv, const char* outFile, const char* errFile, stringStream* err_msg) {
+
+  // I want vfork, but use posix_spawn, since vfork() is becoming obsolete and compilers
+  // will warn. Its also safer, and with modern glibcs it is as cheap as vfork.
+  PosixSpawnFileActions fa;
+  PosixSpawnAttr atr;
+
+  bool rc = fa.ok && atr.ok;
+
+  if (outFile != NULL) { // Redirect stdout, stderr to files
+        assert(errFile != NULL, "Require both");
+    rc &= (::posix_spawn_file_actions_addopen(&fa.v, 1,
+        outFile, O_WRONLY | O_CREAT | O_TRUNC, 0664) == 0);
+    rc &= (::posix_spawn_file_actions_addopen(&fa.v, 2,
+        errFile, O_WRONLY | O_CREAT | O_TRUNC, 0664) == 0);
+  } else { // Dup stdout to stderr
+    rc &= (::posix_spawn_file_actions_adddup2 (&fa.v, 2, 1) == 0);
+  }
+  pid_t child_pid = -1;
+
+  // Hint toward vfork. Note that newer glibcs (2.24+) will ignore this, but they use clone(),
+  // so its alright.
+  rc &= (posix_spawnattr_setflags(&atr.v, POSIX_SPAWN_USEVFORK) == 0);
+
+  if (rc == false) {
+    err_msg->print("Error during posix_spawn setup");
+    return false;
+  }
+
+  // Note about inheriting file descriptors: in theory, posix_spawn should close all stray descriptors:
+  // "If file_actions is a null pointer, then file descriptors open in the calling process shall remain open
+  //  in the child process, except for those whose close-on- exec flag FD_CLOEXEC is set (see fcntl)."
+  // (https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnp.html)
+  // - which I assume means they get closed if we specify a file actions object, which we do.
+  rc &= (::posix_spawn(&child_pid, argv[0], &fa.v, &atr.v, (char**)argv, os::get_environ()) == 0);
+
+  if (rc) {
+    int status;
+    rc = (::waitpid(child_pid, &status, 0) != -1) &&
+         (WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    if (rc == false) {
+      err_msg->print("Command failed or crashed");
+    }
+  } else {
+    err_msg->print("posix_spawn failed (%s)", os::strerror(errno));
+  }
+
+  return rc;
+}
+
+// Calls a single jcmd via posix_spawn. Output is written to <report-dir>/<command name>-<pid>-<spike>-<percentage>
+// if HiMemReportDir is given; to stdout if not.
+static void call_single_jcmd(const ParsedCommand* cmd, int pid, time_t t) {
+
+  // if report dir is given, calc .out and .err file names
+  const char* out_file = NULL;
+  const char* err_file = NULL;
+  stringStream out_file_ss, err_file_ss;
+  if (g_report_dir != NULL) {
+    // output files are named <command name>_pid<pid>_<timestamp>.(out|err), e.g. "VM.info_4711_2022_08_01_07_52_22.out".
+    print_file_name(&out_file_ss, cmd->name(), pid, t, ".out");
+    out_file = out_file_ss.base();
+    print_file_name(&err_file_ss, cmd->name(), pid, t, ".err");
+    err_file = err_file_ss.base();
+  }
+
+  stringStream jcmd_executable;
+  jcmd_executable.print("%s/bin/jcmd", Arguments::get_java_home());
+
+  stringStream target_pid;
+  target_pid.print("%d", pid);
+
+  stringStream jcmd_command;
+  jcmd_command.print_raw(cmd->name());
+  if (cmd->has_arguments()) {
+    jcmd_command.put(' ');
+    jcmd_command.print_raw(cmd->args());
+  }
+
+  // Special consideration for GC.heap_dump: if the command was given without arguments, we append
+  // a file name for the heap dump ("<reportdir>/heapdump_pid<pid>_<timestamp>.dump")
+  if (!cmd->has_arguments() && ::strcmp(cmd->name(), "GC.heap_dump") == 0) {
+    jcmd_command.put(' ');
+    print_file_name(&jcmd_command, "GC.heap_dump", pid, t, ".dump");
+  }
+
+  const char* argv[4];
+  argv[0] = jcmd_executable.base();
+  argv[1] = target_pid.base();
+  argv[2] = jcmd_command.base();
+  argv[3] = NULL;
+
+  stringStream err_msg;
+  if (spawn_command(argv, out_file, err_file, &err_msg)) {
+    stderr_stream.print("HiMemReport: Successfully executed \"%s\"", jcmd_command.base());
+    if (out_file != NULL) {
+      stderr_stream.print(", output redirected to report dir");
+    }
+    stderr_stream.cr();
+  } else {
+    stderr_stream.print("HiMemReport: Failed to execute \"%s\" (%s)", jcmd_command.base(), err_msg.base());
+  }
+}
+
+// Helper, trims string
+static char* trim_string(char* s) {
+  char* p = s;
+  while (::isspace(*p)) p++;
+  char* p2 = p + ::strlen(p) - 1;
+  while (p2 > p && ::isspace(*p2)) {
+    *p2 = '\0';
+    p2--;
+  }
+  return p;
+}
+
+struct JcmdClosure {
+  virtual bool do_it(const char* cmd) = 0;
+};
+
+static bool iterate_exec_string(const char* exec_string, JcmdClosure* closure) {
+  char* exec_copy = os::strdup(exec_string);
+  char* save = NULL;
+  for (char* tok = strtok_r(exec_copy, ";", &save);
+       tok != NULL; tok = ::strtok_r(NULL, ";", &save)) {
+    const char* p = trim_string(tok);
+    if (::strlen(p) > 0 && !closure->do_it(p)) {
+      os::free(exec_copy);
+      return false;
+    }
+  }
+  os::free(exec_copy);
+  return true;
+}
+
+class CallJCmdClosure : public JcmdClosure {
+  const pid_t _pid;
+  const time_t _time;
+public:
+  CallJCmdClosure(int pid, time_t time) : _pid(pid), _time(time) {}
+  bool do_it(const char* command_string) override {
+    ParsedCommand cmd(command_string);
+    assert(cmd.is_valid(), "Invalid command");
+    call_single_jcmd(&cmd, _pid, _time);
+    return true;
+  }
+};
+
+struct VerifyJCmdClosure : public JcmdClosure {
+  bool do_it(const char* command_string) override {
+    log_info(vitals)("HiMemReportExec: storing command \"%s\".", command_string);
+    if (!ParsedCommand(command_string).is_valid()) {
+      // We print a warning here, fingerpointing the specific command that failed, then exit the VM later.
+      log_warning(vitals)("HiMemReportExec: Command \"%s\" invalid.", command_string);
+      return false;
+    }
+    return true;
+  }
+};
+
+//////////////////// alert handling and reporting ///////////////////////////////////////////////////////////////
+
+static int g_num_alerts = 0;
+
+// We don't want to flood the report directory if the footprint of the VM wobbles strongly. We will give up
+// after a reasonable amount of reports have been printed.
+static const int max_spikes = 32;
+
+static void trigger_high_memory_report(int alvl, int spikeno, int percentage, size_t triggering_size) {
+
+  if (spikeno >= max_spikes) {
+    if (spikeno == max_spikes) {
+      stderr_stream.print_cr("# HiMemReport: Too many spikes encountered. Further reports will be omitted.");
+    }
+    return;
+  }
+
+  g_num_alerts ++;
+
+  stringStream reason;
+  reason.print("rss+swap (" SIZE_FORMAT " K) larger than %d%% of %s (" SIZE_FORMAT " K).",
+               triggering_size / K, percentage, describe_maximum_by_compare_type(g_compare_what),
+               g_alert_state->maximum() / K);
+  const char* message = reason.base();
+
+  const int pid = os::current_process_id();
+  time_t t;
+  time(&t);
+
+  bool printed = false;
+
+  print_high_memory_report_header(&stderr_stream, message, pid, t);
+
+  if (g_report_dir != NULL) {
+    // Dump to file in report dir
+    stringStream ss;
+    print_file_name(&ss, "sapmachine_himemalert", pid, t, ".log");
+    fileStream fs(ss.base());
+    if (fs.is_open()) {
+      stderr_stream.print_cr("# Printing to %s", ss.base());
+      print_high_memory_report_header(&fs, message, pid, t);
+      print_high_memory_report(&fs);
+      printed = true;
+    } else {
+      stderr_stream.print_cr("# Failed to open %s. Printing to stderr instead.", ss.base());
+      stderr_stream.cr();
+    }
+    stderr_stream.flush();
+  }
+
+  if (!printed) {
+    print_high_memory_report(&stderr_stream);
+  }
+
+  stderr_stream.print_cr("# Done.");
+  stderr_stream.print_raw("#");
+  stderr_stream.cr();
+  stderr_stream.flush();
+
+  if (HiMemReportExec != NULL) {
+    CallJCmdClosure closure(pid, t);
+    iterate_exec_string(HiMemReportExec, &closure);
+  }
+
+}
+
+///////////////// Monitor thread /////////////////////////////////////////
+
+void pulse_himem_report() {
+  assert(HiMemReport, "only call for +HiMemReport");
+  assert(g_compare_what != compare_type::compare_none && g_alert_state != NULL, "Not initialized");
+
+  OSWrapper::update_if_needed();
+
+  const value_t rss = OSWrapper::proc_rss_all();
+  const value_t swap = OSWrapper::proc_swdo();
+  if (rss != INVALID_VALUE && swap != INVALID_VALUE) {
+    const size_t rss_swap = (size_t)rss + (size_t)swap;
+    const int old_alvl = g_alert_state->current_alert_level();
+    g_alert_state->update(rss_swap);
+    const int new_alvl = g_alert_state->current_alert_level();
+    const int spikeno = g_alert_state->current_spike_no();
+
+    if (new_alvl > old_alvl) {
+      const int new_percentage = g_alert_state->current_alert_level_percentage();
+      stderr_stream.print_cr("HiMemoryReport: rss+swap=" SIZE_FORMAT " K - alert level increased to %d (>=%d%%).",
+                              rss_swap / K, new_alvl, new_percentage);
+      int skipped = 0;
+      for (int i = old_alvl + 1; i < new_alvl; i ++) {
+        skipped ++;
+        // We may have missed some intermediary steps because the pulse interval was too large.
+        stderr_stream.print_cr("HiMemoryReport: ... seems we passed alert level %d (%d%%) without noticing.",
+                                i, AlertState::alert_level_percentage(i));
+      }
+      // If the alert level increased to a new value, trigger a new report
+      trigger_high_memory_report(new_alvl, spikeno, new_percentage, rss_swap);
+      // Upon first alert, do a NMT baseline
+      if (old_alvl == 0 && new_alvl > 0) {
+        if (NMTStuff::is_enabled()) {
+          NMTStuff::capture_baseline();
+          stderr_stream.print_cr("HiMemoryReport: ... captured NMT baseline");
+        }
+      }
+    } else if (old_alvl > 0 && new_alvl == 0){
+      // Memory usage recovered, and we hit the decay time, and now all is well again.
+      stderr_stream.print_cr("HiMemoryReport: rss+swap=" SIZE_FORMAT " K - seems we recovered. Resetting alert level.",
+                             rss_swap / K);
+      NMTStuff::reset();
+    }
+  }
+}
+
+class HiMemReportThread: public NamedThread {
+
+  static const int interval_seconds = 2;
+
+public:
+
+  HiMemReportThread() : NamedThread() {
+    this->set_name("himem reporter");
+  }
+
+  virtual void run() {
+    record_stack_base_and_size();
+    for (;;) {
+      pulse_himem_report();
+      os::naked_sleep(interval_seconds * 1000);
+    }
+  }
+
+};
+
+static HiMemReportThread* g_reporter_thread = NULL;
+
+static bool initialize_reporter_thread() {
+  g_reporter_thread = new HiMemReportThread();
+  if (g_reporter_thread != NULL) {
+    if (os::create_thread(g_reporter_thread, os::os_thread)) {
+      os::start_thread(g_reporter_thread);
+    }
+    return true;
+  }
+  return false;
+}
+
+///////////////// Externals //////////////////////////////////////////////
+
+extern void initialize_himem_report_facility() {
+
+  static bool initialized = false;
+  assert(initialized == false, "HiMemReport already initialized");
+  initialized = true;
+
+  // Note:
+  // unrecoverable errors:
+  //  - errors the user can easily correct (bad arguments) cause exit right away
+  //  - errors which are subject to environment and cannot be dealt with/are unpredictable
+  //    cause facility to be disabled (with UL warning)
+
+  assert(HiMemReport, "only call for +HiMemReport");
+
+  assert(g_compare_what == compare_type::compare_none && g_alert_state == NULL, "Only initialize once");
+
+  // Verify the exec string
+  VerifyJCmdClosure closure;
+  if (HiMemReportExec != NULL && iterate_exec_string(HiMemReportExec, &closure) == false) {
+    vm_exit_during_initialization("Vitals HiMemReportExec: One or more Exec commands were invalid");
+  }
+
+  // We need to decide what we will compare with what. To do that, we get the current system values.
+  // - If user manually specified a maximum, we will compare rss+swap with that maximum
+  // - If we live inside a cgroup with a memory limit, we will compare process rss+swap vs this limit
+  //   (snapshotted at VM start; maybe later we can react to dynamic limit changes, but for the moment I don't care)
+  // - If we do not live in a cgroup, or in a cgroup with no limit, compare process rss+swap vs the
+  //   physical memory of the machine.
+  size_t limit = 0;
+  if (HiMemReportMax != 0) {
+    g_compare_what = compare_type::compare_rss_vs_manual_limit;
+    limit = HiMemReportMax;
+    log_info(vitals)("Vitals HiMemReport: Setting limit to HiMemReportMax (" SIZE_FORMAT " K).", limit / K);
+  } else {
+    OSWrapper::update_if_needed();
+    if (OSWrapper::syst_cgro_lim() != INVALID_VALUE) {
+      // limit against cgroup limit
+      g_compare_what = compare_type::compare_rss_vs_cgroup_limit;
+      limit = (size_t)OSWrapper::syst_cgro_lim();
+      log_info(vitals)("Vitals HiMemReport: Setting limit to cgroup memory limit (" SIZE_FORMAT " K).", limit / K);
+    } else if (OSWrapper::syst_phys() != INVALID_VALUE) {
+      // limit against total physical memory
+      g_compare_what = compare_type::compare_rss_vs_phys;
+      limit = (size_t)OSWrapper::syst_phys() / 2;
+      log_info(vitals)("Vitals HiMemReport: Setting limit to half of total physical memory (" SIZE_FORMAT " K).", limit / K);
+    }
+  }
+
+  if (limit == 0) {
+    log_warning(vitals)("Vitals HiMemReport: limit could not be established; will disable high memory reports "
+                    "(specify -XX:HiMemReportMax=<size> to establish a manual limit).");
+    FLAG_SET_ERGO(HiMemReport, false);
+    return;
+  }
+
+  // HiMemReportDir:
+  // We fix up the report directory when VM starts, so if its relative, it refers to the initial current directory.
+  // If it cannot be established, we treat it as predictable argument error and exit the VM.
+  if (HiMemReportDir != NULL && ::strlen(HiMemReportDir) > 0) {
+    g_report_dir = new ReportDir(HiMemReportDir);
+    if (!g_report_dir->create_if_needed()) {
+      log_warning(vitals)("Vitals: Cannot access HiMemReportDir %s.", g_report_dir->path());
+      vm_exit_during_initialization("Vitals HiMemReport: Failed to create or access HiMemReportDir \"%s\".", g_report_dir->path());
+      return;
+    }
+  }
+
+  g_alert_state = new AlertState(limit);
+
+  if (!initialize_reporter_thread()) {
+    log_warning(vitals)("Vitals HiMemReport: Failed to start monitor thread. Will disable.");
+    FLAG_SET_ERGO(HiMemReport, false);
+    return;
+  }
+
+  log_info(vitals)("Vitals: HiMemReport subsystem initialized.");
+
+}
+
+extern void print_himemreport_state(outputStream* st) {
+  if (g_alert_state != NULL) {
+    st->print("HiMemReport: monitoring rss+swap vs %s (" SIZE_FORMAT " K)",
+              describe_maximum_by_compare_type(g_compare_what),
+              g_alert_state->maximum() / K);
+    if (g_alert_state->current_alert_level() == 0) {
+      st->print(", all is well");
+    } else {
+      st->print(", current level: %d (%d%%)", g_alert_state->current_alert_level(),
+                g_alert_state->current_alert_level_percentage());
+    }
+    st->print(", spikes: %d, alerts: %d", g_alert_state->current_spike_no(), g_num_alerts);
+  } else {
+    st->print("HiMemReport: not monitoring.");
+  }
+}
+
+// For printing in thread lists only.
+extern const Thread* himem_reporter_thread() { return g_reporter_thread; }
+
+} // namespace sapmachine_vitals
+

--- a/src/hotspot/os/linux/vitals_linux_himemreport.hpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.hpp
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2021, SAP SE. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,31 +21,24 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
+ *
  */
 
-/*
- * @test TestVitalsOff
- * @summary Test verifies that -XX:-EnableVitals disables vitals
- * @library /test/lib
- * @run driver TestVitalsOff run
- */
+#ifndef OS_LINUX_VITALS_LINUX_HELPERS_HPP
+#define OS_LINUX_VITALS_LINUX_HELPERS_HPP
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+#include "vitals/vitals_internals.hpp"
 
-public class TestVitalsOff {
+namespace sapmachine_vitals {
 
-    public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                "-XX:-EnableVitals",
-                "-XX:MaxMetaspaceSize=16m",
-                "-Xlog:vitals",
-                "-Xmx128m",
-                "-version");
+void initialize_himem_report_facility();
 
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldHaveExitValue(0);
-        output.shouldNotContain("Initializing Vitals");
-    }
+void print_himemreport_state(outputStream* st);
 
-}
+// For printing in thread lists only.
+extern const Thread* himem_reporter_thread();
+
+} // namespace sapmachine_vitals
+
+#endif // OS_LINUX_VITALS_LINUX_HELPERS_HPP
+

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -1,0 +1,562 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "jvm_io.h"
+#include "osContainer_linux.hpp"
+#include "vitals_linux_oswrapper.hpp"
+#include "logging/log.hpp"
+#include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "vitals/vitals_internals.hpp"
+
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+
+
+
+#define LOG_HERE_F(msg, ...)  { printf("[%d] ", (int)::getpid()); ::printf(msg, __VA_ARGS__); printf("\n"); fflush(stdout); }
+#define LOG_HERE(msg)         { printf("[%d] ", (int)::getpid()); ::printf("%s", msg); printf("\n"); fflush(stdout); }
+
+extern const char* sapmachine_get_memory_controller_path();
+
+namespace sapmachine_vitals {
+
+#define DEFINE_VARIABLE(name) \
+  value_t OSWrapper::_##name = INVALID_VALUE;
+
+ALL_VALUES_DO(DEFINE_VARIABLE)
+
+#undef DEFINE_VARIABLE
+
+time_t OSWrapper::_last_update = 0;
+
+static const int num_seconds_until_update = 1;
+
+///////////// procfs stuff //////////////////////////////////////////////////
+
+class ProcFile {
+  char* _buf;
+
+  // To keep the code simple, I just use a fixed sized buffer.
+  enum { bufsize = 64*K };
+
+public:
+
+  ProcFile() : _buf(NULL) {
+    _buf = (char*)os::malloc(bufsize, mtInternal);
+  }
+
+  ~ProcFile () {
+    os::free(_buf);
+  }
+
+  bool read(const char* filename) {
+
+    FILE* f = ::fopen(filename, "r");
+    if (f == NULL) {
+      return false;
+    }
+
+    size_t bytes_read = ::fread(_buf, 1, bufsize, f);
+    _buf[bufsize - 1] = '\0';
+
+    ::fclose(f);
+
+    return bytes_read > 0 && bytes_read < bufsize;
+  }
+
+  const char* text() const { return _buf; }
+
+  // Utility function; parse a number string as value_t
+  static value_t as_value(const char* text, size_t scale = 1) {
+    value_t value;
+    errno = 0;
+    char* endptr = NULL;
+    value = (value_t)::strtoll(text, &endptr, 10);
+    if (endptr == text || errno != 0) {
+      value = INVALID_VALUE;
+    } else {
+      value *= scale;
+    }
+    return value;
+  }
+
+  // Return the start of the file, as number. Useful for proc files which
+  // contain a single number. Returns INVALID_VALUE if value did not parse
+  value_t as_value(size_t scale = 1) const {
+    return as_value(_buf, scale);
+  }
+
+  const char* get_prefixed_line(const char* prefix) const {
+    return ::strstr(_buf, prefix);
+  }
+
+  value_t parsed_prefixed_value(const char* prefix, size_t scale = 1) const {
+    value_t value = INVALID_VALUE;
+    const char* const s = get_prefixed_line(prefix);
+    if (s != NULL) {
+      errno = 0;
+      const char* p = s + ::strlen(prefix);
+      return as_value(p, scale);
+    }
+    return value;
+  }
+
+};
+
+struct cpu_values_t {
+  value_t user;
+  value_t nice;
+  value_t system;
+  value_t idle;
+  value_t iowait;
+  value_t steal;
+  value_t guest;
+  value_t guest_nice;
+};
+
+static void parse_proc_stat_cpu_line(const char* line, cpu_values_t* out) {
+  // Note: existence of some of these values depends on kernel version
+  out->user = out->nice = out->system = out->idle = out->iowait = out->steal = out->guest = out->guest_nice =
+      INVALID_VALUE;
+  uint64_t user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice;
+  int num = ::sscanf(line,
+      "cpu "
+      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " "
+      UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " " UINT64_FORMAT " ",
+      &user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal, &guest, &guest_nice);
+  if (num >= 4) {
+    out->user = user;
+    out->nice = nice;
+    out->system = system;
+    out->idle = idle;
+    if (num >= 5) { // iowait (5) (since Linux 2.5.41)
+      out->iowait = iowait;
+      if (num >= 8) { // steal (8) (since Linux 2.6.11)
+        out->steal = steal;
+        if (num >= 9) { // guest (9) (since Linux 2.6.24)
+          out->guest = guest;
+          if (num >= 10) { // guest (9) (since Linux 2.6.33)
+            out->guest_nice = guest_nice;
+          }
+        }
+      }
+    }
+  }
+}
+
+
+#ifdef __GLIBC__
+// We use either mallinfo (which may be obsolete or removed in newer glibc versions) or mallinfo2
+// (which does not exist prior to glibc 2.34).
+
+#define MALLINFO_MEMBER_DO(f) \
+		f(arena) \
+		f(ordblks) \
+		f(smblks) \
+		f(hblks) \
+		f(hblkhd) \
+		f(usmblks) \
+		f(fsmblks) \
+		f(uordblks) \
+		f(fordblks) \
+		f(keepcost)
+
+struct glibc_mallinfo {
+#define DEF_MALLINFO_MEMBER(f) int f;
+  MALLINFO_MEMBER_DO(DEF_MALLINFO_MEMBER)
+#undef DEF_MALLINFO_MEMBER
+};
+
+struct glibc_mallinfo2 {
+#define DEF_MALLINFO2_MEMBER(f) size_t f;
+  MALLINFO_MEMBER_DO(DEF_MALLINFO2_MEMBER)
+#undef DEF_MALLINFO2_MEMBER
+};
+
+typedef struct glibc_mallinfo   (*mallinfo_func_t)(void);
+typedef struct glibc_mallinfo2  (*mallinfo2_func_t)(void);
+
+static mallinfo_func_t  g_mallinfo = NULL;
+static mallinfo2_func_t g_mallinfo2 = NULL;
+
+static void mallinfo_init() {
+  g_mallinfo = CAST_TO_FN_PTR(mallinfo_func_t, dlsym(RTLD_DEFAULT, "mallinfo"));
+  g_mallinfo2 = CAST_TO_FN_PTR(mallinfo2_func_t, dlsym(RTLD_DEFAULT, "mallinfo2"));
+}
+
+#undef MALLINFO_MEMBER_DO
+
+#endif // __GLIBC__
+
+// Helper function, returns true if string is a numerical id
+static bool is_numerical_id(const char* s) {
+  const char* p = s;
+  while(*p >= '0' && *p <= '9') {
+    p ++;
+  }
+  return *p == '\0' ? true : false;
+}
+
+/////////////// cgroup stuff
+// We use part of the hotspot cgroup wrapper, but not all of it.
+// The reason:
+// - wrapper uses UL heavily, which I don't want to happen in a sampler thread (I only log in initialization, which is ok)
+// - wrapper does not expose all metrics I need (eg kmem)
+// What the wrapper does very nicely is the parse stuff, which I don't want to re-invent, therefore
+// I use the wrapper to get the controller path.
+
+class CGroups : public AllStatic {
+
+  static bool _containerized;
+  static const char* _file_usg;
+  static const char* _file_usgsw;
+  static const char* _file_lim;
+  static const char* _file_limsw;
+  static const char* _file_slim;
+  static const char* _file_kusg;
+
+public:
+
+  static bool initialize() {
+
+    // For the heck of it, I go through with initialization even if we are not
+    // containerized, since I like to know controller paths even for those cases.
+
+    _containerized = OSContainer::is_containerized();
+    log_info(vitals)("Vitals cgroup initialization: containerized = %d", _containerized);
+
+    const char* controller_path = sapmachine_get_memory_controller_path();
+    if (controller_path == NULL) {
+      log_info(vitals)("Vitals cgroup initialization: controller path NULL");
+      return false;
+    }
+    size_t pathlen = ::strlen(controller_path);
+    if (pathlen == 0) {
+      log_info(vitals)("Vitals cgroup initialization: controller path empty?");
+      return false;
+    }
+    stringStream path;
+    if (controller_path[pathlen - 1] == '/') {
+      path.print("%s", controller_path);
+    } else {
+      path.print("%s/", controller_path);
+    }
+
+    log_info(vitals)("Vitals cgroup initialization: controller path: %s", path.base());
+
+    // V1 or V2?
+    stringStream ss;
+    ss.print("%smemory.usage_in_bytes", path.base());
+    struct stat s;
+    const bool isv1 = os::file_exists(ss.base());
+    if (isv1) {
+      log_info(vitals)("Vitals cgroup initialization: v1");
+    } else  {
+      ss.reset();
+      ss.print("%smemory.current", path.base());
+      if (os::file_exists(ss.base())) {
+        // okay, its v2
+        log_info(vitals)("Vitals cgroup initialization: v2");
+      } else {
+        log_info(vitals)("Vitals cgroup initialization: no clue. Giving up.");
+        return false;
+      }
+    }
+
+    _file_usg = os::strdup(ss.base()); // so, we have that.
+
+#define STORE_PATH(variable, filename) \
+  ss.reset(); ss.print("%s%s", path.base(), filename); variable = os::strdup(ss.base());
+
+    if (isv1) {
+      STORE_PATH(_file_usgsw, "memory.memsw.usage_in_bytes");
+      STORE_PATH(_file_kusg, "memory.kmem.usage_in_bytes");
+      STORE_PATH(_file_lim, "memory.limit_in_bytes");
+      STORE_PATH(_file_limsw, "memory.memsw.limit_in_bytes");
+      STORE_PATH(_file_slim, "memory.soft_limit_in_bytes");
+    } else {
+      STORE_PATH(_file_usgsw, "memory.swap.current");
+      STORE_PATH(_file_kusg, "memory.kmem.usage_in_bytes");
+      STORE_PATH(_file_lim, "memory.max");
+      STORE_PATH(_file_limsw, "memory.swap.max");
+      STORE_PATH(_file_slim, "memory.low");
+    }
+#undef STORE_PATH
+
+#define LOG_PATH(variable) \
+    log_info(vitals)("Vitals: %s=%s", #variable, variable == NULL ? "<null>" : variable);
+    LOG_PATH(_file_usg)
+    LOG_PATH(_file_usgsw)
+    LOG_PATH(_file_kusg)
+    LOG_PATH(_file_lim)
+    LOG_PATH(_file_limsw)
+    LOG_PATH(_file_slim)
+#undef LOG_PATH
+
+    // Initialization went through. We show columns if we are containerized.
+    return _containerized;
+  }
+
+  struct cgroup_values_t {
+    value_t lim;
+    value_t limsw;
+    value_t slim;
+    value_t usg;
+    value_t usgsw;
+    value_t kusg;
+  };
+
+  static bool get_stats(cgroup_values_t* v) {
+    v->lim = v->limsw = v->slim = v->usg = v->usgsw = v->kusg = INVALID_VALUE;
+    ProcFile pf;
+#define GET_VALUE(var) \
+  { \
+    const char* what = _file_ ## var; \
+    if (what != NULL && pf.read(what)) { \
+      v-> var = pf.as_value(1); \
+    } \
+  }
+  GET_VALUE(usg);
+  GET_VALUE(usgsw);
+  GET_VALUE(kusg);
+  GET_VALUE(lim);
+  GET_VALUE(limsw);
+  GET_VALUE(slim);
+#undef GET_VALUE
+    // Cgroup limits defaults to PAGE_COUNTER_MAX in the kernel; so a very large number means "no limit"
+    // Note that on 64-bit, the default is LONG_MAX aligned down to pagesize; but I am not sure this is
+    // always true, so I just assume a very high value.
+    const size_t practically_infinite = LP64_ONLY(128 * K * G) NOT_LP64(4 * G);
+    if (v->lim > practically_infinite)    v->lim = INVALID_VALUE;
+    if (v->slim > practically_infinite)   v->slim = INVALID_VALUE;
+    if (v->limsw > practically_infinite)  v->limsw = INVALID_VALUE;
+    return true;
+
+  } // end: CGroups::get_stats()
+
+}; // end: CGroups
+
+bool CGroups::_containerized = false;
+const char* CGroups::_file_usg = NULL;
+const char* CGroups::_file_usgsw = NULL;
+const char* CGroups::_file_lim = NULL;
+const char* CGroups::_file_limsw = NULL;
+const char* CGroups::_file_slim = NULL;
+const char* CGroups::_file_kusg = NULL;
+
+void OSWrapper::update_if_needed() {
+
+  time_t t;
+  time(&t);
+  if (t != (time_t)-1 &&
+      t < (_last_update + num_seconds_until_update)) {
+    return; // still good
+  }
+  _last_update = t;
+
+  // Update Values from ProcFS (and elsewhere)
+
+#define RESETVAL(name) _ ## name = INVALID_VALUE;
+ALL_VALUES_DO(RESETVAL)
+#undef RESETVAL
+
+  ProcFile bf;
+  if (bf.read("/proc/meminfo")) {
+
+    // All values in /proc/meminfo are in KB
+    const size_t scale = K;
+
+    _syst_phys = bf.parsed_prefixed_value("MemTotal:", scale);
+    _syst_avail = bf.parsed_prefixed_value("MemAvailable:", scale);
+
+    const value_t swap_total = bf.parsed_prefixed_value("SwapTotal:", scale);
+    const value_t swap_free = bf.parsed_prefixed_value("SwapFree:", scale);
+    if (swap_total != INVALID_VALUE && swap_free != INVALID_VALUE) {
+      _syst_swap = swap_total - swap_free;
+    }
+
+    // Calc committed ratio. Values > 100% indicate overcommitment.
+    const value_t commitlimit = bf.parsed_prefixed_value("CommitLimit:", scale);
+    const value_t committed = bf.parsed_prefixed_value("Committed_AS:", scale);
+    if (commitlimit != INVALID_VALUE && commitlimit != 0 && committed != INVALID_VALUE) {
+      _syst_comm = committed;
+      const value_t ratio = (committed * 100) / commitlimit;
+      _syst_crt = ratio;
+    }
+
+  }
+
+  if (bf.read("/proc/vmstat")) {
+    _syst_si = bf.parsed_prefixed_value("pswpin");
+    _syst_so = bf.parsed_prefixed_value("pswpout");
+  }
+
+  if (bf.read("/proc/stat")) {
+    // Read and parse global cpu values
+    cpu_values_t values;
+    const char* line = bf.get_prefixed_line("cpu");
+    parse_proc_stat_cpu_line(line, &values);
+
+    _syst_cpu_us = values.user + values.nice;
+    _syst_cpu_sy = values.system;
+    _syst_cpu_id = values.idle;
+    _syst_cpu_st = values.steal;
+    _syst_cpu_gu = values.guest + values.guest_nice;
+
+    // procs_running: this is actually number of threads running
+    // procs_blocked: number of threads blocked on real disk IO
+    // See https://utcc.utoronto.ca/~cks/space/blog/linux/ProcessStatesAndProcStat
+    // and https://lore.kernel.org/lkml/12601530441257@xenotime.net/#t
+    // and the canonical man page description at https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+    _syst_tr = bf.parsed_prefixed_value("procs_running");
+    _syst_tb = bf.parsed_prefixed_value("procs_blocked");
+  }
+
+  // cgroups business
+  CGroups::cgroup_values_t v;
+  if (CGroups::get_stats(&v)) {
+    _syst_cgro_usg = v.usg;
+    _syst_cgro_usgsw = v.usgsw;
+    _syst_cgro_kusg = v.kusg;
+    _syst_cgro_lim = v.lim;
+    _syst_cgro_limsw = v.limsw;
+    _syst_cgro_slim = v.slim;
+  }
+
+  if (bf.read("/proc/self/status")) {
+
+    _proc_virt = bf.parsed_prefixed_value("VmSize:", K);
+    _proc_swdo = bf.parsed_prefixed_value("VmSwap:", K);
+    _proc_rss_all = bf.parsed_prefixed_value("VmRSS:", K);
+    _proc_rss_anon = bf.parsed_prefixed_value("RssAnon:", K);
+    _proc_rss_file = bf.parsed_prefixed_value("RssFile:", K);
+    _proc_rss_shm = bf.parsed_prefixed_value("RssShmem:", K);
+
+    _proc_thr = bf.parsed_prefixed_value("Threads:");
+
+  }
+
+  // Number of open files: iterate over /proc/self/fd and count.
+  {
+    DIR* d = ::opendir("/proc/self/fd");
+    if (d != NULL) {
+      value_t v = 0;
+      struct dirent* en = NULL;
+      do {
+        en = ::readdir(d);
+        if (en != NULL) {
+          v ++;
+        }
+      } while(en != NULL);
+      ::closedir(d);
+      assert(v >= 2, "should have read at least '.' and '..'");
+      v -= 2; // We discount . and ..
+      _proc_io_of = v;
+    }
+  }
+
+  // Number of processes: iterate over /proc/<pid> and count.
+  // Number of threads: read "num_threads" from /proc/<pid>/stat
+  {
+    DIR* d = ::opendir("/proc");
+    if (d != NULL) {
+      value_t v_p = 0;
+      value_t v_t = 0;
+      struct dirent* en = NULL;
+      do {
+        en = ::readdir(d);
+        if (en != NULL) {
+          if (is_numerical_id(en->d_name)) {
+            v_p ++;
+            char tmp[128];
+            jio_snprintf(tmp, sizeof(tmp), "/proc/%s/stat", en->d_name);
+            if (bf.read(tmp)) {
+              const char* text = bf.text();
+              // See man proc(5)
+              // (20) num_threads  %ld
+              long num_threads = 0;
+              ::sscanf(text, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %*u %*u %*d %*d %*d %*d %ld", &num_threads);
+              v_t += num_threads;
+            }
+          }
+        }
+      } while(en != NULL);
+      ::closedir(d);
+      _syst_p = v_p;
+      _syst_t = v_t;
+    }
+  }
+
+  if (bf.read("/proc/self/io")) {
+    _proc_io_rd = bf.parsed_prefixed_value("rchar:");
+    _proc_io_wr = bf.parsed_prefixed_value("wchar:");
+  }
+
+  if (bf.read("/proc/self/stat")) {
+    const char* text = bf.text();
+    // See man proc(5)
+    // (14) utime  %lu
+    // (15) stime  %lu
+    long unsigned cpu_utime = 0;
+    long unsigned cpu_stime = 0;
+    ::sscanf(text, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu", &cpu_utime, &cpu_stime);
+    _proc_cpu_us = cpu_utime;
+    _proc_cpu_sy = cpu_stime;
+  }
+
+#ifdef __GLIBC__
+  // Note "glibc heap used", from experiments and glibc source code reading, would be aprox. the sum
+  //  of mmaped data area size (contains large allocations) and the small block sizes.
+  if (g_mallinfo2 != NULL) {
+    glibc_mallinfo2 mi = g_mallinfo2();
+    _proc_chea_usd = mi.uordblks + mi.hblkhd;
+    _proc_chea_free = mi.fordblks;
+  } else if (g_mallinfo != NULL) {
+    // disregard output from old style mallinfo if rss > 4g, since we cannot
+    // know whether we wrapped. For rss < 4g, we know values in mallinfo cannot
+    // have wrapped.
+    if (LP64_ONLY(_proc_rss_all < (4 * G)) NOT_LP64(true)) {
+      glibc_mallinfo mi = g_mallinfo();
+      _proc_chea_usd = (value_t)(unsigned)mi.uordblks + (value_t)(unsigned)mi.hblkhd;
+      _proc_chea_free = (value_t)(unsigned)mi.fordblks;
+    }
+  }
+#endif // __GLIBC__
+
+}
+
+bool OSWrapper::initialize() {
+#ifdef __GLIBC__
+  mallinfo_init();
+#endif
+  return CGroups::initialize();
+}
+
+} // namespace sapmachine_vitals

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.hpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_VITALS_LINUX_PROCFS_HPP
+#define OS_LINUX_VITALS_LINUX_PROCFS_HPP
+
+#include "utilities/globalDefinitions.hpp"
+#include "vitals/vitals_internals.hpp"
+
+namespace sapmachine_vitals {
+
+class OSWrapper {
+
+  static time_t _last_update;
+
+#define ALL_VALUES_DO(f) \
+		f(syst_phys) \
+	  f(syst_avail) \
+	  f(syst_comm) \
+	  f(syst_crt) \
+	  f(syst_swap) \
+	  f(syst_si) \
+	  f(syst_so) \
+	  f(syst_p) \
+	  f(syst_t) \
+	  f(syst_tr) \
+	  f(syst_tb) \
+	  f(syst_cpu_us) \
+	  f(syst_cpu_sy) \
+	  f(syst_cpu_id) \
+	  f(syst_cpu_st) \
+	  f(syst_cpu_gu) \
+	  f(syst_cgro_lim) \
+	  f(syst_cgro_limsw) \
+	  f(syst_cgro_slim) \
+	  f(syst_cgro_usg) \
+	  f(syst_cgro_usgsw) \
+	  f(syst_cgro_kusg) \
+	  f(proc_virt) \
+	  f(proc_rss_all) \
+	  f(proc_rss_anon) \
+	  f(proc_rss_file) \
+	  f(proc_rss_shm) \
+	  f(proc_swdo) \
+	  f(proc_chea_usd) \
+	  f(proc_chea_free) \
+	  f(proc_cpu_us) \
+	  f(proc_cpu_sy) \
+	  f(proc_io_of) \
+	  f(proc_io_rd) \
+	  f(proc_io_wr) \
+	  f(proc_thr) \
+
+#define DECLARE_VARIABLE(name) \
+  static value_t _##name;
+
+ALL_VALUES_DO(DECLARE_VARIABLE)
+
+#undef DECLARE_VARIABLE
+
+public:
+
+#define DEFINE_GETTER(name) \
+  static value_t name() { return _ ## name; }
+
+ALL_VALUES_DO(DEFINE_GETTER)
+
+#undef DEFINE_GETTER
+
+  static void update_if_needed();
+
+  static bool initialize();
+
+};
+
+} // namespace sapmachine_vitals
+
+#endif // OS_LINUX_VITALS_LINUX_HELPERS_HPP

--- a/src/hotspot/os/windows/vitals_windows.cpp
+++ b/src/hotspot/os/windows/vitals_windows.cpp
@@ -41,21 +41,19 @@ static Column* g_col_process_working_set_size = NULL;
 static Column* g_col_process_commit_charge = NULL;
 
 bool platform_columns_initialize() {
-  g_col_system_memoryload = new PlainValueColumn("system", NULL, "mload",
-      "Approximate percentage of physical memory that is in use.");
+  g_col_system_memoryload =
+      define_column<PlainValueColumn>("system", NULL, "mload", "Approximate percentage of physical memory that is in use.", true);
 
   // MEMORYSTATUSEX ullAvailPhys
-  g_col_system_avail_phys = new MemorySizeColumn("system", NULL, "avail-phys",
-      "Amount of physical memory currently available.");
-
+  g_col_system_avail_phys =
+      define_column<MemorySizeColumn>("system", NULL, "avail-phys", "Amount of physical memory currently available.", true);
   // PROCESS_MEMORY_COUNTERS_EX WorkingSetSize
-  g_col_process_working_set_size = new MemorySizeColumn("process", NULL, "wset",
-      "Working set size");
+  g_col_process_working_set_size =
+      define_column<MemorySizeColumn>("system", NULL, "wset", "Working set size", true);
 
   // PROCESS_MEMORY_COUNTERS_EX PrivateUsage
-  g_col_process_commit_charge = new MemorySizeColumn("process", NULL, "comch",
-      "Commit charge");
-
+  g_col_process_commit_charge =
+      define_column<MemorySizeColumn>("system", NULL, "comch", "Commit charge", true);
 
   return true;
 }

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -193,6 +193,7 @@
   LOG_TAG(valuebasedclasses) \
   LOG_TAG(verification) \
   LOG_TAG(verify) \
+  LOG_TAG(vitals) /* SapMachine 2022-06-01: Vitals */ \
   LOG_TAG(vmmutex) \
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -149,6 +149,9 @@
 
 // SapMachine 2019-02-20 : vitals
 #include "vitals/vitals.hpp"
+#ifdef LINUX
+#include "vitals_linux_himemreport.hpp"
+#endif
 
 // Initialization after module runtime initialization
 void universe_post_module_init();  // must happen after call_initPhase2
@@ -3054,6 +3057,11 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (EnableVitals) {
     sapmachine_vitals::initialize();
   }
+#ifdef LINUX
+  if (HiMemReport) {
+    sapmachine_vitals::initialize_himem_report_facility();
+  }
+#endif // LINUX
 
 #if INCLUDE_RTM_OPT
   RTMLockingCounters::init();
@@ -3500,9 +3508,6 @@ void Threads::add(JavaThread* p, bool force_daemon) {
 
   _number_of_threads++;
 
-  // SapMachine 2019-02-20 : vitals
-  sapmachine_vitals::counters::inc_threads_created(1);
-
   oop threadObj = p->threadObj();
   bool daemon = true;
   // Bootstrapping problem: threadObj can be null for initial
@@ -3525,6 +3530,9 @@ void Threads::add(JavaThread* p, bool force_daemon) {
 
   // Make new thread known to active EscapeBarrier
   EscapeBarrier::thread_added(p);
+
+  // SapMachine 2019-02-20 : vitals
+  sapmachine_vitals::counters::inc_threads_created(1);
 
 }
 
@@ -3788,6 +3796,15 @@ void Threads::print_on(outputStream* st, bool print_stacks,
     st->cr();
   }
 
+#ifdef LINUX
+  // SapMachine 2022-05-07 : HiMemReport
+  const Thread* himem_reporter_thread = sapmachine_vitals::himem_reporter_thread();
+  if (himem_reporter_thread != NULL) {
+    himem_reporter_thread->print_on(st);
+    st->cr();
+  }
+#endif
+
   st->flush();
 }
 
@@ -3845,6 +3862,11 @@ void Threads::print_on_error(outputStream* st, Thread* current, char* buf,
   // SapMachine 2019-11-07 : vitals
   print_on_error(const_cast<Thread*>(sapmachine_vitals::samplerthread()),
                  st, current, buf, buflen, &found_current);
+#ifdef LINUX
+  // SapMachine 2022-05-07 : HiMemReport
+  print_on_error(const_cast<Thread*>(sapmachine_vitals::himem_reporter_thread()),
+                 st, current, buf, buflen, &found_current);
+#endif
 
   if (Universe::heap() != NULL) {
     PrintOnErrorClosure print_closure(st, current, buf, buflen, &found_current);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -69,7 +69,9 @@
 
 // SapMachine 2019-02-20 : vitals
 #include "vitals/vitals.hpp"
-
+#ifdef LINUX
+#include "vitals_linux_himemreport.hpp"
+#endif
 // SapMachine 2021-09-01: malloc-trace
 #ifdef LINUX
 #include "malloctrace/mallocTrace.hpp"
@@ -1171,6 +1173,13 @@ void VMError::report(outputStream* st, bool _verbose) {
        sapmachine_vitals::print_report(st, &info);
      }
 
+#ifdef LINUX
+  STEP("Vitals HiMemReport")
+    st->cr();
+  sapmachine_vitals::print_himemreport_state(st);
+    st->cr();
+#endif // LINUX
+
   STEP("printing system")
 
      if (_verbose) {
@@ -1364,9 +1373,16 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("Vitals")
   sapmachine_vitals::print_info_t info;
   sapmachine_vitals::default_settings(&info);
-  info.sample_now = false;
+  info.sample_now = true;
   st->print_cr("Vitals:");
   sapmachine_vitals::print_report(st, &info);
+
+#ifdef LINUX
+  // STEP("Vitals HiMemReport")
+  st->cr();
+  sapmachine_vitals::print_himemreport_state(st);
+  st->cr();
+#endif // LINUX
 
   // STEP("printing system")
 

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -54,7 +54,7 @@
 #include <time.h>
 
 // JDK-8280583: "Always build NMT" did away with INCLUDE_NMT for JDK19++
-#ifdef JDK_MAINLINE
+#if defined(JDK_MAINLINE) || defined(JDK19u)
 #define INCLUDE_NMT 1
 #endif
 
@@ -232,6 +232,52 @@ public:
   }
 };
 
+
+////// Legend ///////////////////////////////////////////////
+
+Legend* Legend::_the_legend = NULL;
+
+bool Legend::initialize() {
+  _the_legend = new Legend();
+  return _the_legend != NULL;
+}
+
+stringStream _legend;
+stringStream _footnote;
+static Legend* _the_legend;
+
+Legend::Legend() : _last_added_cat(NULL) {}
+
+void Legend::add_column_info(const char* const category, const char* const header,
+                       const char* const name, const char* const description) {
+  // Print category label if this column opens a new category
+  if (_last_added_cat != category) {
+    print_text_with_dashes(&_legend, category, 30);
+    _legend.cr();
+  }
+  _last_added_cat = category;
+  // print column name and description
+  const int min_width_column_label = 16;
+  char buf[32];
+  if (header != NULL) {
+    jio_snprintf(buf, sizeof(buf), "%s-%s", header, name);
+  } else {
+    jio_snprintf(buf, sizeof(buf), "%s", name);
+  }
+  _legend.print_cr("%*s: %s", min_width_column_label, buf, description);
+}
+
+void Legend::add_footnote(const char* text) {
+  _footnote.print_cr("%s", text);
+}
+
+void Legend::print_on(outputStream* st) const {
+  st->print_raw(_legend.base());
+  st->cr();
+  st->print_raw(_footnote.base());
+  st->print_cr("(Vitals version %X, pid: %d)", vitals_version, os::current_process_id());
+}
+
 ////// ColumnList: a singleton class holding all information about all columns
 
 ColumnList* ColumnList::_the_list = NULL;
@@ -361,50 +407,6 @@ static void print_column_names(outputStream* st, const ColumnWidths* widths, con
   st->cr();
 }
 
-static void print_legend(outputStream* st, const print_info_t* pi) {
-  const Column* c = ColumnList::the_list()->first();
-  const Column* c_prev = NULL;
-  while (c != NULL) {
-    // Print category label.
-    if (c->index_within_category_section() == 0) {
-      print_text_with_dashes(st, c->category(), 30);
-      st->cr();
-    }
-    // print column name and description
-    const int min_width_column_label = 16;
-    char buf[32];
-    if (c->header() != NULL) {
-      jio_snprintf(buf, sizeof(buf), "%s-%s", c->header(), c->name());
-    } else {
-      jio_snprintf(buf, sizeof(buf), "%s", c->name());
-    }
-    st->print("%*s: %s", min_width_column_label, buf, c->description());
-
-    // If column is a delta value, indicate so
-    if (c->is_delta()) {
-      st->print_raw(" [delta]");
-    }
-
-    st->cr();
-
-    c_prev = c;
-    c = c->next();
-  }
-  st->cr();
-  st->print_cr("[delta] values refer to the previous measurement.");
-  if (pi->scale != 0) {
-    const char* display_unit = NULL;
-    switch (pi->scale) {
-      case 1: display_unit = "  "; break;
-      case K: display_unit = "KB"; break;
-      case M: display_unit = "MB"; break;
-      case G: display_unit = "GB"; break;
-      default: ShouldNotReachHere();
-    }
-    st->print_cr("[mem] values are in %s.", display_unit);
-  }
-}
-
 // Print a human readable size.
 // byte_size: size, in bytes, to be printed.
 // scale: K,M,G or 0 (dynamic)
@@ -481,17 +483,14 @@ static int print_memory_size(outputStream* st, size_t byte_size, size_t scale)  
 
 ///////// class Column and childs ///////////
 
-Column::Column(const char* category, const char* header, const char* name, const char* description, bool delta)
+Column::Column(const char* category, const char* header, const char* name, const char* description)
   : _category(category),
     _header(header), // may be NULL
     _name(name),
     _description(description),
-    _delta(delta),
     _next(NULL), _idx(-1),
     _idx_cat(-1), _idx_hdr(-1)
-{
-  ColumnList::the_list()->add_column(this);
-}
+{}
 
 void Column::print_value(outputStream* st, value_t value, value_t last_value,
     int last_value_age, int min_width, const print_info_t* pi) const {
@@ -546,7 +545,7 @@ int PlainValueColumn::do_print0(outputStream* st, value_t value,
 
 int DeltaValueColumn::do_print0(outputStream* st, value_t value,
     value_t last_value, int last_value_age, const print_info_t* pi) const {
-  if (_show_only_positive && last_value > value) {
+  if (last_value > value) {
     // we assume the underlying value to be monotonically raising, and that
     // any negative delta would be just a fluke (e.g. counter overflows)
     // we do not want to show
@@ -585,14 +584,6 @@ static void print_one_sample(outputStream* st, const Sample* sample,
   if (pi->csv) {
     st->print("\"");
   }
-
-  // For analysis, print sample numbers
-#ifdef ASSERT
-  if (pi->raw) {
-    st->print(",%d,%d", sample->num(),
-              last_sample != NULL ? last_sample->num() : -1);
-  }
-#endif
 
   if (pi->csv == false) {
     ostream_put_n(st, ' ', TIMESTAMP_DIVIDER_LEN);
@@ -979,18 +970,28 @@ static Column* g_col_heap_used = NULL;
 
 static Column* g_col_metaspace_committed = NULL;
 static Column* g_col_metaspace_used = NULL;
+
+static bool g_show_classspace_columns = false;
 static Column* g_col_classspace_committed = NULL;
 static Column* g_col_classspace_used = NULL;
+
 static Column* g_col_metaspace_cap_until_gc = NULL;
 
 static Column* g_col_codecache_committed = NULL;
 
+static bool g_show_nmt_columns = false;
 static Column* g_col_nmt_malloc = NULL;
 static Column* g_col_nmt_mmap = NULL;
+static Column* g_col_nmt_gc_overhead = NULL;
+static Column* g_col_nmt_other = NULL;
+static Column* g_col_nmt_overhead = NULL;
 
 static Column* g_col_number_of_java_threads = NULL;
 static Column* g_col_number_of_java_threads_non_demon = NULL;
+
+static bool g_show_size_thread_stacks_col = false;
 static Column* g_col_size_thread_stacks = NULL;
+
 static Column* g_col_number_of_java_threads_created = NULL;
 
 static Column* g_col_number_of_clds = NULL;
@@ -1000,67 +1001,91 @@ static Column* g_col_number_of_classes = NULL;
 static Column* g_col_number_of_class_loads = NULL;
 static Column* g_col_number_of_class_unloads = NULL;
 
-//...
+static bool is_nmt_enabled() {
+#if INCLUDE_NMT
+  // Note: JDK version dependency: Before JDK18, NMT had the ability to shut down operations
+  // at any point in time, and therefore we also had NMT_minimal tracking level. Therefore,
+  // to stay version independent, we never must compare against NMT_off or NMT_minimal directly,
+  // only always against NMT_summary/detail. And to be very safe, don't assume a numerical
+  // value either, since older JDKs had NMT_unknown as a very high numerical value.
+  const NMT_TrackingLevel lvl = MemTracker::tracking_level();
+  return (lvl == NMT_summary || lvl == NMT_detail);
+#else
+  return false;
+#endif
+}
 
 static bool add_jvm_columns() {
   // Order matters!
+  const char* const jvm_cat = "jvm";
 
-  g_col_heap_committed = new MemorySizeColumn("jvm",
-      "heap", "comm", "Java Heap Size, committed");
-  g_col_heap_used = new MemorySizeColumn("jvm",
-      "heap", "used", "Java Heap Size, used");
+  Legend::the_legend()->add_footnote("  [delta]: values refer to the previous measurement.");
+  Legend::the_legend()->add_footnote("    [nmt]: only shown if NMT is available and activated");
+  Legend::the_legend()->add_footnote("     [cs]: only shown on 64-bit if class space is active");
+  Legend::the_legend()->add_footnote("  [linux]: only on Linux");
 
-  g_col_metaspace_committed = new MemorySizeColumn("jvm",
-      "meta", "comm", "Meta Space Size (class+nonclass), committed");
+  g_col_heap_committed =
+      define_column<MemorySizeColumn>(jvm_cat, "heap", "comm", "Java Heap Size, committed", true);
+  g_col_heap_used =
+      define_column<MemorySizeColumn>(jvm_cat, "heap", "used", "Java Heap Size, used", true);
 
-  g_col_metaspace_used = new MemorySizeColumn("jvm",
-      "meta", "used", "Meta Space Size (class+nonclass), used");
+  g_col_metaspace_committed =
+      define_column<MemorySizeColumn>(jvm_cat, "meta", "comm", "Meta Space Size (class+nonclass), committed", true);
+  g_col_metaspace_used =
+      define_column<MemorySizeColumn>(jvm_cat, "meta", "used", "Meta Space Size (class+nonclass), used", true);
 
-  if (Metaspace::using_class_space()) {
-    g_col_classspace_committed = new MemorySizeColumn("jvm",
-        "meta", "csc", "Class Space Size, committed");
-    g_col_classspace_used = new MemorySizeColumn("jvm",
-        "meta", "csu", "Class Space Size, used");
-  }
+  // Class space columns only shown if class space is active
+  g_show_classspace_columns = Metaspace::using_class_space();
+  g_col_classspace_committed =
+      define_column<MemorySizeColumn>(jvm_cat, "meta", "csc", "Class Space Size, committed [cs]", g_show_classspace_columns);
+  g_col_classspace_used =
+      define_column<MemorySizeColumn>(jvm_cat, "meta", "csu", "Class Space Size, used [cs]",  g_show_classspace_columns);
 
-  g_col_metaspace_cap_until_gc = new MemorySizeColumn("jvm",
-      "meta", "gctr", "GC threshold");
+  g_col_metaspace_cap_until_gc =
+      define_column<MemorySizeColumn>(jvm_cat, "meta", "gctr", "GC threshold", true);
 
-  g_col_codecache_committed = new MemorySizeColumn("jvm",
-      NULL, "code", "Code cache, committed");
+  g_col_codecache_committed =
+      define_column<MemorySizeColumn>(jvm_cat, NULL, "code", "Code cache, committed", true);
 
-  g_col_nmt_malloc = new MemorySizeColumn("jvm",
-      "nmt", "mlc", "Memory malloced by hotspot (requires NMT)");
+  // NMT columns only shown if NMT is at least at summary level
+  g_show_nmt_columns = is_nmt_enabled();
+  g_col_nmt_malloc =
+     define_column<MemorySizeColumn>(jvm_cat, "nmt", "mlc", "Memory malloced by hotspot [nmt]", g_show_nmt_columns);
+  g_col_nmt_mmap =
+      define_column<MemorySizeColumn>(jvm_cat, "nmt", "map", "Memory mapped by hotspot [nmt]", g_show_nmt_columns);
+  g_col_nmt_gc_overhead =
+      define_column<MemorySizeColumn>(jvm_cat, "nmt", "gc", "NMT \"gc\" (GC-overhead, malloc and mmap) [nmt]", g_show_nmt_columns);
+  g_col_nmt_other =
+      define_column<MemorySizeColumn>(jvm_cat, "nmt", "oth", "NMT \"other\" (typically DBB or Unsafe.allocateMemory) [nmt]", g_show_nmt_columns);
+  g_col_nmt_overhead =
+      define_column<MemorySizeColumn>(jvm_cat, "nmt", "ovh", "NMT overhead [nmt]", g_show_nmt_columns);
 
-  g_col_nmt_mmap = new MemorySizeColumn("jvm",
-      "nmt", "map", "Memory mapped and committed by hotspot (requires NMT)");
+  g_col_number_of_java_threads =
+      define_column<PlainValueColumn>(jvm_cat, "jthr", "num", "Number of java threads", true);
+  g_col_number_of_java_threads_non_demon =
+      define_column<PlainValueColumn>(jvm_cat, "jthr", "nd", "Number of non-demon java threads", true);
+  g_col_number_of_java_threads_created =
+      define_column<DeltaValueColumn>(jvm_cat, "jthr", "cr", "Threads created [delta]", true);
 
-  g_col_number_of_java_threads = new PlainValueColumn("jvm",
-      "jthr", "num", "Number of java threads");
+  // Displaying thread stack size for now only implemented on Linux, and requires NMT
+  g_show_size_thread_stacks_col = LINUX_ONLY(g_show_nmt_columns) NOT_LINUX(false);
+  g_col_size_thread_stacks =
+      define_column<MemorySizeColumn>(jvm_cat, "jthr", "st", "Total reserved size of java thread stacks [nmt] [linux]",
+          g_show_size_thread_stacks_col);
 
-  g_col_number_of_java_threads_non_demon = new PlainValueColumn("jvm",
-      "jthr", "nd", "Number of non-demon java threads");
+  g_col_number_of_clds =
+      define_column<PlainValueColumn>(jvm_cat,  "cldg", "num", "Classloader Data", true);
+  g_col_number_of_anon_clds =
+      define_column<PlainValueColumn>(jvm_cat,  "cldg", "anon", "Anonymous CLD", true);
 
-  g_col_number_of_java_threads_created = new DeltaValueColumn("jvm",
-      "jthr", "cr", "Threads created");
+  g_col_number_of_classes =
+      define_column<PlainValueColumn>(jvm_cat, "cls", "num", "Classes (instance + array)", true);
 
-  g_col_size_thread_stacks = new MemorySizeColumn("jvm",
-      "jthr", "st", "Total reserved size of java thread stacks");
+  g_col_number_of_class_loads =
+        define_column<DeltaValueColumn>(jvm_cat, "cls", "ld", "Class loaded [delta]", true);
 
-  g_col_number_of_clds = new PlainValueColumn("jvm",
-      "cldg", "num", "Classloader Data");
-
-  g_col_number_of_anon_clds = new PlainValueColumn("jvm",
-      "cldg", "anon", "Anonymous CLD");
-
-  g_col_number_of_classes = new PlainValueColumn("jvm",
-      "cls", "num", "Classes (instance + array)");
-
-  g_col_number_of_class_loads = new DeltaValueColumn("jvm",
-      "cls", "ld", "Class loaded");
-
-  g_col_number_of_class_unloads = new DeltaValueColumn("jvm",
-      "cls", "uld", "Classes unloaded");
+  g_col_number_of_class_unloads =
+        define_column<DeltaValueColumn>(jvm_cat, "cls", "uld", "Classes unloaded [delta]", true);
 
   return true;
 }
@@ -1075,33 +1100,6 @@ static void set_value_in_sample(const Column* col, Sample* sample, T t) {
     assert(ColumnList::the_list()->is_valid_column_index(idx), "Invalid column index");
     sample->set_value(idx, (value_t)t);
   }
-}
-
-class AddStackSizeThreadClosure: public ThreadClosure {
-  size_t _l;
-public:
-  AddStackSizeThreadClosure() : ThreadClosure(), _l(0) {}
-  void do_thread(Thread* thread) {
-    _l += thread->stack_size();
-  }
-  size_t get() const { return _l; }
-};
-
-static uint64_t accumulate_thread_stack_size() {
-#if defined(LINUX)
-  // Do not iterate thread list and query stack size until 8212173 is completely solved. It is solved
-  // for Linux (possibly BSD); on the other platforms, one runs a miniscule but real risk of triggering
-  // the assert in Thread::stack_size().
-  size_t l = 0;
-  AddStackSizeThreadClosure tc;
-  {
-    MutexLocker ml(Threads_lock);
-    Threads::threads_do(&tc);
-  }
-  return (uint64_t)tc.get();
-#else
-  return INVALID_VALUE;
-#endif
 }
 
 // Count CLDs
@@ -1119,29 +1117,70 @@ public:
 };
 
 #if INCLUDE_NMT
-static value_t get_bytes_malloced_by_jvm_via_nmt() {
+struct nmt_values_t {
+  // How much memory, in total, was committed via mmap
+  value_t mapped_total;
+  // How much memory, in total, was malloced
+  value_t malloced_total;
+  // How many allocations from malloc, in total
+  value_t malloced_num;
+  // thread stack size; depending on NMT version this would
+  // be reserved (I believe up to and including jdk 8) or committed (9+)
+  value_t thread_stacks_committed;
+  // NMT "GC" category (both malloced and mapped)
+  value_t gc_overhead;
+  // NMT "other" category (both malloced and mapped). Usually dominated by DBB allocated with allocateDirect(),
+  // and Unsafe.allocateMemory.
+  value_t other_memory;
+  // NMT overhead  (both malloced and mapped)
+  value_t overhead;
+};
+
+static bool get_nmt_values(nmt_values_t* out) {
   value_t result = INVALID_VALUE;
-  if (MemTracker::tracking_level() != NMT_off) {
+  if (is_nmt_enabled()) {
     MutexLocker locker(MemTracker::query_lock());
-    result = MallocMemorySummary::as_snapshot()->total();
+    /*const*/MallocMemorySnapshot* mlc_snapshot = MallocMemorySummary::as_snapshot();
+    VirtualMemorySnapshot vm_snapshot;
+    VirtualMemorySummary::snapshot(&vm_snapshot);
+    out->malloced_total = mlc_snapshot->total();
+    out->mapped_total = vm_snapshot.total_committed();
+    out->thread_stacks_committed =
+        vm_snapshot.by_type(mtThreadStack)->committed();
+    out->thread_stacks_committed =
+        vm_snapshot.by_type(MEMFLAGS::mtThreadStack)->committed() +
+        mlc_snapshot->by_type(MEMFLAGS::mtThreadStack)->malloc_size();
+    out->gc_overhead =
+        vm_snapshot.by_type(MEMFLAGS::mtGC)->committed() +
+        mlc_snapshot->by_type(MEMFLAGS::mtGC)->malloc_size();
+    out->other_memory =
+        vm_snapshot.by_type(MEMFLAGS::mtOther)->committed() +
+        mlc_snapshot->by_type(MEMFLAGS::mtOther)->malloc_size();
+    out->overhead =
+        vm_snapshot.by_type(MEMFLAGS::mtNMT)->committed() +
+        mlc_snapshot->by_type(MEMFLAGS::mtNMT)->malloc_size() +
+        mlc_snapshot->malloc_overhead()->size();
+    out->malloced_num =
+        // I misuse the tracking overhead counter, since all malloc allocations should have been counted here
+        mlc_snapshot->malloc_overhead()->count();
+    return true;
   }
-  return result;
-}
-static value_t get_bytes_mmaped_by_jvm_via_nmt() {
-  value_t result = INVALID_VALUE;
-  if (MemTracker::tracking_level() != NMT_off) {
-    MutexLocker locker(MemTracker::query_lock());
-    VirtualMemorySnapshot snapshot;
-    VirtualMemorySummary::snapshot(&snapshot);
-    result = snapshot.total_committed();
-  }
-  return result;
+  return false;
 }
 #endif // INCLUDE_NMT
 
 void sample_jvm_values(Sample* sample, bool avoid_locking) {
 
   // Note: if avoid_locking=true, skip values which need JVM-side locking.
+
+  nmt_values_t nmt_vals;
+  bool have_nmt_values = false;
+#if INCLUDE_NMT
+  if (!avoid_locking) {
+    have_nmt_values = get_nmt_values(&nmt_vals);
+  }
+#endif
+
 
   // Heap
   if (!avoid_locking) {
@@ -1177,12 +1216,13 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   set_value_in_sample(g_col_codecache_committed, sample, codecache_committed);
 
   // NMT integration
-#if INCLUDE_NMT
-  if (!avoid_locking) {
-    set_value_in_sample(g_col_nmt_malloc, sample, get_bytes_malloced_by_jvm_via_nmt());
-    set_value_in_sample(g_col_nmt_mmap, sample, get_bytes_mmaped_by_jvm_via_nmt());
+  if (have_nmt_values) {
+    set_value_in_sample(g_col_nmt_malloc, sample, nmt_vals.malloced_total);
+    set_value_in_sample(g_col_nmt_mmap, sample, nmt_vals.mapped_total);
+    set_value_in_sample(g_col_nmt_gc_overhead, sample, nmt_vals.gc_overhead);
+    set_value_in_sample(g_col_nmt_other, sample, nmt_vals.other_memory);
+    set_value_in_sample(g_col_nmt_overhead, sample, nmt_vals.overhead);
   }
-#endif
 
   // Java threads
   set_value_in_sample(g_col_number_of_java_threads, sample, Threads::number_of_threads());
@@ -1190,8 +1230,8 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   set_value_in_sample(g_col_number_of_java_threads_created, sample, counters::g_threads_created);
 
   // Java thread stack size
-  if (!avoid_locking) {
-    set_value_in_sample(g_col_size_thread_stacks, sample, accumulate_thread_stack_size());
+  if (have_nmt_values) {
+    set_value_in_sample(g_col_size_thread_stacks, sample, nmt_vals.thread_stacks_committed);
   }
 
   // CLDG
@@ -1214,16 +1254,22 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 
 bool initialize() {
 
-  log_info(os)("Initializing vitals...");
+  static bool initialized = false;
+  assert(initialized == false, "Vitals already initialized");
+  initialized = true;
+
+  log_info(vitals)("Vitals v%x", vitals_version);
+  log_info(vitals)("Initializing vitals...");
 
   // Adjust VitalsSampleInterval
   if (VitalsSampleInterval == 0) {
-    log_warning(os)("Invalid VitalsSampleInterval (" UINTX_FORMAT ") specified. Vitals disabled.",
+    log_warning(vitals)("Invalid VitalsSampleInterval (" UINTX_FORMAT ") specified. Vitals disabled.",
                     VitalsSampleInterval);
     return false;
   }
 
   bool success = ColumnList::initialize();
+  success &= Legend::initialize();
 
   // Order matters. First platform columns, then jvm columns.
   success &= platform_columns_initialize();
@@ -1237,12 +1283,12 @@ bool initialize() {
   success &= initialize_sampler_thread();
 
   if (success) {
-    log_info(os)("Vitals intialized. Sample interval: " UINTX_FORMAT " seconds.", VitalsSampleInterval);
+    log_info(vitals)("Vitals intialized. Sample interval: " UINTX_FORMAT " seconds.", VitalsSampleInterval);
   } else {
-    log_warning(os)("Failed to initialize Vitals.");
+    log_warning(vitals)("Failed to initialize Vitals.");
   }
 
-  return true;
+  return success;
 
 }
 
@@ -1281,13 +1327,25 @@ void print_report(outputStream* st, const print_info_t* pinfo) {
 
   // Print legend at the top (omit if suppressed on command line, or in csv mode).
   if (info.no_legend == false && info.csv == false) {
-    print_legend(st, &info);
+    Legend::the_legend()->print_on(st);
+    if (info.scale != 0) {
+      const char* display_unit = NULL;
+      switch (info.scale) {
+        case 1: display_unit = "bytes"; break;
+        case K: display_unit = "KB"; break;
+        case M: display_unit = "MB"; break;
+        case G: display_unit = "GB"; break;
+        default: ShouldNotReachHere();
+      }
+      st->print_cr("[mem] values are in %s.", display_unit);
+    }
     st->cr();
   }
 
   // If we are to sample the current values at print time, do that and print them too.
+  // Note: we omit the "Now" sample for csv output.
   Sample* sample_now = NULL;
-  if (info.sample_now) {
+  if (info.sample_now && !info.csv) {
     sample_now = Sample::allocate();
     sample_values(sample_now, true /* never lock for now sample - be safe */ );
   }

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -31,12 +31,8 @@
 
 // Configure for different JDK versions
 //#define JDK_MAINLINE
-<<<<<<< HEAD
+//#define JDK19u
 #define JDK18u
-=======
-#define JDK19u
-//#define JDK18u
->>>>>>> 485e5731ef5... SapMachine #1124: Vitals: June 22 package (SapMachine 19)
 //#define JDK17u
 //#define JDK11u
 

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -31,7 +31,12 @@
 
 // Configure for different JDK versions
 //#define JDK_MAINLINE
+<<<<<<< HEAD
 #define JDK18u
+=======
+#define JDK19u
+//#define JDK18u
+>>>>>>> 485e5731ef5... SapMachine #1124: Vitals: June 22 package (SapMachine 19)
 //#define JDK17u
 //#define JDK11u
 

--- a/src/hotspot/share/vitals/vitalsDCmd.cpp
+++ b/src/hotspot/share/vitals/vitalsDCmd.cpp
@@ -95,6 +95,9 @@ void VitalsDCmd::execute(DCmdSource source, TRAPS) {
   info.sample_now = _sample_now.value();
 
   output()->print_cr("Vitals:");
+  if (info.sample_now && info.csv) {
+    output()->print_cr("(\"now\" ignored in csv mode)");
+  }
   sapmachine_vitals::print_report(output(), &info);
 }
 

--- a/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
+++ b/test/hotspot/jtreg/runtime/Vitals/CSVParser.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+
+public class CSVParser {
+
+    public final static class CSVHeader {
+        final List<String> columns = new ArrayList<>();
+        Hashtable<String, Integer> columnPositions = new Hashtable<>();
+
+        int size() {
+            return columns.size();
+        }
+
+        String at(int position) {
+            return columns.get(position);
+        }
+
+        int findColumn(String name) {
+            Integer i = columnPositions.get(name);
+            return (i == null) ? -1 : i;
+        }
+
+        boolean hasColumn(String name) {
+            return findColumn(name) != -1;
+        }
+
+        void addColumn(String name) {
+            if (columnPositions.containsKey(name)) {
+                throw new RuntimeException("Already have column " + name);
+            }
+            columns.add(name);
+            columnPositions.put(name, columns.size() - 1);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            for (String s : columns) {
+                bld.append(s);
+                bld.append(",");
+            }
+            return bld.toString();
+        }
+    }
+
+    public final static class CSVDataLine {
+        ArrayList<String> data = new ArrayList<>();
+
+        int size() {
+            return data.size();
+        }
+
+        String at(int position) {
+            return data.get(position);
+        }
+
+        boolean isEmpty(int position) {
+            String s = at(position);
+            return s == null || s.isEmpty() || s.equals("?");
+        }
+
+        long numberAt(int position) throws NumberFormatException {
+            if (isEmpty(position)) {
+                throw new RuntimeException("no data at position " + position);
+            }
+            return Long.parseLong(at(position));
+        }
+
+        void addData(String s) {
+            // If data was surrounded by quotes, remove quotes
+            if (s.startsWith("\"") && s.endsWith("\"")) {
+                s = s.substring(1, s.length() - 1);
+            }
+            s = s.trim();
+            data.add(s);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            for (String s : data) {
+                bld.append(s);
+                bld.append(",");
+            }
+            return bld.toString();
+        }
+    }
+
+    public final static class CSV {
+        public CSVHeader header;
+        public CSVDataLine[] lines;
+
+        // Convenience function. Given a column name and a data line number, return value for that column in that line
+        String getContentOfCell(String columnname, int lineno) {
+            return lines[lineno].at(header.findColumn(columnname));
+        }
+
+        long getContentOfCellAsNumber(String columnname, int lineno) {
+            return Long.parseLong(getContentOfCell(columnname, lineno));
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("CSV: " + header.size() + " columns, " + lines.length + " data lines.\n");
+            builder.append(header);
+            builder.append("\n");
+            for (CSVDataLine line : lines) {
+                builder.append(line);
+                builder.append("\n");
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class CSVParseException extends Exception {
+        public CSVParseException(String message) {
+            super("CSV parse error " + ": " + message);
+        }
+        public CSVParseException(String message, int errorLine) {
+            super("CSV parse error at line " + errorLine + ": " + message);
+        }
+    }
+
+    /**
+     * Parses the given lines as CSV. The first lines must be the header, all subsequent lines
+     * valid data.
+     * @param lines
+     * @return
+     */
+    public static final CSV parseCSV(String [] lines) throws CSVParseException {
+
+        if (lines.length < 2) {
+            throw new CSVParseException("Not enough data", -1);
+        }
+
+        System.out.println("--- CSV parser input: ---");
+        for (String s : lines) {
+            System.out.println(s);
+        }
+        System.out.println("--- /CSV parser input: ---");
+
+        int lineno = 0;
+        CSVHeader header = new CSVHeader();
+        ArrayList<CSVDataLine> datalines = new ArrayList<>();
+
+        try {
+            // Parse header line
+            String[] parts = lines[lineno].split(",");
+            for (String s : parts) {
+                header.addColumn(s);
+            }
+
+            lineno ++;
+
+            // Parse Data
+            while (lineno < lines.length) {
+                CSVDataLine dataLine = new CSVDataLine();
+                parts = lines[lineno].split(",");
+                for (String s : parts) {
+                    dataLine.addData(s);
+                }
+                if (dataLine.size() != header.size()) {
+                    // We have more or less data than columns. Print some helpful message to stderr, then abort.
+                    String s = "Line " + lineno + ": expected " + header.size() + " entries, found " + dataLine.size() + ".";
+                    System.err.println(s);
+                    System.err.println("Header: " + header.toString());
+                    System.err.println("Data: " + dataLine.toString());
+                    for (int i = 0; i < header.size() || i < dataLine.size(); i ++) {
+                        String col = (i < header.size() ? header.at(i) : "<NULL>");
+                        String dat = (i < dataLine.size() ? dataLine.at(i) : "<NULL>");
+                        System.err.println("pos: " + i + " column: " + col + " data: " + dat);
+                    }
+                    throw new CSVParseException(s, lineno);
+                }
+                datalines.add(dataLine);
+                lineno ++;
+            }
+
+        } catch (Exception e) {
+            System.err.println("--- CSV parse error : " + e.getMessage() + "---");
+            e.printStackTrace();
+            System.err.println("--- /CSV parse error : " + e.getMessage() + "---");
+            throw new CSVParseException(e.getMessage(), lineno);
+        }
+
+        CSV csv = new CSV();
+        csv.header = header;
+        CSVDataLine[] arr = new CSVDataLine[datalines.size()];
+        csv.lines = datalines.toArray(arr);
+
+        System.out.println("---- parsed ----");
+        System.out.println(csv);
+        System.out.println("---- /parsed ----");
+
+        return csv;
+
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2021, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestHiMemReport-print
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReport print
+ */
+
+/*
+ * @test TestHiMemReport-dump
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReport dump
+ */
+
+/*
+ * @test TestHiMemReport-dump-with-exec-to-reportdir
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReport dump-with-exec-to-reportdir
+ */
+
+/*
+ * @test TestHiMemReport-dump-with-exec-to-stderr
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReport dump-with-exec-to-stderr
+ */
+
+/*
+ * @test TestHiMemReport-natural-max
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReport natural-max
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TestHiMemReport {
+
+    // Match the output file suffix we generate with the HiMemReportFacility
+    // (xxx_pid<pid>_<year>_<month>_<day>_<hour>_<minute>_<second>.yyy)
+    static final String patterFileSuffix = "_pid\\d+_\\d+_\\d+_\\d+_\\d+_\\d+_\\d+";
+
+    // These tests are very simple. We start the VM with a footprint (rss) higher than
+    // what we set as HiMemReportMax. Therefore, the HiMem reporter should genereate a
+    // 100% report right away.
+    // Testing anything more is much more complicated since the test would have to
+    // predict, with a certain correctness, rss and swap.
+
+    static final String[] beforeReport = {
+        "HiMemoryReport: rss\\+swap=.* - alert level increased to 3 \\(>=\\d+%\\).",
+        "HiMemoryReport: ... seems we passed alert level 1 \\(\\d+%\\) without noticing.",
+        "HiMemoryReport: ... seems we passed alert level 2 \\(\\d+%\\) without noticing.",
+    };
+
+    static final String[] reportHeader = {
+            "# High Memory Report:",
+            "# rss\\+swap .* larger than \\d+% of HiMemReportMax.*",
+            "# Spike number: 1",
+    };
+
+    static final String[] reportBody = {
+            ".*Vitals.*",
+            "Now:",
+            "Native Memory Tracking:",
+            "Total: reserved=.*, committed=.*",
+            "# END: High Memory Report"
+    };
+
+    static void testPrint() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:NativeMemoryTracking=summary",
+                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                TestHiMemReport.class.getName(),
+                "sleep", "2" // num seconds to sleep to give the reporter thread time to generate output
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+
+        String[] lines = VitalsUtils.stderrAsLines(output);
+        int line = VitalsUtils.matchPatterns(lines, 0, beforeReport);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportHeader);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportBody);
+    }
+
+    static void testDump() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:NativeMemoryTracking=summary",
+                "-XX:HiMemReportDir=himemreport-1",
+                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                TestHiMemReport.class.getName(),
+                "sleep", "2" // num seconds to sleep to give the reporter thread time to generate output
+                );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+
+        // We expect, on stderr, just the report header
+        String[] lines = VitalsUtils.stderrAsLines(output);
+        int line = VitalsUtils.matchPatterns(lines, 0, beforeReport);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportHeader);
+
+        // We expect a report in a file inside HiMemReportDir, and a mentioning of it on
+        // stderr
+        line = VitalsUtils.matchPatterns(lines, line + 1,
+            new String[] { "# Printing to .*himemreport-1/sapmachine_himemalert" + patterFileSuffix + ".log",
+                           "# Done\\." } );
+
+        String reportFile = output.firstMatch("# Printing to (.*himemreport-1/sapmachine_himemalert" + patterFileSuffix + ".log)", 1);
+        VitalsUtils.assertFileExists(reportFile);
+
+        VitalsUtils.assertFileContentMatches(new File(reportFile), reportBody);
+    }
+
+    static void testDumpWithExecToReportDir() throws Exception {
+        String reportDirName = "himemreport-2";
+        // Here we not only dump, but we also execute several jcmds. Therefore we take some more seconds to sleep
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:HiMemReportDir=himemreport-2",
+                "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders;GC.heap_dump",
+                "-XX:NativeMemoryTracking=summary",
+                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                TestHiMemReport.class.getName(),
+                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+
+        // We expect, on stderr, just the report header
+        String[] lines = VitalsUtils.stderrAsLines(output);
+        int line = VitalsUtils.matchPatterns(lines, 0, beforeReport);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportHeader);
+
+        // We expect a report in a file inside HiMemReportDir, and a mentioning of it on
+        // stderr
+        line = VitalsUtils.matchPatterns(lines, line + 1,
+                new String[] { "# Printing to .*himemreport-2/sapmachine_himemalert" + patterFileSuffix + ".log",
+                        "# Done\\." } );
+
+        String reportFile = output.firstMatch("# Printing to (.*himemreport-2/sapmachine_himemalert" + patterFileSuffix + ".log)", 1);
+        VitalsUtils.assertFileExists(reportFile);
+        VitalsUtils.assertFileContentMatches(new File(reportFile), reportBody);
+
+        // We also expect, in the report dir, several more files
+        String reportDir = output.firstMatch("# Printing to (.*himemreport-2/)sapmachine_himemalert" + patterFileSuffix + ".log", 1);
+        VitalsUtils.assertFileExists(reportDir);
+        File reportDirAsFile = new File(reportDir);
+
+        ////////
+        // HiMemReportExec should have caused three jcmds to fire...
+
+        line = VitalsUtils.matchPatterns(lines, line + 1,
+                new String[] { "HiMemReport: Successfully executed \"VM.flags -all\", output redirected to report dir",
+                        "HiMemReport: Successfully executed \"VM.metaspace show-loaders\", output redirected to report dir",
+                        "HiMemReport: Successfully executed \"GC.heap_dump .*himemreport-2/GC.heap_dump" + patterFileSuffix + ".dump\", output redirected to report dir" } );
+
+        // VM.flags:
+
+        // I expect two files, VM.flags_pidXXXX_1_100.err and VM.flags_pidXXXX_1_100.out, in the report dir...
+        File VMflagsOutFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "VM.flags" + patterFileSuffix + ".out");
+        File VMflagsErrFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "VM.flags" + patterFileSuffix + ".err");
+
+        // The err file should be empty
+        VitalsUtils.assertFileisEmpty(VMflagsErrFile.getAbsolutePath());
+
+        // The out file should contain a valid flags report, containing, among other things, the flags we passed above
+        // Note that since we started VM.flags with -all, we have the full flags output
+        VitalsUtils.assertFileContentMatches(VMflagsOutFile, new String[] {
+                ".*HiMemReport *= *true.*",
+                ".*HiMemReportDir *= *himemreport-2.*",
+                ".*HiMemReportExec *= *VM.flags.*VM.metaspace.*GC.heap_dump.*",
+                ".*HiMemReportMax *= *134217728.*"
+        });
+
+        // "VM.metaspace":
+
+        // I expect two files, VM.metaspace_pidXXXX_1_100.err and VM.metaspace_pidXXXX_1_100.out, in the report dir...
+        File VMmetaspaceOutFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "VM.metaspace" + patterFileSuffix + ".out");
+        File VMmetaspaceErrFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "VM.metaspace" + patterFileSuffix + ".err");
+
+        // The err file should be empty
+        VitalsUtils.assertFileisEmpty(VMmetaspaceErrFile.getAbsolutePath());
+
+        // The out file should contain a valid flags report, containing, among other things, the flags we passed above
+        // Note that since we started VM.flags with -all, we have the full flags output
+        VitalsUtils.assertFileContentMatches(VMmetaspaceOutFile, new String[] {
+                "Usage per loader:",
+                ".*app.*",
+                ".*bootstrap.*",
+                "Total Usage.*",
+                "Virtual space.*",
+                "Settings.*",
+                "MaxMetaspaceSize.*"
+        });
+
+        // GC.heap_dump:
+
+        // I expect three files, the usual GC.heap_dump_pid<pid>_<timestamp>.(out|err) and the heap dump itself as
+        // GC.heap_dump_pid<pid>_<timestamp>.dump.
+        File heapDumpOutFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "GC.heap_dump" + patterFileSuffix + ".out");
+        File heapDumpErrFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "GC.heap_dump" + patterFileSuffix + ".err");
+        File heapDumpDumpFile = VitalsUtils.findFirstMatchingFileInDirectory(reportDirAsFile,  "GC.heap_dump" + patterFileSuffix + ".dump");
+
+        // The err file should be empty
+        VitalsUtils.assertFileisEmpty(heapDumpErrFile.getAbsolutePath());
+
+        // The out file should contain "dumped blabla"
+        VitalsUtils.assertFileContentMatches(heapDumpOutFile, new String[] {
+           "Dumping heap to.*",
+           "Heap dump file created.*"
+        });
+
+        // The real dump file should exist and be reasonably sized.
+        VitalsUtils.assertFileExists(heapDumpDumpFile);
+        if (heapDumpDumpFile.length() < 1024 * 16) {
+            throw new RuntimeException("heap dump suspiciously small.");
+        }
+    } // end: testDumpWithExecToReportDir
+
+    // Test multiple Execs, with the output of the commands going to stderr
+    static void testDumpWithExecToStderr() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders",
+                "-XX:NativeMemoryTracking=summary",
+                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                TestHiMemReport.class.getName(),
+                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+
+        // We expect the normal HiMemReport on stderr...
+        String[] lines = VitalsUtils.stderrAsLines(output);
+        int line = VitalsUtils.matchPatterns(lines, 0, beforeReport);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportHeader);
+        line = VitalsUtils.matchPatterns(lines, line + 1, reportBody);
+
+        // ... as well as the output of VM.flags
+        line = VitalsUtils.matchPatterns(lines, line + 1, new String [] {
+                        ".*HiMemReport *= *true.*",
+                        ".*HiMemReportMax *= *134217728.*",
+                        "HiMemReport: Successfully executed \"VM.flags -all\""
+        });
+
+        // ... as well as the output of VM.metaspace
+        line = VitalsUtils.matchPatterns(lines, line + 1, new String [] {
+                "Usage per loader:",
+                ".*app.*",
+                ".*bootstrap.*",
+                "Total Usage.*",
+                "Virtual space.*",
+                "Settings.*",
+                "MaxMetaspaceSize.*",
+                "HiMemReport: Successfully executed \"VM.metaspace show-loaders\""
+        });
+
+    } // end: testDumpWithExecToReportDir
+
+
+
+    /**
+     * test that HiMemReport can feel out some limit from the environment without being given one explicitely
+     * (I'm not sure that this always works, but I would like to know if it does not, and if not, in what context)
+     */
+    static void testHasNaturalMax() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-Xlog:vitals", "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldNotMatch("HiMemReport.*limit could not be established");
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args[0].equals("print"))
+            testPrint();
+        else if (args[0].equals("dump"))
+            testDump();
+        else if (args[0].equals("dump-with-exec-to-reportdir"))
+            testDumpWithExecToReportDir();
+        else if (args[0].equals("dump-with-exec-to-stderr"))
+            testDumpWithExecToStderr();
+        else if (args[0].equals("natural-max"))
+            testHasNaturalMax();
+        else if (args[0].equals("sleep")) {
+            int numSeconds = Integer.parseInt(args[1]);
+            Thread.sleep(numSeconds * 1000);
+        }else
+            throw new RuntimeException("Invalid test " + args[0]);
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportArgParsing.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportArgParsing.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2021, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-ValidNonExistingReportDir
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing ValidNonExistingReportDir
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-ValidExistingReportDir
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing ValidExistingReportDir
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-InValidReportDir
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing InValidReportDir
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-HiMemReportOn
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing HiMemReportOn
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-HiMemReportOff
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing HiMemReportOff
+ */
+
+/*
+ * @test TestHiMemReportArgParsing-HiMemReportOffByDefault
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportArgParsing HiMemReportOffByDefault
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TestHiMemReportArgParsing {
+
+    /**
+     * test HiMemReportDir with a valid, absolute path to a non-existing directory
+     */
+    static void testValidNonExistingReportDir() throws IOException {
+        File subdir = VitalsUtils.createSubTestDir("test-outputdir-1", false);
+        VitalsUtils.fileShouldNotExist(subdir);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(), "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        VitalsUtils.outputStdoutMatchesPatterns(output, new String[] {
+                ".*[vitals].*HiMemReportDir: Created report directory.*" + subdir.getName() + ".*",
+                ".*[vitals].*HiMemReport subsystem initialized.*"
+        });
+        VitalsUtils.fileShouldExist(subdir);
+    }
+
+    /**
+     * test HiMemReportDir with a valid, absolute path to an existing directory
+     */
+    static void testValidExistingReportDir() throws IOException {
+        File subdir = VitalsUtils.createSubTestDir("test-outputdir-2", true);
+        VitalsUtils.fileShouldExist(subdir);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(), "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        VitalsUtils.outputStdoutMatchesPatterns(output, new String[] {
+                ".*[vitals].*Found existing report directory at.*" + subdir.getName() + ".*",
+                ".*[vitals].*HiMemReport subsystem initialized.*"
+        });
+        VitalsUtils.fileShouldExist(subdir);
+    }
+
+    /**
+     * test HiMemReportDir with an invalid path (containing several layers, which the VM will not create, it will only
+     * create subdirs of max 1 level). We explicitly omit Xlog:vitals, but still expect a warning
+     */
+    static void testInValidReportDir() throws IOException {
+        File f = new File("/tmp/gibsnicht/gibsnicht/gibsnicht");
+        VitalsUtils.fileShouldNotExist(f);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + f.getAbsolutePath(), "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldNotHaveExitValue(0);
+        VitalsUtils.outputStdoutMatchesPatterns(output, new String[] {
+                ".*[vitals].*Failed to create report directory.*" + f.getAbsolutePath() + ".*",
+                "Error occurred during initialization of VM"
+        });
+        VitalsUtils.fileShouldNotExist(f);
+    }
+
+    /**
+     * test +HiMemReport without any further options. It should come up with a reasonable limit.
+     */
+    static void testHiMemReportOn() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        VitalsUtils.outputStdoutMatchesPatterns(output, new String[] {
+                ".*[vitals].*Setting limit to.*",
+                ".*[vitals].*HiMemReport subsystem initialized.*"
+        });
+    }
+
+    /**
+     * test that -HiMemReport means off
+     */
+    static void testHiMemReportOff() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:-HiMemReport", "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("HiMemReport subsystem initialized");
+    }
+
+    /**
+     * test that HiMemReport is off by default
+     */
+    static void testHiMemReportOffByDefault() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Xlog:vitals",
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("HiMemReport subsystem initialized");
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args[0].equals("ValidNonExistingReportDir"))
+            testValidNonExistingReportDir();
+        else if (args[0].equals("ValidExistingReportDir"))
+            testValidExistingReportDir();
+        else if (args[0].equals("InValidReportDir"))
+            testInValidReportDir();
+        else if (args[0].equals("HiMemReportOn"))
+            testHiMemReportOn();
+        else if (args[0].equals("HiMemReportOff"))
+            testHiMemReportOff();
+        else if (args[0].equals("HiMemReportOffByDefault"))
+            testHiMemReportOffByDefault();
+        else
+            throw new RuntimeException("Invalid test " + args[0]);
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportExecParsing.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportExecParsing.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestHiMemReportExecParsing
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportExecParsing 1
+ */
+
+/*
+ * @test TestHiMemReportExecParsing
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportExecParsing 2
+ */
+
+/*
+ * @test TestHiMemReportExecParsing
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportExecParsing 3
+ */
+
+/*
+ * @test TestHiMemReportExecParsing
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run driver TestHiMemReportExecParsing 4
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+
+public class TestHiMemReportExecParsing {
+
+    static void do_test(String execString, boolean shouldSucceed, String... shouldContain) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+HiMemReport", "-Xlog:vitals", "-XX:HiMemReportExec=" + execString,
+                "-Xmx64m", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        if (shouldSucceed) {
+            output.shouldHaveExitValue(0);
+        } else {
+            output.shouldNotHaveExitValue(0);
+        }
+        for (String s : shouldContain) {
+            output.shouldContain(s);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int variant = Integer.parseInt(args[0]);
+        switch (variant) {
+            case 1:
+                do_test("VM.metaspace", true, "HiMemReportExec: storing command \"VM.metaspace\"");
+                break;
+            case 2:
+                do_test("VM.info;VM.metaspace;GC.heap_dump", true,
+                        "HiMemReportExec: storing command \"VM.info\"", "HiMemReportExec: storing command \"VM.metaspace\"",
+                        "HiMemReportExec: storing command \"GC.heap_dump\"");
+                break;
+            case 3:
+                do_test(";  VM.info;; ; VM.metaspace show-loaders   ", true,
+                        "HiMemReportExec: storing command \"VM.info\"", "HiMemReportExec: storing command \"VM.metaspace show-loaders\"");
+                break;
+            case 4:
+                do_test("  hallo ", false,
+                        "HiMemReportExec: Command \"hallo\" invalid");
+                break;
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsInvalidSampleInterval.java
@@ -40,7 +40,7 @@ public class TestVitalsInvalidSampleInterval {
                 "-XX:VitalsSampleInterval=0",
                 "-XX:MaxMetaspaceSize=16m",
                 "-Xmx128m",
-                "-version"); // Note: explicitly omit Xlog:os, since the warning should always appear
+                "-version"); // Note: explicitly omit Xlog:vitals, since the warning should always appear
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldContain("Invalid VitalsSampleInterval (0) specified. Vitals disabled.");

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -39,7 +39,7 @@ public class TestVitalsValidSampleInterval {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:VitalsSampleInterval=" + interval,
                 "-XX:MaxMetaspaceSize=16m",
-                "-Xlog:os",
+                "-Xlog:vitals",
                 "-Xmx128m",
                 "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/Vitals/ValuesFromProcFS.java
+++ b/test/hotspot/jtreg/runtime/Vitals/ValuesFromProcFS.java
@@ -1,0 +1,78 @@
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ValuesFromProcFS {
+
+    // from proc meminfo
+    public long MemAvail = -1;
+    public long Committed_AS = -1;
+    public long SwapTotal = -1;
+    public long SwapFree = -1;
+
+    private static Pattern patMemAvail = Pattern.compile("MemAvail: *(\\d+) *kB");
+    private static Pattern patCommitted_AS = Pattern.compile("Committed_AS: *(\\d+) *kB");
+    private static Pattern patSwapTotal = Pattern.compile("SwapTotal: *(\\d+) *kB");
+    private static Pattern patSwapFree = Pattern.compile("SwapFree: *(\\d+) *kB");
+
+    // from proc pid status
+    public long VmRSS = -1;
+    public long VmSwap = -1;
+    public long VmSize = -1;
+
+    private static Pattern patVmRSS = Pattern.compile("VmRSS: *(\\d+) *kB");
+    private static Pattern patVmSize = Pattern.compile("VmSize: *(\\d+) *kB");
+    private static Pattern patVmSwap = Pattern.compile("VmSwap: *(\\d+) *kB");
+
+    /**
+     * Retrieve data from proc fs
+     *
+     * @param pid if != -1, return some data for the process too
+     * @return
+     * @throws IOException
+     */
+    public static ValuesFromProcFS retrieveForProcess(long pid) throws IOException {
+        ValuesFromProcFS v = new ValuesFromProcFS();
+
+        if (pid != -1) {
+            String lines[] = VitalsUtils.fileAsLines(new File("/proc/" + pid + "/status"));
+            for (String s : lines) {
+                Matcher m = patVmRSS.matcher(s);
+                if (m.matches()) {
+                    v.VmRSS = Long.parseLong(m.group(1)) * 1024;
+                }
+                m = patVmSize.matcher(s);
+                if (m.matches()) {
+                    v.VmSize = Long.parseLong(m.group(1)) * 1024;
+                }
+                m = patVmSwap.matcher(s);
+                if (m.matches()) {
+                    v.VmSwap = Long.parseLong(m.group(1)) * 1024;
+                }
+            }
+        }
+
+        String lines[] = VitalsUtils.fileAsLines(new File("/proc/meminfo"));
+        for (String s : lines) {
+            Matcher m = patMemAvail.matcher(s);
+            if (m.matches()) {
+                v.MemAvail = Long.parseLong(m.group(1)) * 1024;
+            }
+            m = patCommitted_AS.matcher(s);
+            if (m.matches()) {
+                v.Committed_AS = Long.parseLong(m.group(1)) * 1024;
+            }
+            m = patSwapTotal.matcher(s);
+            if (m.matches()) {
+                v.SwapTotal = Long.parseLong(m.group(1)) * 1024;
+            }
+            m = patSwapFree.matcher(s);
+            if (m.matches()) {
+                v.SwapFree = Long.parseLong(m.group(1)) * 1024;
+            }
+        }
+
+        return v;
+    }
+}

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsDCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, SAP SE. All rights reserved.
+ * Copyright (c) 2020,2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,88 @@
  * @test
  * @summary Test of diagnostic command VM.vitals
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.compiler
- *          java.management
- *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=1 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=2 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=3 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=4 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=5 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=6 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=7 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=8 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=9 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=10 -XX:VitalsSampleInterval=1 VitalsDCmdTest
+ */
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.vitals
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -Dsapmachine.vitalstest=11 -XX:VitalsSampleInterval=1 VitalsDCmdTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -41,43 +118,88 @@ public class VitalsDCmdTest {
 
     public void run(CommandExecutor executor) {
 
-        OutputAnalyzer output = executor.execute("VM.vitals");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldMatch("\\d+[gkm]"); // we print by default in "dynamic" scale which should show some values as k or m or g
-        output.shouldNotContain("Now"); // off by default
+        try {
 
-        output = executor.execute("VM.vitals reverse");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
+            int testnumber = Integer.parseInt(System.getProperties().getProperty("sapmachine.vitalstest"));
 
-        output = executor.execute("VM.vitals scale=m");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+            switch (testnumber) {
+                case 1:
+                    OutputAnalyzer output = executor.execute("VM.vitals");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldMatch("\\d+[gkm]"); // we print by default in "dynamic" scale which should show some values as k or m or g
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 2:
+                    output = executor.execute("VM.vitals reverse");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 3:
+                    output = executor.execute("VM.vitals scale=m");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 4:
+                    output = executor.execute("VM.vitals scale=1");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 5:
+                    output = executor.execute("VM.vitals raw");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldNotContain("Now"); // off by default
+                    break;
+                case 6:
+                    output = executor.execute("VM.vitals now");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldContain("Now");
+                    break;
+                case 7:
+                    output = executor.execute("VM.vitals reverse now");
+                    VitalsTestHelper.outputMatchesVitalsTextMode(output);
+                    output.shouldContain("Now");
+                    break;
+                case 8:
+                    output = executor.execute("VM.vitals csv");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    VitalsTestHelper.parseCSV(output);
+                    break;
+                case 9:
+                    output = executor.execute("VM.vitals csv reverse");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    VitalsTestHelper.parseCSV(output);
+                    break;
+                case 10: {
+                    output = executor.execute("VM.vitals csv reverse raw");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    output.shouldNotContain("Now"); // off always in csv mode
+                    CSVParser.CSV csv = VitalsTestHelper.parseCSV(output);
+                    VitalsTestHelper.simpleCSVSanityChecks(csv); // requires raw or scale=1 mode
+                }
+                break;
+                case 11: {
+                    output = executor.execute("VM.vitals csv now reverse scale=1");
+                    VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+                    // "Now" sample printing always off in csv mode even if explicitly given.
+                    output.shouldNotContain("Now");
+                    output.shouldContain("\"now\" ignored in csv mode");
+                    CSVParser.CSV csv = VitalsTestHelper.parseCSV(output);
+                    VitalsTestHelper.simpleCSVSanityChecks(csv); // requires raw or scale=1 mode
+                }
+                break;
+                default:
+                    throw new RuntimeException("unknown test number " + testnumber);
+            }
 
-        output = executor.execute("VM.vitals scale=1");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-        output.shouldNotMatch("\\d+[km]"); // A specific scale disables dynamic scaling, and we omit the unit suffix
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
 
-        output = executor.execute("VM.vitals raw");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals now");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals reverse now");
-        VitalsTestHelper.outputMatchesVitalsTextMode(output);
-
-        output = executor.execute("VM.vitals csv");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-        output.shouldNotContain("Now"); // off always in csv mode
-
-        output = executor.execute("VM.vitals csv reverse");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-
-        output = executor.execute("VM.vitals csv reverse raw");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
-
-        output = executor.execute("VM.vitals csv now reverse raw");
-        VitalsTestHelper.outputMatchesVitalsCSVMode(output);
     }
 
     @Test

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 import java.io.File;
@@ -5,31 +29,32 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 
 public class VitalsTestHelper {
 
+//    Last 60 minutes:
+//                                  ---------------------------------------system---------------------------------------- -------------------------process-------------------------- ----------------------------------------jvm-----------------------------------------
+//                                                                        ------cpu------ ------------cgroup-------------      -------rss--------      -cheap-- -cpu- ----io----     --heap--- ----------meta----------      --nmt--- ----jthr----- --cldg-- ----cls-----
+//                                  avail comm  crt swap si so p t  pr pb us sy id  st gu lim  limsw slim usg  usgsw kusg virt all  anon file shm swdo usd free us sy of rd   wr thr comm used comm used csc  csu  gctr code mlc map  num nd cr st  num anon num  ld  uld
+//            2022-05-14 14:52:36   54.4g 21.7g  65   0k  0  0 2 22  2  0  3  0  96  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:26   54.4g 21.9g  65   0k  0  0 2 22  4  1  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:16   54.4g 21.8g  65   0k  0  0 2 22  3  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:52:06   54.4g 21.8g  65   0k  0  0 2 22  1  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:56   54.4g 21.7g  64   0k  0  0 2 22  2  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:46   54.4g 21.5g  64   0k  0  0 2 22  1  0  0  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
+//            2022-05-14 14:51:36   54.4g 21.5g  64   0k  0  0 2 22  1  0  1  0  99  0  0 8.0g 16.0g      118m  118m   2m 5.1g 109m  72m  38m  0k   0k 44m   7m  0  0  4  11k 0k  21 130m   7m   3m   3m 320k 224k  21m   8m 43m 193m  12  1  0 20m  34   31 1330   0   0
 
-    // Example output:
-    // Last 60 minutes:
-    //                      ---------------------------system--------------------------- ------------------------process------------------------ --------------------------------------jvm---------------------------------------
-    //                                                                -------cpu--------       -------rss--------          -cpu- ----io-----     --heap--- ----------meta----------           ----jthr----- --cldg-- ----cls-----
-    //                      avail comm  crt swap si so p   t    pr pb us sy id  wa st gu virt  all  anon file shm swdo hp  us sy of rd   wr  thr comm used comm used csc  csu  gctr code mlc  num nd cr st  num anon num  ld  uld
-    //2022-03-10 07:41:27   55,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0 100  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k  0k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
-    //2022-03-10 07:41:17   55,0g 11,5g  34   0k  0  0 538 1267  1  0  1  0  99  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  0  0  4 128k 21k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  0 37m  27   24 1286   0   0
-    //2022-03-10 07:41:07   55,0g 11,5g  34   0k  0  0 538 1268  1  0  3  0  96  0  0  0 23,2g 3,6g 3,6g  36m  0k   0k 92k  3  0  4 128k  8k  38 1,0g 531m   3m   2m 320k 222k  21m   8m 1,5g  12  1  1 37m  27   24 1286   0   0
-    //2022-03-10 07:40:57   56,9g 11,6g  34   0k  0  0 539 1279  4  0  2  0  98  0  0  0 21,2g 1,7g 1,7g  36m  0k   0k 92k  2  0  3 131k <1k  38 1,0g 530m   3m   2m 320k 222k  21m   8m 604m  12  1  1 37m  27   24 1286   0   0
-    //2022-03-10 07:40:47   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
-    //2022-03-10 07:40:37   58,0g 11,5g  34   0k  0  0 538 1267  1  0  0  0 100  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 128k  0k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  0 36m  27   24 1286   0   0
-    //2022-03-10 07:40:27   58,0g 11,5g  34   0k  0  0 538 1269  1  0  0  0  99  0  0  0 20,2g 642m 606m  36m  0k   0k 92k  0  0  3 998k <1k  37 1,0g 530m   3m   2m 320k 222k  21m   8m  43m  11  1  5 36m  27   24 1286 842   0
-    //2022-03-10 07:40:17   58,5g 11,5g  34   0k       537 1254  4  0                    18,9g  95m  65m  31m  0k   0k 92k        2           18 1,0g  10m 128k  55k  64k   2k  21m   7m  42m   9  1    16m   3    0  444
+    // Header regex matcher in text mode. These should catch on all platforms, therefore they only check JVM columns,
+    // and only those columns that are unconditionally available (or should be)
+    public static final String jvm_header_line0_textmode = ".*---jvm---.*";
+    public static final String jvm_header_line1_textmode = ".*-heap-.*-meta-.*-jthr-.*-cldg-.*-cls-.*";
+    public static final String jvm_header_line2_textmode = ".*comm.*used.*comm.*used.*gctr.*code.*num.*nd.*cr.*num.*ld.*uld.*";
 
-    // Note: all platforms should have the --jvm-- section. Some platforms have more. Above printout is from linux.
-    // For now, we just test for the stuff which is in all platforms.
-    public static final String jvm_header_line1_textmode = ".*heap.*meta.*";
-    public static final String jvm_header_line2_textmode = ".*comm.*used.*comm.*used.*";
-
+    // This is supposed to match a header in csv mode. Here I am rather lenient, because analysing regex mismatches is a
+    // pain. We later do more strict sanity checks where we check most of the fields anyway.
     public static final String jvm_header_line_csvmode = ".*jvm-heap-comm,jvm-heap-used,jvm-meta-comm,jvm-meta-used.*";
 
     public static final String timestamp_regex = "\\d{4}+-\\d{2}+-\\d{2}.*\\d{2}:\\d{2}:\\d{2}";
@@ -78,7 +103,7 @@ public class VitalsTestHelper {
     }
 
     static final String[] expected_output_textmode = new String[] {
-            jvm_header_line1_textmode, jvm_header_line2_textmode, sample_line_regex_minimal_textmode
+            jvm_header_line0_textmode, jvm_header_line1_textmode, jvm_header_line2_textmode, sample_line_regex_minimal_textmode
     };
 
     static final String[] expected_output_csvmode = new String[] {
@@ -112,6 +137,116 @@ public class VitalsTestHelper {
         String[] lines = output.asLines().toArray(new String[0]);
         if (!findMatchesInStrings(lines, expected_output_csvmode)) {
             throw new RuntimeException("Expected output not found (see error output)");
+        }
+    }
+
+    // Some more extensive sanity checks are possible in CSV mode
+    public static CSVParser.CSV parseCSV(OutputAnalyzer output) throws CSVParser.CSVParseException {
+        String[] lines = output.asLines().toArray(new String[0]);
+
+        // Search for the beginning of the CSV output
+        int firstline = -1;
+        int lastline = -1;
+        Pattern headerLinePattern = Pattern.compile(jvm_header_line_csvmode);
+        Pattern csvDataLinePattern = Pattern.compile(sample_line_regex_minimal_csvmode);
+        for (int lineno = 0; lineno < lines.length && firstline == -1 && lastline == -1; lineno ++) {
+            String line = lines[lineno];
+            if (firstline == -1) {
+                if (headerLinePattern.matcher(line).matches()) {
+                    firstline = lineno;
+                }
+            } else {
+                if (headerLinePattern.matcher(line).matches()) {
+                    throw new CSVParser.CSVParseException("Found header twice", lineno);
+                }
+                if (!csvDataLinePattern.matcher(line).matches()) {
+                    lastline = lineno - 1;
+                    break;
+                }
+            }
+        }
+        if (lastline == -1) {
+            lastline = lines.length - 1;
+        }
+
+        if (firstline == -1) {
+            throw new CSVParser.CSVParseException("Could not find CSV header line");
+        }
+
+        String [] csvlines = Arrays.copyOfRange(lines, firstline, lastline + 1);
+
+        CSVParser.CSV csv;
+        csv = CSVParser.parseCSV(csvlines);
+
+        return csv;
+    }
+
+    /**
+     * Does some more extensive tests on a csv raw output. Requires output to be done with scale=1 or raw mode
+     * @param csv
+     */
+    static public void simpleCSVSanityChecks(CSVParser.CSV csv) throws CSVParser.CSVParseException {
+
+        // The following columns are allowed to be empty (column shown but values missing), e.g.
+        // for delta columns
+        // Note: data that are always missing (e.g. because of linux kernel version) should have
+        // their columns hidden instead, see vitals.cpp)
+        String colsThatCanBeEmpty =
+                  "|jvm-jthr-cr"  // delta column
+                + "|syst-si|syst-so" // deltas
+                + "|jvm-cls-ld" // delta
+                + "|jvm-cls-uld" // delta
+                ;
+
+        String colsThatCanBeEmpty_WINDOWS = "";
+
+        String colsThatCanBeEmpty_OSX = "";
+
+        String colsThatCanBeEmpty_LINUX =
+                  "|syst-cpu.*" // CPU values may be omitted in containers; also they are all deltas
+                + "|syst-cgr.*" // Cgroup values may be omitted in root cgroup
+                + "|proc-chea-usd|proc-chea-free" // cannot be shown if RSS is > 4g and glibc is too old
+                + "|proc-io-rd|proc-io-wr" // deltas
+                + "|proc-cpu-us|proc-cpu-sy" // deltas
+                ;
+
+        String regexCanBeEmpty = "(x" + colsThatCanBeEmpty;
+        if (Platform.isLinux()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_LINUX;
+        } else if (Platform.isWindows()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_WINDOWS;
+        } else if (Platform.isOSX()) {
+            regexCanBeEmpty += colsThatCanBeEmpty_OSX;
+        }
+        regexCanBeEmpty += ")";
+
+        System.out.println("Columns allowed to be empty: " + regexCanBeEmpty);
+        Pattern canBeEmptyPattern = Pattern.compile(regexCanBeEmpty);
+
+        for (int lineno = 0; lineno < csv.lines.length; lineno ++) {
+            CSVParser.CSVDataLine line = csv.lines[lineno];
+            // Iterate through all columns and do some basic checks.
+            // In raw mode, all but the first column are longs. The first column is a time stamp.
+            for (int i = 1; i < csv.header.size(); i ++) {
+                String col = csv.header.at(i);
+                if (line.isEmpty(i)) {
+                    // aka empty
+                    if (!canBeEmptyPattern.matcher(col).matches()) {
+                        throw new CSVParser.CSVParseException("Column " + col + " must not have empty value.", lineno + 1);
+                    }
+                } else {
+                    long l = 0;
+                    try {
+                        l = line.numberAt(i);
+                    } catch (NumberFormatException e) {
+                        throw new CSVParser.CSVParseException("Column " + col + ": cannot parse value as long (" + l + ")", lineno + 1);
+                    }
+                    long highestReasonableRawValue = 0x00800000_00000000l;
+                    if (l < 0 || l > highestReasonableRawValue) {
+                        throw new CSVParser.CSVParseException("Column " + col + ": Suspiciously high or low value:" + l, lineno + 1);
+                    }
+                }
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsUtils.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsUtils.java
@@ -1,0 +1,147 @@
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class VitalsUtils {
+
+    static String outputDir;
+    static File outputDirAsFile;
+
+    static {
+        outputDir = System.getProperty("user.dir", ".");
+        outputDirAsFile = new File(outputDir);
+    }
+
+    static File createSubTestDir(String name, boolean create) {
+        File subdir = new File(outputDir, name);
+        if (subdir.exists()) {
+            throw new RuntimeException("test dir already exists: " + subdir);
+        }
+        if (create) {
+            subdir.mkdirs();
+            if (!subdir.exists()) {
+                throw new RuntimeException("Cannot create test dir at " + subdir);
+            }
+        }
+        return subdir;
+    }
+
+    static void fileShouldExist(File f) {
+        if (!f.exists()) {
+            throw new RuntimeException("expected but does not exist: " + f);
+        }
+    }
+
+    static void fileShouldNotExist(File f) {
+        if (f.exists()) {
+            throw new RuntimeException("expected not to exist, but exists: " + f);
+        }
+    }
+
+    static String[] stderrAsLines(OutputAnalyzer output) {
+        return output.getStderr().split("\\R");
+    }
+    static String[] stdoutAsLines(OutputAnalyzer output) {
+        return output.getStdout().split("\\R");
+    }
+
+    /**
+     * Look in lines for a number of subsequent matches. Start looking at startAtLine. Return line number of last
+     * match. Throws RuntimeException if not all regexes where matching.
+     * @param lines
+     * @param startAtLine
+     * @param regexes
+     * @return
+     */
+    static int matchPatterns(String[] lines, int startAtLine, String[] regexes) {
+        int nextToMatch = 0;
+        int nLine = startAtLine;
+        while (nLine < lines.length) {
+            if (lines[nLine].matches(regexes[nextToMatch])) {
+                System.out.println("Matched \"" + regexes[nextToMatch] +"\" at line " + nLine + "(\"" + lines[nLine] + "\")");
+                nextToMatch++;
+                if (nextToMatch == regexes.length) {
+                    break;
+                }
+            }
+            nLine ++;
+        }
+        if (nextToMatch < regexes.length) {
+            throw new RuntimeException("Not all matches found. First missing pattern " + nextToMatch + ":" + regexes[nextToMatch]);
+        }
+        return nLine;
+    }
+
+    static int outputStderrMatchesPatterns(OutputAnalyzer output, String[] regexes) {
+        return matchPatterns(stderrAsLines(output), 0, regexes);
+    }
+
+    static int outputStdoutMatchesPatterns(OutputAnalyzer output, String[] regexes) {
+        return matchPatterns(stdoutAsLines(output), 0, regexes);
+    }
+
+    static String [] fileAsLines(File f) throws IOException {
+        Path path = Paths.get(f.getAbsolutePath());
+        return Files.readAllLines(path).toArray(new String[0]);
+    }
+
+    static void assertFileExists(File f) {
+        if (!f.exists()) {
+            throw new RuntimeException("File " + f.getAbsolutePath() + " does not exist");
+        } else {
+            System.out.println("File " + f.getAbsolutePath() + " exists - ok!");
+        }
+    }
+
+    static void assertFileExists(String filename) {
+        File f = new File(filename);
+        assertFileExists(f);
+    }
+
+    static void assertFileisEmpty(File f) {
+        if (f.length() > 0) {
+            throw new RuntimeException("File " + f.getAbsolutePath() + " expected to be empty, but is not empty.");
+        } else {
+            System.out.println("File " + f.getAbsolutePath() + " has zero size - ok!");
+        }
+    }
+
+    static void assertFileisEmpty(String filename) {
+        File f = new File(filename);
+        assertFileisEmpty(f);
+    }
+
+    static void assertFileContentMatches(File f, String[] regexes) throws IOException {
+        String[] lines = fileAsLines(f);
+        matchPatterns(lines, 0, regexes);
+        System.out.println("File " + f.getAbsolutePath() + " matches " + regexes[0] + ", ... etc - ok!");
+    }
+
+    static File findFirstMatchingFileInDirectory(File dir, String regex) {
+        File[] files = dir.listFiles();
+        for (File f : files) {
+            if (f.getName().matches(regex)) {
+                System.out.println("Found required file " + f.getAbsolutePath() + " - ok!");
+                return f;
+            }
+        }
+        throw new RuntimeException("Could not find file matching \"" + regex + "\" inside " + dir.getAbsolutePath());
+    }
+
+    // Extract pid of target process (first line of output shall contain "<pid>:\n"
+    private static Pattern patPidInJcmdOutput = Pattern.compile("^(\\d+):\r");
+    static long pidFromJcmdOutput(OutputAnalyzer output) {
+        String s = output.getOutput();
+        Matcher m = patPidInJcmdOutput.matcher(s);
+        if (m.matches()) {
+            return Long.parseLong(m.group(1));
+        }
+        throw new RuntimeException("Cannot find pid in jcmd output");
+    }
+}

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Serial
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseSerialGC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=summary -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+/*
+ * @test G1
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseG1GC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=summary -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+/*
+ * @test G1_no_nmt
+ * @summary Test that Vitals memory sizes are within expectations
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc java.compiler java.management jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run testng/othervm -XX:+UseG1GC -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xms64m -XX:NativeMemoryTracking=off -XX:VitalsSampleInterval=1 VitalsValuesSanityCheck
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import org.testng.annotations.Test;
+import sun.hotspot.WhiteBox;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class VitalsValuesSanityCheck {
+
+    static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    final long K = 1024;
+    final long M = 1024 * K;
+    final long G = 1024 * M;
+
+    // total size of what we will allocate from the cheap in the main function
+    final long cheapAllocationSize = 32 * M;
+    // individual block size, small enough to be guaranteed touched and counting toward rss
+    final long cheapAllocationBlockSize = 1024;
+    final long numCheapAllocations = cheapAllocationSize / cheapAllocationBlockSize;
+
+
+    private static void assertColumnExists(CSVParser.CSV csv, String colname) {
+        if (!csv.header.hasColumn(colname)) {
+            throw new RuntimeException("Column " + colname + " not found");
+        }
+    }
+
+    /**
+     * scan the CSV for the highest value in a column.
+     *
+     * @param csv
+     * @param colname
+     * @return highest value, or -1 on error (either the column was not found, or no cell in the column contain a valid value)
+     */
+    private static long findHighestValueForColumn(CSVParser.CSV csv, String colname) {
+        int index = csv.header.findColumn(colname);
+        if (index == -1) {
+            throw new RuntimeException("cannot find column " + colname);
+        }
+        long max = -1;
+        int line_containing_max = -1;
+        int i = 0;
+        for (i = 0; i < csv.lines.length; i++) {
+            CSVParser.CSVDataLine line = csv.lines[i];
+            if (!line.isEmpty(index)) {
+                long l2 = line.numberAt(index);
+                if (l2 > max) {
+                    max = l2;
+                    line_containing_max = i;
+                }
+            }
+        }
+        if (max == -1) {
+            System.out.println("Found no valid value " + colname);
+        } else {
+            System.out.println("Found highest value for " + colname + " in line " + line_containing_max + ": " + max);
+        }
+        return max;
+    }
+
+    /**
+     * Check that a certain value is between [min and max).
+     * @param colname
+     * @param min
+     * @param max
+     */
+    private static void checkValueIsBetween(long value, String colname, long min, long max) {
+        if (value < min) {
+            throw new RuntimeException(colname + " seems too low (expected at least " + min + ")");
+        } else if (value >= max) {
+            throw new RuntimeException(colname + " seems too high (expected at most " + max + ")");
+        }
+    }
+
+    /**
+     * Check that a certain value exists (column exists), look for the highest value found,
+     * and check that it is between [min and max).
+     * For convenience, we also return that highest value.
+     *
+     * @param colname
+     * @param min
+     * @param max
+     * @return the highest value
+     */
+    private static long checkValueIsBetween(CSVParser.CSV csv, String colname, long min, long max) {
+        long l = findHighestValueForColumn(csv, colname);
+        checkValueIsBetween(l, colname, min, max);
+        return l;
+    }
+
+    public void run(CommandExecutor executor) {
+
+        try {
+
+            final long veryLowButNot0 = K;
+            // very high but still far away from 0x80000000_00000000
+            final long veryVeryHigh = 256 * G;
+
+            // We malloced at least xxx M, and the VM also uses some.
+            long expected_minimal_cheap_usage_jvm = 2 * M;
+            long expected_minimal_cheap_usage = cheapAllocationSize + expected_minimal_cheap_usage_jvm;
+
+            // We read the vitals in csv form and get the parsed output.
+            // Note to self: don't use raw! It does display delta values as accumulating absolutes.
+            // The heap (64m) should show up as full committed. It is also touched, so it should contribute to RSS unless we swap
+            // The VM will have allocated 32M C-heap as well, in 1KB chunks. These should show up in NMT, in the cheap columns
+            // as well as in rss.
+            OutputAnalyzer output = executor.execute("VM.vitals csv scale=1");
+            VitalsTestHelper.outputMatchesVitalsCSVMode(output);
+            output.shouldNotContain("Now"); // off by default
+            CSVParser.CSV csv = VitalsTestHelper.parseCSV(output);
+
+            VitalsTestHelper.simpleCSVSanityChecks(csv);
+
+            // Java heap (we specify 64M, but depending on GC this can wobble a bit)
+            long highest_expected_jvm_heap_comm = M * 68;
+            long lowest_expected_jvm_heap_comm = M * 60;
+            long jvm_heap_comm = checkValueIsBetween(csv, "jvm-heap-comm", lowest_expected_jvm_heap_comm, highest_expected_jvm_heap_comm);
+            // check heap used
+            long jvm_heap_used = checkValueIsBetween(csv, "jvm-heap-used", veryLowButNot0, jvm_heap_comm);
+
+            // Class+nonclass metaspace
+            long highest_expected_metaspace_comm = 1 * G; // for this little programm, nothing more
+            long jvm_meta_comm = checkValueIsBetween(csv, "jvm-meta-comm", veryLowButNot0, highest_expected_metaspace_comm);
+            long jvm_meta_used = checkValueIsBetween(csv, "jvm-meta-used", veryLowButNot0, jvm_meta_comm);
+
+            // Class space
+            if (Platform.is64bit()) {
+                long highest_expected_classspace_comm = highest_expected_metaspace_comm / 2;
+                long jvm_meta_csc = checkValueIsBetween(csv, "jvm-meta-csc", veryLowButNot0, highest_expected_classspace_comm);
+                checkValueIsBetween(csv, "jvm-meta-csu", veryLowButNot0, jvm_meta_csc);
+            }
+
+            // Code cache
+            long jvm_code = checkValueIsBetween(csv, "jvm-code", veryLowButNot0, 2 * G);
+
+            // How much we know for now the JVM mapped for sure
+            long jvm_mapped_this_much_at_least = jvm_heap_comm + jvm_code + jvm_meta_comm;
+
+            // How much we think the jvm has touched (RSS) at least.
+            long jvm_touched_this_much_at_least = (jvm_heap_used + jvm_meta_used) / 2;
+
+            long jvm_highest_expected_cheap_usage = expected_minimal_cheap_usage * 10;
+
+            // NMT (may be off)
+            long jvm_nmt_mlc = -1;
+            if (csv.header.hasColumn("jvm-nmt-mlc")) {
+                // NMT committed maps:
+                long highest_expected_nmt_mmap = jvm_mapped_this_much_at_least + 2 * G; // very generous
+                long lowest_expected_nmt_mmap = jvm_mapped_this_much_at_least;
+                checkValueIsBetween(csv, "jvm-nmt-map", lowest_expected_nmt_mmap, highest_expected_nmt_mmap);
+                // NMT malloc:
+                jvm_nmt_mlc = checkValueIsBetween(csv, "jvm-nmt-mlc", expected_minimal_cheap_usage, jvm_highest_expected_cheap_usage);
+                checkValueIsBetween(csv, "jvm-nmt-ovh", veryLowButNot0, jvm_nmt_mlc);
+                checkValueIsBetween(csv, "jvm-nmt-gc", veryLowButNot0, jvm_nmt_mlc);
+                checkValueIsBetween(csv, "jvm-nmt-oth", veryLowButNot0, jvm_nmt_mlc);
+
+            }
+
+            // Number of jvm threads: we expect at least 4-5 in total, with at least one non-deamon thread (the one we run in right now)
+            long min_expected_java_threads = 5; // probably more
+            long max_expected_java_threads = 1000; // probably way less, but lets go with this.
+            long jvm_thr_num = checkValueIsBetween(csv, "jvm-jthr-num", min_expected_java_threads, max_expected_java_threads);
+            // we expect at least 1 non-deamon thread (me)
+            checkValueIsBetween(csv, "jvm-jthr-nd", 1, jvm_thr_num);
+            // How many threads were created in the last second (delta col)?
+            checkValueIsBetween(csv, "jvm-jthr-cr", 0, 10000);
+
+            // Classloaders:
+            long min_expected_classloaders = 1; // probably more
+            long max_expected_classloaders = 100000; // probably way less, not sure how many lambdas are active, dep. on jvm version they show up as cldg entries
+            long jvm_clg_num = checkValueIsBetween(csv, "jvm-cldg-num", min_expected_classloaders, max_expected_classloaders);
+            checkValueIsBetween(csv, "jvm-cldg-anon", 0, jvm_clg_num);
+
+            // Classes:
+            long min_expected_classes_base = 300; // probably more
+            long max_expected_classes_base = 60000; // probably way less
+            long jvm_cls_num = checkValueIsBetween(csv, "jvm-cls-num", min_expected_classes_base, max_expected_classes_base);
+            // cls-ld and cls-uld are delta values!
+            // Unless loading is insanely slow, I'd expect at least two-digit loads per second (vitals interval)
+            checkValueIsBetween(csv, "jvm-cls-ld", 10, max_expected_classes_base);
+            // I don't think we have unloaded yet
+            checkValueIsBetween(csv, "jvm-cls-uld", 0, max_expected_classes_base);
+
+            // Linux specific platform columns
+            if (Platform.isLinux()) {
+
+                // Check --- system --- cols on Linux
+
+                long highestExpectedMemoryValue = 512 * G; // I wish...
+                if (csv.header.hasColumn("syst-avail")) {
+                    checkValueIsBetween(csv, "syst-avail", M, highestExpectedMemoryValue);
+                }
+
+                long syst_comm = checkValueIsBetween(csv, "syst-comm", M, highestExpectedMemoryValue);
+                checkValueIsBetween(csv, "syst-crt", 1, 10000); // its a percentage; anything above ~150 is very unlikely unless we aggressivly overcommit
+                checkValueIsBetween(csv, "syst-swap", 0, highestExpectedMemoryValue);
+                // si, so: number of pages, delta
+                checkValueIsBetween(csv, "syst-si", 0, 100000);
+                checkValueIsBetween(csv, "syst-so", 0, 100000);
+
+                // Number of processes and kernel threads. In containers shows the local processes only. But we should have
+                // at least one, us, and multiple kernel threads, since we are multithreaded.
+                long min_expected_processes = 1;
+                long max_expected_processes = 1000000000; // Anything above a billion would surprise me
+                checkValueIsBetween(csv, "syst-p", min_expected_processes, max_expected_processes);
+
+                long min_expected_kernel_threads = min_expected_java_threads;
+                long max_expected_kernel_threads = 1000000000; // same here
+                long syst_t = checkValueIsBetween(csv, "syst-t", min_expected_kernel_threads, max_expected_kernel_threads);
+
+                // threads running, blocked on disk IO (cannot be larger than number of kernel threads)
+                checkValueIsBetween(csv, "syst-tr", 0, syst_t);
+                checkValueIsBetween(csv, "syst-tb", 0, syst_t);
+
+                // Cgroup
+                // We may not always show this. But if we do, at least the usage numbers should be checked
+                if (csv.header.hasColumn("syst-cgro-usg")) {
+                    checkValueIsBetween(csv, "syst-cgro-usg", veryLowButNot0, highestExpectedMemoryValue);
+                }
+                if (csv.header.hasColumn("syst-cgro-kusg")) {
+                    // kusg can get surprisingly high, e.g. if ran on a host hosting guest VMs (seen that with virtual box)
+                    // ... and it can be 0 too for some reason, seen on our loaner ppcle machines at Adopt
+                    checkValueIsBetween(csv, "syst-cgro-kusg", 0, highestExpectedMemoryValue);
+                }
+
+                // Check --- process --- cols on Linux
+                long proc_virt = checkValueIsBetween(csv, "proc-virt", jvm_mapped_this_much_at_least, 100 * G); // virt size can get crazy
+                long proc_rss_all = checkValueIsBetween(csv, "proc-rss-all", jvm_touched_this_much_at_least, proc_virt);
+                if (csv.header.hasColumn("proc-rss-anon")) {
+                    checkValueIsBetween(csv, "proc-rss-anon", jvm_touched_this_much_at_least, proc_rss_all); // most JVM mappings are anon
+                    checkValueIsBetween(csv, "proc-rss-file", 0, proc_rss_all);
+                    checkValueIsBetween(csv, "proc-rss-shm", 0, proc_rss_all);
+                }
+
+                checkValueIsBetween(csv, "proc-swdo", 0, proc_virt);
+
+                // -cheap--
+                if (!Platform.isMusl() && proc_rss_all < 4 * G) {
+                    // we expect to see what NMT sees, plus a bit, since glibc has overhead. If NMT is off, we use
+                    // our initial ballpark number.
+                    long min_c_heap_usage_glibc = (jvm_nmt_mlc == -1 ? jvm_nmt_mlc : expected_minimal_cheap_usage) + K;
+                    long max_c_heap_usage_glibc = min_c_heap_usage_glibc + (2 * G); // glibc has crazy overhead
+                    // but cannot be larger than rss ever was
+                    if (max_c_heap_usage_glibc > proc_rss_all) {
+                        max_c_heap_usage_glibc = proc_rss_all - M; // bit less since a lot of stuff is not malloc
+                    }
+                    checkValueIsBetween(csv, "proc-chea-usd", min_c_heap_usage_glibc, max_c_heap_usage_glibc);
+                    checkValueIsBetween(csv, "proc-chea-free", 0, max_c_heap_usage_glibc);
+                }
+
+                checkValueIsBetween(csv, "proc-cpu-us", 0, 100000);
+                checkValueIsBetween(csv, "proc-cpu-sy", 0, 100000);
+
+                // Number of open file descriptors
+                // (at least one, since we write to stdout. Probably not many more.
+                checkValueIsBetween(csv, "proc-io-of", 1, 1000);
+
+                // IO read, written (note: deltas, so its "read, written, in one second").
+                checkValueIsBetween(csv, "proc-io-rd", 0, 1 * G);
+                checkValueIsBetween(csv, "proc-io-wr", 0, 10 * G);
+
+                // Number of threads in this process (java + native)
+                checkValueIsBetween(csv, "proc-thr", jvm_thr_num, jvm_thr_num + 100);
+
+            } // end: linux specific sanity tests
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void jmx() {
+        for (int i = 0; i < numCheapAllocations; i++) {
+            long p = wb.NMTMalloc(cheapAllocationBlockSize);
+        }
+        try {
+            // wait some time. We sample with 1sec sample frequency, that should give us more than one sample
+            // and therefore some of them should show delta values
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        run(new JMXExecutor());
+    }
+
+}

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -33,6 +33,11 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+// SapMachine 2022-07-01: Vitals: needed for Platform.isMusl
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+
 public class Platform {
     public  static final String vmName      = privilegedGetProperty("java.vm.name");
     public  static final String vmInfo      = privilegedGetProperty("java.vm.info");
@@ -185,6 +190,20 @@ public class Platform {
 
     public static String getVMVersion() {
         return vmVersion;
+    }
+
+    // SapMachine 2022-07-01: Vitals: Platform.isMusl() cherry-picked from upstream since its needed for Vitals sanity tests.
+    public static boolean isMusl() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("ldd", "--version");
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String l = b.readLine();
+            if (l != null && l.contains("musl")) { return true; }
+        } catch(Exception e) {
+        }
+        return false;
     }
 
     public static boolean isAArch64() {


### PR DESCRIPTION
Backport to SapMachine 18. I originally thought I can leave this out since 19 is around the corner, but seems not.

As usual, the 18-specific changes you can find in the second commit: ea21757676876853c558a07290c03e74b442aeff

(in this case, I downported the patch from jdk19, not mainline, so the changes are minimal).

Changes:
- Platform.isMusl is missing, I re-added it.

fixes #1124

