### PR TITLE
SapMachine (17) #1294: Undo JDK-8226608 for SapMachine

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -150,7 +150,8 @@ void DCmdRegistrant::register_dcmds(){
 
   // Debug on cmd (only makes sense with JVMTI since the agentlib needs it).
 #if INCLUDE_JVMTI
-  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<DebugOnCmdStartDCmd>(full_export, true, true));
+  // SapMachine 2022-12-12 Revert JDK-8226608, we should show the VM.start_java_debugging command in jcmd help
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<DebugOnCmdStartDCmd>(full_export, true, false));
 #endif // INCLUDE_JVMTI
 
 #if INCLUDE_CDS

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -872,6 +872,8 @@ printUsage(void)
  "launch=<command line>            run debugger on event             none\n"
  "onthrow=<exception name>         debug on throw                    none\n"
  "onuncaught=y|n                   debug on any uncaught?            n\n"
+ // SapMachine 2022-12-12 Revert JDK-8226608, we should show the onjcmd=y|n option in jdwp usage
+ "onjcmd=y|n                       start debug via jcmd?             n\n"
  "timeout=<timeout value>          for listen/attach in milliseconds n\n"
  "mutf8=y|n                        output modified utf-8             n\n"
  "quiet=y|n                        control over terminal messages    n\n"));


### PR DESCRIPTION
(cherry picked from commit 5795e59ce5a63e0fb579c1010d80f4d27486fff1)

fixes #1294
