### PR TITLE
SapMachine #1161: SapMachine 17, 11 do not build in minimal (11)

### DIFF
--- a/src/hotspot/os/linux/vitals_linux_himemreport.cpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.cpp
@@ -42,6 +42,7 @@
 #include "services/memReporter.hpp"
 #include "services/memTracker.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 #include "vitals/vitals_internals.hpp"
 
@@ -49,6 +50,13 @@
 #include <spawn.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+
+// Newer JDKS: NMT is always on and this macro does not exist
+// Older JDKs: NMT can be off at compile time; in that case INCLUDE_NMT
+//  will be defined=0 via CFLAGS; or on, in that case it will be defined=1 in macros.hpp.
+#ifndef INCLUDE_NMT
+#define INCLUDE_NMT 1
+#endif
 
 // Logging and output:
 // We log during initialization phase to UL using the "vitals" tag.
@@ -216,6 +224,7 @@ static const char* describe_maximum_by_compare_type(compare_type t) {
 // NMT is nice, but the interface is unnecessary convoluted. For now, to keep merge surface small,
 // we work with what we have
 
+#if INCLUDE_NMT
 class NMTStuff : public AllStatic {
 
   static MemBaseline _baseline;
@@ -302,7 +311,7 @@ public:
 
 MemBaseline NMTStuff::_baseline;
 time_t NMTStuff::_baseline_time = 0;
-
+#endif // INCLUDE_NMT
 
 //////////// Reporting //////////////////////////////////////////////
 
@@ -405,10 +414,12 @@ static void print_high_memory_report(outputStream* st) {
   st->cr();
   st->flush();
 
+#if INCLUDE_NMT
   st->cr();
   st->print_cr("--- NMT report ---");
   NMTStuff::report_as_best_as_possible(st);
   st->print_cr("--- /NMT report ---");
+#endif
 
   st->cr();
   st->cr();
@@ -773,6 +784,7 @@ void pulse_himem_report() {
       }
       // If the alert level increased to a new value, trigger a new report
       trigger_high_memory_report(new_alvl, spikeno, new_percentage, rss_swap);
+#if INCLUDE_NMT
       // Upon first alert, do a NMT baseline
       if (old_alvl == 0 && new_alvl > 0) {
         if (NMTStuff::is_enabled()) {
@@ -780,11 +792,14 @@ void pulse_himem_report() {
           stderr_stream.print_cr("HiMemoryReport: ... captured NMT baseline");
         }
       }
+#endif // INCLUDE_NMT
     } else if (old_alvl > 0 && new_alvl == 0){
       // Memory usage recovered, and we hit the decay time, and now all is well again.
       stderr_stream.print_cr("HiMemoryReport: rss+swap=" SIZE_FORMAT " K - seems we recovered. Resetting alert level.",
                              rss_swap / K);
+#if INCLUDE_NMT
       NMTStuff::reset();
+#endif
     }
   }
 }

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -50,8 +50,10 @@
 #include <locale.h>
 #include <time.h>
 
-// JDK-8280583: "Always build NMT" did away with INCLUDE_NMT for JDK19++
-#if defined(JDK_MAINLINE) || defined(JDK19u)
+// Newer JDKS: NMT is always on and this macro does not exist
+// Older JDKs: NMT can be off at compile time; in that case INCLUDE_NMT
+//  will be defined=0 via CFLAGS; or on, in that case it will be defined=1 in macros.hpp.
+#ifndef INCLUDE_NMT
 #define INCLUDE_NMT 1
 #endif
 
@@ -1115,7 +1117,7 @@ static void set_value_in_sample(const Column* col, Sample* sample, T t) {
 //  }
 //};
 
-#if INCLUDE_NMT
+
 struct nmt_values_t {
   // How much memory, in total, was committed via mmap
   value_t mapped_total;
@@ -1136,7 +1138,7 @@ struct nmt_values_t {
 };
 
 static bool get_nmt_values(nmt_values_t* out) {
-  value_t result = INVALID_VALUE;
+#if INCLUDE_NMT
   if (is_nmt_enabled()) {
     MutexLocker locker(MemTracker::query_lock());
     /*const*/MallocMemorySnapshot* mlc_snapshot = MallocMemorySummary::as_snapshot();
@@ -1164,9 +1166,9 @@ static bool get_nmt_values(nmt_values_t* out) {
         mlc_snapshot->malloc_overhead()->count();
     return true;
   }
+#endif // INCLUDE_NMT
   return false;
 }
-#endif // INCLUDE_NMT
 
 void sample_jvm_values(Sample* sample, bool avoid_locking) {
 
@@ -1174,12 +1176,9 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
 
   nmt_values_t nmt_vals;
   bool have_nmt_values = false;
-#if INCLUDE_NMT
   if (!avoid_locking) {
     have_nmt_values = get_nmt_values(&nmt_vals);
   }
-#endif
-
 
   // Heap
   if (!avoid_locking) {


### PR DESCRIPTION
Needed manual resolve. Patch is semantically unchanged.

fixes #1161

