### PR TITLE
SapMachine #1211: Various Fixes to Vitals and MallocTracer

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -93,6 +93,7 @@ public:
 
 };
 
+static bool g_show_system_memavail = false;
 static Column* g_col_system_memavail = NULL;
 static Column* g_col_system_memcommitted = NULL;
 static Column* g_col_system_memcommitted_ratio = NULL;
@@ -155,8 +156,10 @@ bool platform_columns_initialize() {
   OSWrapper::initialize();
   OSWrapper::update_if_needed();
 
+  // syst-avail depends on kernel version.
+  g_show_system_memavail = OSWrapper::syst_avail() != INVALID_VALUE;
   g_col_system_memavail =
-      define_column<MemorySizeColumn>(system_cat, NULL, "avail", "Memory available without swapping [host]", true);
+      define_column<MemorySizeColumn>(system_cat, NULL, "avail", "Memory available without swapping [host] [krn]", g_show_system_memavail);
   g_col_system_memcommitted =
       define_column<MemorySizeColumn>(system_cat, NULL, "comm", "Committed memory [host]", true);
   g_col_system_memcommitted_ratio =
@@ -266,7 +269,9 @@ void sample_platform_values(Sample* sample) {
 
   OSWrapper::update_if_needed();
 
-  set_value_in_sample(g_col_system_memavail, sample, OSWrapper::syst_avail());
+  if (g_show_system_memavail) {
+    set_value_in_sample(g_col_system_memavail, sample, OSWrapper::syst_avail());
+  }
   set_value_in_sample(g_col_system_swap, sample, OSWrapper::syst_swap());
 
   set_value_in_sample(g_col_system_memcommitted, sample, OSWrapper::syst_comm());

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -80,6 +80,7 @@ public:
 
     FILE* f = ::fopen(filename, "r");
     if (f == NULL) {
+      log_debug(vitals)("Failed to fopen %s (%d)", filename, errno);
       return false;
     }
 
@@ -381,14 +382,19 @@ void OSWrapper::update_if_needed() {
   }
   _last_update = t;
 
-  // Update Values from ProcFS (and elsewhere)
+  static bool first_call = true;
 
+  // Update Values from ProcFS (and elsewhere)
 #define RESETVAL(name) _ ## name = INVALID_VALUE;
 ALL_VALUES_DO(RESETVAL)
 #undef RESETVAL
 
   ProcFile bf;
   if (bf.read("/proc/meminfo")) {
+
+    if (first_call) {
+      log_debug(vitals)("Read /proc/meminfo: \n%s", bf.text());
+    }
 
     // All values in /proc/meminfo are in KB
     const size_t scale = K;
@@ -549,6 +555,8 @@ ALL_VALUES_DO(RESETVAL)
     }
   }
 #endif // __GLIBC__
+
+  first_call = false;
 
 }
 

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsTestHelper.java
@@ -203,7 +203,8 @@ public class VitalsTestHelper {
         String colsThatCanBeEmpty_OSX = "";
 
         String colsThatCanBeEmpty_LINUX =
-                  "|syst-cpu.*" // CPU values may be omitted in containers; also they are all deltas
+                  "|syst-avail" // Older kernels < 3.14 miss this value
+                + "|syst-cpu.*" // CPU values may be omitted in containers; also they are all deltas
                 + "|syst-cgr.*" // Cgroup values may be omitted in root cgroup
                 + "|proc-chea-usd|proc-chea-free" // cannot be shown if RSS is > 4g and glibc is too old
                 + "|proc-io-rd|proc-io-wr" // deltas

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -305,9 +305,9 @@ public class VitalsValuesSanityCheck {
                     // our initial ballpark number.
                     long min_c_heap_usage_glibc = (jvm_nmt_mlc == -1 ? jvm_nmt_mlc : expected_minimal_cheap_usage) + K;
                     long max_c_heap_usage_glibc = min_c_heap_usage_glibc + (2 * G); // glibc has crazy overhead
-                    // but cannot be larger than rss ever was
-                    if (max_c_heap_usage_glibc > proc_rss_all) {
-                        max_c_heap_usage_glibc = proc_rss_all - M; // bit less since a lot of stuff is not malloc
+                    // but cannot be larger than virt ever was
+                    if (max_c_heap_usage_glibc > proc_virt) {
+                        max_c_heap_usage_glibc = proc_virt - M; // bit less since a lot of stuff is not malloc
                     }
                     checkValueIsBetween(csv, "proc-chea-usd", min_c_heap_usage_glibc, max_c_heap_usage_glibc);
                     checkValueIsBetween(csv, "proc-chea-free", 0, max_c_heap_usage_glibc);

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceDcmdTest.java
@@ -159,10 +159,14 @@ public class MallocTraceDcmdTest {
         return output.getStdout().contains("Not a glibc system");
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String args[]) throws Throwable {
 
         if (NotAGlibcSystem()) {
             throw new SkippedException("Not a glibc system, skipping test");
+        }
+
+        if (!MallocTraceTestHelpers.GlibcSupportsMallocHooks()) {
+            throw new SkippedException("Glibc has no malloc hooks. Skipping test.");
         }
 
         MallocStresser stresser = new MallocStresser(3);

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
@@ -47,7 +47,12 @@ import jtreg.SkippedException;
 
 public class MallocTraceTest {
 
-    public static void main(String... args) throws Exception {
+    public static void main(String... args) throws Throwable {
+
+        if (!MallocTraceTestHelpers.GlibcSupportsMallocHooks()) {
+            throw new SkippedException("Glibc has no malloc hooks. Skipping test.");
+        }
+
         if (args[0].equals("off") || args[0].equals("on")) {
             boolean active = args[0].equals("on");
             String option = active ? "-XX:+EnableMallocTrace" : "-XX:-EnableMallocTrace";

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
@@ -1,0 +1,27 @@
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class MallocTraceTestHelpers {
+
+    // Returns <major> <minor> in the form:
+    // 0x0000MMmm
+    public static int GlibVersion() throws Throwable {
+        OutputAnalyzer output = ProcessTools.executeProcess("/usr/bin/ldd", "--version");
+        output.reportDiagnosticSummary();
+        String version = output.firstMatch("^ldd.* ([\\d+\\.]+)$", 1);
+        System.out.println("Glibc version is " + version);
+        if (version == null) {
+            return 0; // unknown, assume very low
+        }
+        String[] parts = version.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        int as_numeric = minor | (major << 8);
+        return as_numeric;
+    }
+
+    public static boolean GlibcSupportsMallocHooks() throws Throwable {
+        return GlibVersion() < 0x222; // 0x0223 aka 2.34
+    }
+
+}


### PR DESCRIPTION
A collection of small to tiny fixes. To reduce work, I do them in one patch.

https://github.com/SAP/SapMachine/commit/01ab4db14b03b7bbe34bfb2cf29df74cfe3bb817
Fix for #1210. Now we skip certain tests on test systems with glibc >= 2.34

https://github.com/SAP/SapMachine/commit/ecfcca05ab84871108fce583cb375f9346f37750
Fix for #1209. If /proc/meminfo "MemAvailable" is missing (old kernel), we now omit the "syst-avail" column.

https://github.com/SAP/SapMachine/commit/c646c102189fef637577dcb3a367cdc8b7bf8109
Tracing for #1204. I have no idea what the problem is, maybe this tracing helps.

https://github.com/SAP/SapMachine/commit/2aab7ebb50d5941e283fbae484fde96ec0c9a019
Fix for #1203 . C-heap size and RSS are unrelated, because C-Heap may contain untouched memory. Fixes test that relies on this assumption.

fixes #1203
fixes #1209 
fixes #1210
fixes #1211

