### PR TITLE
SapMachine #1172: Vitals: VitalsValuesSanityCheck_id0 fails (trivial) (18)

### DIFF
--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -280,11 +280,13 @@ public class VitalsValuesSanityCheck {
                 if (csv.header.hasColumn("syst-cgro-usg")) {
                     checkValueIsBetween(csv, "syst-cgro-usg", veryLowButNot0, highestExpectedMemoryValue);
                 }
-                if (csv.header.hasColumn("syst-cgro-kusg")) {
-                    // kusg can get surprisingly high, e.g. if ran on a host hosting guest VMs (seen that with virtual box)
-                    // ... and it can be 0 too for some reason, seen on our loaner ppcle machines at Adopt
-                    checkValueIsBetween(csv, "syst-cgro-kusg", 0, highestExpectedMemoryValue);
-                }
+//                Completely disable this test because hunting down erros here is exhausting. Many kernels don't seem to show
+//                kernel memory values. So this may not show off at all, or show a column without value.
+//                if (csv.header.hasColumn("syst-cgro-kusg")) {
+//                    // kusg can get surprisingly high, e.g. if ran on a host hosting guest VMs (seen that with virtual box)
+//                    // ... and it can be 0 too for some reason, seen on our loaner ppcle machines at Adopt
+//                    checkValueIsBetween(csv, "syst-cgro-kusg", 0, highestExpectedMemoryValue);
+//                }
 
                 // Check --- process --- cols on Linux
                 long proc_virt = checkValueIsBetween(csv, "proc-virt", jvm_mapped_this_much_at_least, 100 * G); // virt size can get crazy


### PR DESCRIPTION
Clean trivial downport.

fixes #1172

