### PR TITLE
SapMachine (17): Update test exclusion list and fix some bugs pre-release 17.0.4

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4783,7 +4783,8 @@ static int _cpu_count(const cpu_set_t* cpus) {
 // dynamic check - see 6515172 for details.
 // If anything goes wrong we fallback to returning the number of online
 // processors - which can be greater than the number available to the process.
-int os::Linux::active_processor_count() {
+static int get_active_processor_count() {
+  // Note: keep this function, with its CPU_xx macros, *outside* the os namespace (see JDK-8289477).
   cpu_set_t cpus;  // can represent at most 1024 (CPU_SETSIZE) processors
   cpu_set_t* cpus_p = &cpus;
   int cpus_size = sizeof(cpu_set_t);
@@ -4853,6 +4854,10 @@ int os::Linux::active_processor_count() {
 
   assert(cpu_count > 0 && cpu_count <= os::processor_count(), "sanity check");
   return cpu_count;
+}
+
+int os::Linux::active_processor_count() {
+  return get_active_processor_count();
 }
 
 // Determine the active processor count from one of

--- a/src/hotspot/os/linux/vitals_linux_himemreport.cpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.cpp
@@ -42,6 +42,7 @@
 #include "services/memReporter.hpp"
 #include "services/memTracker.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 #include "vitals/vitals_internals.hpp"
 
@@ -49,6 +50,13 @@
 #include <spawn.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+
+// Newer JDKS: NMT is always on and this macro does not exist
+// Older JDKs: NMT can be off at compile time; in that case INCLUDE_NMT
+//  will be defined=0 via CFLAGS; or on, in that case it will be defined=1 in macros.hpp.
+#ifndef INCLUDE_NMT
+#define INCLUDE_NMT 1
+#endif
 
 // Logging and output:
 // We log during initialization phase to UL using the "vitals" tag.
@@ -214,6 +222,7 @@ static const char* describe_maximum_by_compare_type(compare_type t) {
 // NMT is nice, but the interface is unnecessary convoluted. For now, to keep merge surface small,
 // we work with what we have
 
+#if INCLUDE_NMT
 class NMTStuff : public AllStatic {
 
   static MemBaseline _baseline;
@@ -300,7 +309,7 @@ public:
 
 MemBaseline NMTStuff::_baseline;
 time_t NMTStuff::_baseline_time = 0;
-
+#endif // INCLUDE_NMT
 
 //////////// Reporting //////////////////////////////////////////////
 
@@ -403,10 +412,12 @@ static void print_high_memory_report(outputStream* st) {
   st->cr();
   st->flush();
 
+#if INCLUDE_NMT
   st->cr();
   st->print_cr("--- NMT report ---");
   NMTStuff::report_as_best_as_possible(st);
   st->print_cr("--- /NMT report ---");
+#endif
 
   st->cr();
   st->cr();
@@ -769,6 +780,7 @@ void pulse_himem_report() {
       }
       // If the alert level increased to a new value, trigger a new report
       trigger_high_memory_report(new_alvl, spikeno, new_percentage, rss_swap);
+#if INCLUDE_NMT
       // Upon first alert, do a NMT baseline
       if (old_alvl == 0 && new_alvl > 0) {
         if (NMTStuff::is_enabled()) {
@@ -776,11 +788,14 @@ void pulse_himem_report() {
           stderr_stream.print_cr("HiMemoryReport: ... captured NMT baseline");
         }
       }
+#endif // INCLUDE_NMT
     } else if (old_alvl > 0 && new_alvl == 0){
       // Memory usage recovered, and we hit the decay time, and now all is well again.
       stderr_stream.print_cr("HiMemoryReport: rss+swap=" SIZE_FORMAT " K - seems we recovered. Resetting alert level.",
                              rss_swap / K);
+#if INCLUDE_NMT
       NMTStuff::reset();
+#endif
     }
   }
 }

--- a/src/hotspot/os/linux/vitals_linux_himemreport.cpp
+++ b/src/hotspot/os/linux/vitals_linux_himemreport.cpp
@@ -617,8 +617,11 @@ static void call_single_jcmd(const ParsedCommand* cmd, int pid, time_t t) {
   argv[3] = NULL;
 
   stringStream err_msg;
+  const jlong t1 = os::javaTimeNanos();
   if (spawn_command(argv, out_file, err_file, &err_msg)) {
-    stderr_stream.print("HiMemReport: Successfully executed \"%s\"", jcmd_command.base());
+    const jlong t2 = os::javaTimeNanos();
+    const int command_time_ms = (t2 - t1) / (1000 * 1000);
+    stderr_stream.print("HiMemReport: Successfully executed \"%s\" (%d ms)", jcmd_command.base(), command_time_ms);
     if (out_file != NULL) {
       stderr_stream.print(", output redirected to report dir");
     }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1242,7 +1242,9 @@ void MethodData::initialize() {
   int extra_size = extra_data_count * DataLayout::compute_size_in_bytes(0);
 
   // Let's zero the space for the extra data
-  Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  if (extra_size > 0) {
+    Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  }
 
   // Add a cell to record information about modified arguments.
   // Set up _args_modified array after traps cells so that

--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -51,6 +51,11 @@
 #
 compiler/rtm/locking/TestRTMSpinLoopCount.java                                       generic-ppc64,linux-ppc64le
 
+# SapMachine 2022-04-01
+# Expected that method with rtm lock elision was deoptimized after 1 lock attempts: expected 2 to equal 1
+#
+compiler/rtm/locking/TestRTMAbortThreshold.java                                      generic-ppc64,linux-ppc64le
+
 # SapMachine 2019-04-29
 # Sporadic timeout 11 only since 3.3.2019, which is probably the date we started to run these again.
 vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java                                generic-all
@@ -81,22 +86,19 @@ serviceability/dcmd/framework/VMVersionTest.java                                
 # SapMachine 2020-04-09
 # We see some new failures on aarch64, 11u only. They probably aren't new but
 # we just started to run tests for 11u on that platform lately
+# SapMachine 2022-06-03 Let's give it a try. Local tests pass.
+# SapMachine 2022-06-20 We still see timeouts. Only in 11 on ...
 #
 #compiler/c2/cr6340864/TestIntVect.java                                               linux-aarch64
 #
+#
 #compiler/c2/cr6340864/TestLongVect.java                                              linux-aarch64
+#
 #
 #compiler/c2/cr6340864/TestShortVect.java                                             linux-aarch64
 #
+#
 #compiler/codegen/TestCharVect2.java                                                  linux-aarch64
-
-###############################################################################
-# New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
-
-# SapMachine 2020-07-31
-# Fails because UseShenandoahGC is not recognized if JDK is built without shenandoah (default).
-# https://bugs.openjdk.java.net/browse/JDK-8250888
-#vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java       generic-all
 
 ###############################################################################
 # Tests known to be failing in OpenJDK when JDK 12 was released (3/2019)
@@ -120,67 +122,54 @@ runtime/CompressedOops/UseCompressedOops.java                                   
 # Some brand new shenandoah tests are failing.
 #
 # SapMachine 2019-07-25 Still around
-gc/shenandoah/TestWithLogLevel.java                                                  macosx-all
+# SapMachine 2022-06-03 Let's give it a try.
+#gc/shenandoah/TestWithLogLevel.java                                                  macosx-all
 
 # SapMachine 2019-08-02
 # Exception: Uncommitted too slow
 # In SapMachine, we also see this in 13.
-gc/z/TestUncommit.java                                                               generic-all
+# SapMachine 2022-06-03 Let's give it a try. Local test passes.
+#gc/z/TestUncommit.java                                                               generic-all
 
 ###############################################################################
 # Failing new tests, unsupported new features in jdk14
 
 # SapMachine 2019-08-02
 # Crash: Shenandoah assert_correct failed; Object klass pointer must go to metaspace
-gc/CriticalNativeArgs.java                                                           generic-all
-
-# SapMachine 2019-08-02
-# Test failed with -XX:+AdjustStackSizeForTLS
-runtime/TLS/testtls.sh                                                               generic-all
+# SapMachine 2022-06-03 Let's give it a try. Local test passes.
+# SapMachine 2022-06-03 Test removed in 18.
+#gc/CriticalNativeArgs.java                                                           generic-all
 
 # SapMachine 2019-08-29
 # Some aarch stuff, we don't really care. Do we?
 # Check later on whether it's fixed.
+# SapMachine 2022-06-03 Let's give it a try. Local test passes.
 #
-compiler/c2/aarch64/TestVolatilesG1.java                                             linux-aarch64
+#compiler/c2/aarch64/TestVolatilesG1.java                                             linux-aarch64
 #
-gc/shenandoah/mxbeans/TestChurnNotifications.java#id0                                linux-aarch64
+#gc/shenandoah/mxbeans/TestChurnNotifications.java#id0                                linux-aarch64
 
 # SapMachine 2019-01-02
 # This is failing currently on various places after https://bugs.openjdk.java.net/browse/JDK-8234277
 # It is tracked with https://bugs.openjdk.java.net/browse/JDK-8235220
 # We exclude it now until upstream bug is resolved to reduce noise in testing
 # SapMachine 2020-07-07 Re-enabling test in 15+, because JDK-8235220 is fixed in 15
-#serviceability/sa/ClhsdbScanOops.java                                                generic-all
+#serviceability/sa/ClhsdbScanOops.java                                        8235220 generic-all
 
 ###############################################################################
 # Failing new tests, unsupported new features in jdk15
-
-# SapMachine 2020-02-11
-# New test, fails on AIX due to primordial thread issue
-#
-#
-testlibrary_tests/process/TestNativeProcessBuilder.java                              aix-all
 
 # SapMachine 2020-09-17
 # Fails with: RuntimeException: 'Unloaded library with handle' missing from stdout/stderr
 # Recurring, 1-2 times a month.
 runtime/logging/loadLibraryTest/LoadLibraryTest.java                                 generic-all
 
-# SapMachine 2020-09-17
-# agent library failed to init: FieldAccessWatch
-# Failed to set capabilities, error: 98
-serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java                          aix-all
-
 ###############################################################################
 # Failing new tests, unsupported new features in jdk16
 
 # SapMachine 2020-10-05
-# This test consumes a lot of resourcess - exlcude it on all platforms to avoid issues with out of memory.
+# This test consumes a lot of resources - exclude it on all platforms to avoid issues with out of memory.
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java          generic-all
-
-###############################################################################
-# Failing new tests, unsupported new features in jdk17
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
@@ -154,7 +154,7 @@ public class TestHiMemReport {
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
-                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+                "sleep", "12" // num seconds to sleep to give the reporter thread time to generate output
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -185,9 +185,9 @@ public class TestHiMemReport {
         // HiMemReportExec should have caused three jcmds to fire...
 
         line = VitalsUtils.matchPatterns(lines, line + 1,
-                new String[] { "HiMemReport: Successfully executed \"VM.flags -all\", output redirected to report dir",
-                        "HiMemReport: Successfully executed \"VM.metaspace show-loaders\", output redirected to report dir",
-                        "HiMemReport: Successfully executed \"GC.heap_dump .*himemreport-2/GC.heap_dump" + patterFileSuffix + ".dump\", output redirected to report dir" } );
+                new String[] { "HiMemReport: Successfully executed \"VM.flags -all\" \\(\\d+ ms\\), output redirected to report dir",
+                        "HiMemReport: Successfully executed \"VM.metaspace show-loaders\" \\(\\d+ ms\\), output redirected to report dir",
+                        "HiMemReport: Successfully executed \"GC.heap_dump .*himemreport-2/GC.heap_dump" + patterFileSuffix + ".dump\" \\(\\d+ ms\\), output redirected to report dir" } );
 
         // VM.flags:
 
@@ -260,7 +260,7 @@ public class TestHiMemReport {
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
-                "sleep", "4" // num seconds to sleep to give the reporter thread time to generate output
+                "sleep", "8" // num seconds to sleep to give the reporter thread time to generate output
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -277,7 +277,7 @@ public class TestHiMemReport {
         line = VitalsUtils.matchPatterns(lines, line + 1, new String [] {
                         ".*HiMemReport *= *true.*",
                         ".*HiMemReportMax *= *134217728.*",
-                        "HiMemReport: Successfully executed \"VM.flags -all\""
+                        "HiMemReport: Successfully executed \"VM.flags -all\" \\(\\d+ ms\\)"
         });
 
         // ... as well as the output of VM.metaspace
@@ -289,7 +289,7 @@ public class TestHiMemReport {
                 "Virtual space.*",
                 "Settings.*",
                 "MaxMetaspaceSize.*",
-                "HiMemReport: Successfully executed \"VM.metaspace show-loaders\""
+                "HiMemReport: Successfully executed \"VM.metaspace show-loaders\" \\(\\d+ ms\\)"
         });
 
     } // end: testDumpWithExecToReportDir

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -280,11 +280,13 @@ public class VitalsValuesSanityCheck {
                 if (csv.header.hasColumn("syst-cgro-usg")) {
                     checkValueIsBetween(csv, "syst-cgro-usg", veryLowButNot0, highestExpectedMemoryValue);
                 }
-                if (csv.header.hasColumn("syst-cgro-kusg")) {
-                    // kusg can get surprisingly high, e.g. if ran on a host hosting guest VMs (seen that with virtual box)
-                    // ... and it can be 0 too for some reason, seen on our loaner ppcle machines at Adopt
-                    checkValueIsBetween(csv, "syst-cgro-kusg", 0, highestExpectedMemoryValue);
-                }
+//                Completely disable this test because hunting down erros here is exhausting. Many kernels don't seem to show
+//                kernel memory values. So this may not show off at all, or show a column without value.
+//                if (csv.header.hasColumn("syst-cgro-kusg")) {
+//                    // kusg can get surprisingly high, e.g. if ran on a host hosting guest VMs (seen that with virtual box)
+//                    // ... and it can be 0 too for some reason, seen on our loaner ppcle machines at Adopt
+//                    checkValueIsBetween(csv, "syst-cgro-kusg", 0, highestExpectedMemoryValue);
+//                }
 
                 // Check --- process --- cols on Linux
                 long proc_virt = checkValueIsBetween(csv, "proc-virt", jvm_mapped_this_much_at_least, 100 * G); // virt size can get crazy

--- a/test/jaxp/ProblemList-SapMachine.txt
+++ b/test/jaxp/ProblemList-SapMachine.txt
@@ -47,10 +47,8 @@
 
 # SapMachine 2019-03-12
 # IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 503 Service Unavailable";
-javax/xml/jaxp/unittest/dom/DOMFeatureTest.java                     generic-all
-
-###############################################################################
-# Failing new tests, unsupported new features in jdk17
+# SapMachine 2022-07-07: Give it another chance
+#javax/xml/jaxp/unittest/dom/DOMFeatureTest.java                     generic-all
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/jdk/ProblemList-SapMachine.txt
+++ b/test/jdk/ProblemList-SapMachine.txt
@@ -52,36 +52,18 @@
 # SapMachine 2019-07-16 Still fails
 java/lang/ProcessHandle/InfoTest.java                                                windows-all,aix-all
 
-# SapMachine 2018-08-22 Failures on sparc/linuxppc64le.
+# SapMachine 2018-08-22 Failures on linuxppc64le.
 # Some just fail sporadic.
 #
-com/sun/nio/sctp/SctpChannel/Bind.java                                               solaris-sparcv9
+com/sun/nio/sctp/SctpMultiChannel/Branch.java                                        linux-ppc64le
 #
-com/sun/nio/sctp/SctpChannel/Receive.java                                            solaris-sparcv9
+com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java                             linux-ppc64le
 #
-com/sun/nio/sctp/SctpChannel/ReceiveIntoDirect.java                                  solaris-sparcv9
+com/sun/nio/sctp/SctpMultiChannel/Send.java                                          linux-ppc64le
 #
-com/sun/nio/sctp/SctpChannel/Shutdown.java                                           solaris-sparcv9
+com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                                  linux-ppc64le
 #
-com/sun/nio/sctp/SctpServerChannel/Accept.java                                       solaris-sparcv9
-#
-com/sun/nio/sctp/SctpChannel/CommUp.java                                             solaris-sparcv9
-#
-com/sun/nio/sctp/SctpServerChannel/NonBlockingAccept.java                            solaris-sparcv9
-#
-com/sun/nio/sctp/SctpChannel/Connect.java                                            solaris-sparcv9
-#
-com/sun/nio/sctp/SctpMultiChannel/Branch.java                                        linux-ppc64le,solaris-sparcv9
-#
-com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java                             linux-ppc64le,solaris-sparcv9
-#
-com/sun/nio/sctp/SctpMultiChannel/Send.java                                          linux-ppc64le,solaris-sparcv9
-#
-com/sun/nio/sctp/SctpChannel/SocketOptionTests.java                                  linux-ppc64le,solaris-sparcv9
-#
-com/sun/nio/sctp/SctpChannel/Send.java                                               linux-ppc64le,solaris-sparcv9
-# SapMachine 2019-09-18 See if these still occur
-#com/sun/nio/sctp/SctpChannel/Branch.java                                             solaris-sparcv9
+com/sun/nio/sctp/SctpChannel/Send.java                                               linux-ppc64le
 
 # SapMachine 2018-06-22, 2019-04-30
 # Fails only on recent Suse systems (e.g. SLES 12.2, 12.4, 15): "RuntimeException: Test failed for angle 15.0"
@@ -93,7 +75,7 @@ java/awt/font/Rotate/RotatedTextTest.java                                    821
 # SapMachine 2019-09-26
 # This seems to fail on RHEL 7: java.lang.RuntimeException: Font metrics differ for angle 165
 #
-java/awt/font/Rotate/RotatedFontMetricsTest.java                                     linux-all
+java/awt/font/Rotate/RotatedFontMetricsTest.java                             8219641 linux-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.3 (e.g. seen only in jdk11u-dev after branching 11.0.3 to jdk11u)
@@ -104,8 +86,8 @@ java/awt/font/Rotate/RotatedFontMetricsTest.java                                
 # Seen in 11, 13, 14.
 #
 # SapMachine 2020-06-22
-# We give up on fixing this. We keep the test excldued.
-javax/swing/JFileChooser/4847375/bug4847375.java                                     windows-x64
+# We give up on fixing this. We keep the test excluded.
+javax/swing/JFileChooser/4847375/bug4847375.java                             8227257 windows-x64
 
 # SapMachine 2019-07-15
 # Issue started occuring in 06/2019 but not related to JDK updates
@@ -122,15 +104,9 @@ java/awt/print/PrinterJob/SameService.java                                   822
 #
 #
 # SapMachine 2019-08-13 Remove entry after moving tests to OSX 10.12+. There the font iteration is fast.
-java/awt/FontClass/FontSize1Test.java                                                macosx-all
-
-###############################################################################
-# New failures detected after GA of 11.0.8 (e.g. seen only in jdk11u-dev after branching 11.0.8 to jdk11u)
-
-# SapMachine 2020-09-04
-# This times out on AIX machines. don't fix, AIX is off-topic.  Seen in 11.0.8 and 16.
-#
-java/awt/FontClass/DrawStringWithInfiniteXform.java                                  aix-all
+# As of 2022-05-05 we support 10.14.5 and younger in 11 and 17.
+# So it should pass, reenable.
+#java/awt/FontClass/FontSize1Test.java                                                macosx-all
 
 ###############################################################################
 # New failures detected after GA of 11.0.9 (e.g. seen only in jdk11u-dev after branching 11.0.9 to jdk11u)
@@ -139,6 +115,12 @@ java/awt/FontClass/DrawStringWithInfiniteXform.java                             
 # SocketException: Cannot allocate memory
 #
 # Seen a lot on mac, also 7, 11 ...
+# In 15 https://bugs.openjdk.java.net/browse/JDK-8241786 addressed this, but we still see the
+# failure in 17.
+#
+#
+# A simple backport of 8241786 to 11 caused crashes:
+#
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java                     macosx-all
 
 ###############################################################################
@@ -164,36 +146,22 @@ sun/security/pkcs11/Secmod/AddTrustedCert.java                               823
 
 # SapMachine 2019-02-08
 # times out.
-com/sun/jndi/ldap/LdapDnsProviderTest.java                                           macosx-all
+# 2022-05-05 Timeouts addressed by JDK-8251189 in 16, backported to 11.
+#com/sun/jndi/ldap/LdapDnsProviderTest.java                                           macosx-all
 
 # SapMachine 2019-02-08
 # Can't delete /priv/jvmtests/.../javax/security/auth/Subject/DoAs/NestedActions.d
 # SapMachine 2019-07-12 Still failing
-javax/security/auth/Subject/DoAs.java                                                macosx-all
+# SapMachine 2022-05-05 Let's give it a try
+#javax/security/auth/Subject/DoAs.java                                                macosx-all
 
 # SapMachine 2019-02-08
 # RuntimeException: getBundle("UnreadableRB") doesn't throw class java.io.IOException
 # SapMachine 2019-07-12 Still failing
+# SapMachine 2022-05-05 Still failing. Now:
+# RuntimeException: getBundle("UnreadableRB") doesn't throw class java.io.IOException
+#
 java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java                    windows-all
-
-# SapMachine 2019-02-08
-# assertEquals: expected -1 to equal 53332
-tools/jlink/JLinkReproducibleTest.java                                               aix-ppc64
-
-# SapMachine 2019-02-08
-# java.lang.StackOverflowError
-java/lang/String/concat/WithSecurityManager.java                                     aix-ppc64
-# NoSuchElementException: No value present at java.base/java.util.Optional.get
-java/net/SocketPermission/SocketPermissionTest.java                                  aix-ppc64
-# NoSuchElementException: at java.base/java.util.Spliterators$1Adapter.next()
-java/nio/channels/DatagramChannel/BasicMulticastTests.java                           aix-ppc64
-# RuntimeException: IOException expected at DeleteOnClose.runTest(DeleteOnClose.java:92)
-java/nio/file/Files/DeleteOnClose.java                                               aix-ppc64
-# RuntimeException at SBC.noFollowLinksTests(SBC.java:238)
-java/nio/file/Files/SBC.java                                                         aix-ppc64
-# Happens sporadic:
-# SSLHandshakeException: PKIX path validation failed: CertPathValidatorException: Could not determine revocation status
-javax/net/ssl/Stapling/SSLEngineWithStapling.java                                    aix-ppc64
 
 # SapMachine 2019-02-16
 # timeout, on be a lot, on le once.
@@ -208,17 +176,13 @@ java/nio/channels/FileChannel/CleanerTest.java                                  
 #
 java/awt/font/FontNames/FCCompositeTest.java                                         linux-all
 
-# SapMachine 2019-08-09
-# This test fails only on ..., probably a configuration issue
-#
-#
-java/nio/file/WatchService/LotsOfCloses.java                                         linux-s390x
-
 # SapMachine 2019-08-29
 # GC overhead limit exceeded, occurs very often
 #
 # Created JBS issue: https://bugs.openjdk.java.net/browse/JDK-8230349
-jdk/jfr/event/gc/detailed/TestStressAllocationGCEventsWithParallel.java      8230349 macosx-all
+# SapMachine 2022-05-05 Pointless exclude in 17, test was moved to new location.
+# Also, 8230349 was closed as not reproducible.
+#jdk/jfr/event/gc/detailed/TestStressAllocationGCEventsWithParallel.java      8230349 macosx-all
 
 ###############################################################################
 # Failing new tests, unsupported new features in jdk14
@@ -227,41 +191,17 @@ jdk/jfr/event/gc/detailed/TestStressAllocationGCEventsWithParallel.java      823
 # Richard's new test unveils an aarch64 issue.
 com/sun/jdi/EATests.java                                                             linux-aarch64
 
-# SapMachine 2019-12-04
-# New failures on AIX after recent changes in jdk/jdk
-#
-#
-java/nio/channels/DatagramChannel/AfterDisconnect.java                               aix-all
-#
-java/nio/channels/DatagramChannel/ChangingAddress.java                               aix-all,macosx-all
-
 ###############################################################################
 # Failing new tests, unsupported new features in jdk15
 
-# SapMachine 2019-02-27
-# Fails in nightly tests since middle of February 2020, cannot be reproduced locally
-#
-lib/testlibrary/OutputAnalyzerTest.java                                              generic-all
-
-# SapMachine 2020-04-01 fails in nightly tests sometimes
-# https://bugs.openjdk.java.net/browse/JDK-8227651
-#
-# The bug deals with a similar issue, our info has been added
-javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java                       8227651 linux-s390x, aix-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java                       8227651 linux-s390x
-
-# SapMachine 2020-09-17
-# Seen only on this one machine -- machine issue?
-# *** glibc detected *** /bin/java: double free or corruption
-javax/sound/sampled/Clip/ClipIsRunningAfterStop.java                                 linux-ppc64
-
 # SapMachine 2020-09-17
 # RuntimeException: '/net/usr.work': 13570272264192 != 13570272198656
-java/io/File/GetXSpace.java                                                          generic-all
-
-# SapMachine 2020-09-17
-# Sporadic timeout on ls3876.  Exclude only here
-java/net/Socket/AsyncShutdown.java                                                   linux-ppc64
+# SapMachine 2022-01-24
+# Lets test if 8251466 is fixed with PR 7170 on windows.
+# This will not solve the issue with ...
+# Seen again in 19 on 2022-02-06 on ppc and NTAMD64, e.g. "InvalidPathException: Illegal char <:> at index 0: :"
+#
+#java/io/File/GetXSpace.java                                                          generic-all
 
 # SapMachine 2020-09-17
 # WARNING: Using incubator modules: jdk.incubator.foreign
@@ -269,19 +209,23 @@ java/net/Socket/AsyncShutdown.java                                              
 java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java    linux-ppc64,linux-ppc64le
 
 # SapMachine 2020-09-17
-# IllegalArgumentException: IPv6 socket cannot join IPv4 multicast group
-# many aix machines
-# Added macosx-all to the tests that are in the original exclude list.
-java/net/MulticastSocket/B6427403.java                                               aix-all
-java/net/MulticastSocket/NoLoopbackPackets.java                                      aix-all,macosx-all
-java/net/MulticastSocket/Promiscuous.java                                            aix-all
-java/net/MulticastSocket/SetLoopbackMode.java                                        aix-all,macosx-all
-java/net/MulticastSocket/Test.java                                                   aix-all,macosx-all
-
-# SapMachine 2020-09-17
 # Exception: ERROR: IsModifiableClass failed.
 # I'd assume this test should not be run on mac.
 java/lang/instrument/IsModifiableClassAgent.java                                     macosx-all
+
+# SapMachine 2022-04-01
+# java.lang.RuntimeException: Ratio of blue to red is too great: 0.1125
+#
+# Actually we see this only in 17+ currently, but I assume this is similar to the
+# other failures of tests rotating text in 11. We probably just don't run 11 tests
+# on a machine with the problematic fonts. Seen on ls3858, SLES 15.
+# This was ProblemListed in 11 with 8199022, and de-listed without a fix in 15
+# with 8197797. Since then we see the failure again.
+# In 11, it also fails on s390:
+# SapMachine GL 2022-06-23
+# Now we see it on linuxaarch64
+# Excluding on all linux.
+java/awt/Graphics2D/DrawString/RotTransText.java                             7043153 linux-all
 
 ###############################################################################
 # Failing new tests, unsupported new features in jdk16
@@ -294,35 +238,6 @@ sun/tools/jstat/jstatLineCounts1.sh                                          824
 sun/tools/jstat/jstatLineCounts2.sh                                          8248691 linux-ppc64,linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts3.sh                                          8248691 linux-ppc64,linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts4.sh                                          8248691 linux-ppc64,linux-ppc64le,aix-all
-
-###############################################################################
-# Failing new tests, unsupported new features in jdk17
-
-# SapMachine 2021-07-15
-# These tests create core files on linux-s390x when executing the packaged binary. Might be releated to usage
-# of jdk.incubator.foreign that is not implemented on s390. BUt could also be something compleetely different.
-tools/jpackage/share/jdk/jpackage/tests/AppVersionTest.java                          linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/BasicTest.java                               linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/CookedRuntimeTest.java                       linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/DotInNameTest.java                           linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/JavaOptionsEqualsTest.java#id0               linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/JavaOptionsEqualsTest.java#id1               linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/JLinkOptionsTest.java                        linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java                           linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/ModulePathTest.java                          linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/ModulePathTest2.java                         linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/ModulePathTest3.java                         linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/MultipleJarAppTest.java                      linux-s390x
-tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java                      linux-s390x
-tools/jpackage/share/AddLauncherTest.java#id1                                        linux-s390x
-tools/jpackage/share/ArgumentsTest.java                                              linux-s390x
-tools/jpackage/share/EmptyFolderTest.java                                            linux-s390x
-
-# SapMachine 2021-08-17
-# These tests do run several hours in a fastdebug build (seen 5 hours on linuxx86_64).
-# They will always hit the timeout value. Exclude them to save execution time.
-# Opened https://bugs.openjdk.java.net/browse/JDK-8271613.
-java/foreign/TestMatrix.java                                                         generic-all
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -31,6 +31,7 @@
  * @key intermittent
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
+ * @requires !vm.musl
  * @library /test/lib
  * @run main/othervm/native/timeout=300 -Djava.security.manager=allow Basic
  * @run main/othervm/native/timeout=300 -Djava.security.manager=allow -Djdk.lang.Process.launchMechanism=fork Basic
@@ -40,7 +41,7 @@
 /*
  * @test
  * @modules java.base/java.lang:open
- * @requires (os.family == "linux")
+ * @requires (os.family == "linux" & !vm.musl)
  * @library /test/lib
  * @run main/othervm/timeout=300 -Djava.security.manager=allow -Djdk.lang.Process.launchMechanism=posix_spawn Basic
  */

--- a/test/langtools/ProblemList-SapMachine.txt
+++ b/test/langtools/ProblemList-SapMachine.txt
@@ -59,10 +59,10 @@ jdk/jshell/JdiHangingLaunchExecutionControlTest.java                generic-all
 # SapMachine 2019-05-07
 # java.lang.AssertionError: ... lists don't have the same size expected [91] but found [92]
 # Seen in 11.0.3 and 11.0.4 very sporadic
-jdk/jshell/CommandCompletionTest.java                               macosx-all
-
-###############################################################################
-# Failing new tests, unsupported new features in jdk17
+# SapMachine 2021-11-02: testUserHome error: Command: /env --class-path ~/3D Objects|, output: []: lists don't have the same size expected [1] but found [0]
+#
+# https://bugs.openjdk.java.net/browse/JDK-8277328
+#jdk/jshell/CommandCompletionTest.java                               macosx-all,windows-all
 
 ###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.


### PR DESCRIPTION
This brings in some fixes for vitals and tests. E.g. #1161 #1172 #1170.

fixes #1195 
