### PR TITLE
SapMachine #1241: Vitals NMT "mlc" value can be too high

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -41,6 +41,7 @@
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/threads.hpp"
+#include "services/memBaseline.hpp"
 #include "services/memTracker.hpp"
 #include "services/mallocTracker.hpp"
 #include "utilities/debug.hpp"
@@ -1143,7 +1144,9 @@ static bool get_nmt_values(nmt_values_t* out) {
 #if INCLUDE_NMT
   if (is_nmt_enabled()) {
     MutexLocker locker(MemTracker::query_lock());
-    /*const*/MallocMemorySnapshot* mlc_snapshot = MallocMemorySummary::as_snapshot();
+    MemBaseline baseline;
+    baseline.baseline(true);
+    MallocMemorySnapshot* mlc_snapshot = baseline.malloc_memory_snapshot();
     VirtualMemorySnapshot vm_snapshot;
     VirtualMemorySummary::snapshot(&vm_snapshot);
     out->malloced_total = mlc_snapshot->total();

--- a/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsValuesSanityCheck.java
@@ -313,6 +313,18 @@ public class VitalsValuesSanityCheck {
                     checkValueIsBetween(csv, "proc-chea-free", 0, max_c_heap_usage_glibc);
                 }
 
+                // Counter-check NMT mlc vs rss
+                // "mlc" can be higher than RSS in release builds, since large malloc blocks may not be fully touched.
+                // However, in debug builds os::malloc inits all malloced blocks, so - apart from a few raw mallocs here and there -
+                // we should not see mlc > rss
+                if (jvm_nmt_mlc != -1) {
+                    if (Platform.isDebugBuild()) {
+                        if (proc_rss_all < jvm_nmt_mlc) {
+                            throw new RuntimeException("NMT mlc higher than RSS?");
+                        }
+                    }
+                }
+
                 checkValueIsBetween(csv, "proc-cpu-us", 0, 100000);
                 checkValueIsBetween(csv, "proc-cpu-sy", 0, 100000);
 


### PR DESCRIPTION
See issue text #1241 .

fixes #1241 
fixes #1242 
