### PR TITLE
SapMachine #1162: Vitals: Initialization should not rely on &= short-circuiting (11)

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1269,18 +1269,18 @@ bool initialize() {
   }
 
   bool success = ColumnList::initialize();
-  success &= Legend::initialize();
+  success = success && Legend::initialize();
 
   // Order matters. First platform columns, then jvm columns.
-  success &= platform_columns_initialize();
-  success &= add_jvm_columns();
+  success = success && platform_columns_initialize();
+  success = success && add_jvm_columns();
 
   // -- Now the number of columns is known (and fixed). --
 
   g_all_tables = new SampleTables();
-  success &= (g_all_tables != NULL);
+  success = success && (g_all_tables != NULL);
 
-  success &= initialize_sampler_thread();
+  success = success && initialize_sampler_thread();
 
   if (success) {
     log_info(vitals)("Vitals intialized. Sample interval: " UINTX_FORMAT " seconds.", VitalsSampleInterval);


### PR DESCRIPTION
Not a clean downport, since "os::environ" had to be switched to raw "environ". Otherwise identical.

fixes #1162

