### PR TITLE
SapMachine #1170: Vitals: HiMemReportTest may time out on slow machines (18)

### DIFF
--- a/src/hotspot/os/linux/vitals_linux_himemreport.cpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.cpp
@@ -606,8 +606,11 @@ static void call_single_jcmd(const ParsedCommand* cmd, int pid, time_t t) {
   argv[3] = NULL;
 
   stringStream err_msg;
+  const jlong t1 = os::javaTimeNanos();
   if (spawn_command(argv, out_file, err_file, &err_msg)) {
-    stderr_stream.print("HiMemReport: Successfully executed \"%s\"", jcmd_command.base());
+    const jlong t2 = os::javaTimeNanos();
+    const int command_time_ms = (t2 - t1) / (1000 * 1000);
+    stderr_stream.print("HiMemReport: Successfully executed \"%s\" (%d ms)", jcmd_command.base(), command_time_ms);
     if (out_file != NULL) {
       stderr_stream.print(", output redirected to report dir");
     }

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
@@ -154,7 +154,7 @@ public class TestHiMemReport {
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
-                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+                "sleep", "12" // num seconds to sleep to give the reporter thread time to generate output
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -185,9 +185,9 @@ public class TestHiMemReport {
         // HiMemReportExec should have caused three jcmds to fire...
 
         line = VitalsUtils.matchPatterns(lines, line + 1,
-                new String[] { "HiMemReport: Successfully executed \"VM.flags -all\", output redirected to report dir",
-                        "HiMemReport: Successfully executed \"VM.metaspace show-loaders\", output redirected to report dir",
-                        "HiMemReport: Successfully executed \"GC.heap_dump .*himemreport-2/GC.heap_dump" + patterFileSuffix + ".dump\", output redirected to report dir" } );
+                new String[] { "HiMemReport: Successfully executed \"VM.flags -all\" \\(\\d+ ms\\), output redirected to report dir",
+                        "HiMemReport: Successfully executed \"VM.metaspace show-loaders\" \\(\\d+ ms\\), output redirected to report dir",
+                        "HiMemReport: Successfully executed \"GC.heap_dump .*himemreport-2/GC.heap_dump" + patterFileSuffix + ".dump\" \\(\\d+ ms\\), output redirected to report dir" } );
 
         // VM.flags:
 
@@ -260,7 +260,7 @@ public class TestHiMemReport {
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
-                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+                "sleep", "8" // num seconds to sleep to give the reporter thread time to generate output
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -277,7 +277,7 @@ public class TestHiMemReport {
         line = VitalsUtils.matchPatterns(lines, line + 1, new String [] {
                         ".*HiMemReport *= *true.*",
                         ".*HiMemReportMax *= *134217728.*",
-                        "HiMemReport: Successfully executed \"VM.flags -all\""
+                        "HiMemReport: Successfully executed \"VM.flags -all\" \\(\\d+ ms\\)"
         });
 
         // ... as well as the output of VM.metaspace
@@ -289,7 +289,7 @@ public class TestHiMemReport {
                 "Virtual space.*",
                 "Settings.*",
                 "MaxMetaspaceSize.*",
-                "HiMemReport: Successfully executed \"VM.metaspace show-loaders\""
+                "HiMemReport: Successfully executed \"VM.metaspace show-loaders\" \\(\\d+ ms\\)"
         });
 
     } // end: testDumpWithExecToReportDir


### PR DESCRIPTION
Clean downport.

- Show execution time, in ms, for all commands executed with HiMemReportExec
- Increase time for TestHiMemReport to finish reporting on slow machines

(cherry picked from commit 7fcb181a45a983825471ae2631d84cc2bfd7ab0c)

fixes #1170

