### PR TITLE
SapMachine #1323: Enhancements for devkit build and update GHA JDKs

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,13 +29,13 @@ GTEST_VERSION=1.8.1
 JTREG_VERSION=6.1+2
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.4/sapmachine-jdk-17.0.4_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=b03ad6982a023c1a16be6e8184500935cecbfcafa59a9cc65000c995dce29a0b
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.6/sapmachine-jdk-17.0.6_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=a9d61a0dc7260505bdeb626ed747c8503255a634884b5126b31e18965464d0f7
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.4/sapmachine-jdk-17.0.4_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=49df6166a30792bd508813e1c622358fba395cab5809add706562dd96a6ae86b
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.6/sapmachine-jdk-17.0.6_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=77cc1b941c25f82836b599c6b294b3b92178efc5ddc8feaa7ffd32cbc6b76d3b
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.4/sapmachine-jdk-17.0.4_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=78dba5e09788d0e88f45d00fbab37b85c17af22bae7f404f6bae0252ba0b14d9
+MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.6/sapmachine-jdk-17.0.6_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=2332a717bb7e204b93fb017035a9ecca33ee440df652df2c3ab32ab76be4bcc6

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -114,6 +114,23 @@ else ifeq ($(GCC_VER), 9.2.0)
   gmp_ver := gmp-6.1.2
   mpc_ver := mpc-1.0.3
   gdb_ver := gdb-8.3
+#SapMachine 23-01-22 Some tweaks to building devkits
+else ifeq ($(GCC_VER), 8.4.0)
+  gcc_ver := gcc-8.4.0
+  binutils_ver := binutils-2.32
+  ccache_ver := ccache-3.7.3
+  mpfr_ver := mpfr-3.1.5
+  gmp_ver := gmp-6.1.2
+  mpc_ver := mpc-1.0.3
+  gdb_ver := gdb-8.3
+else ifeq ($(GCC_VER), 8.5.0)
+  gcc_ver := gcc-8.5.0
+  binutils_ver := binutils-2.32
+  ccache_ver := ccache-3.7.3
+  mpfr_ver := mpfr-3.1.5
+  gmp_ver := gmp-6.1.2
+  mpc_ver := mpc-1.0.3
+  gdb_ver := gdb-8.3
 else ifeq ($(GCC_VER), 8.3.0)
   gcc_ver := gcc-8.3.0
   binutils_ver := binutils-2.32
@@ -407,6 +424,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile : CONFIG += --enable-64-bit-bfd --libdir=$(
 
 # Makefile creation. Simply run configure in build dir.
 # Setting CFLAGS to -O2 generates a much faster ld.
+#SapMachine 23-01-22 Some tweaks to building devkits
 $(bfdmakes) \
 $(BUILDDIR)/$(binutils_ver)/Makefile \
     : $(BINUTILS_CFG)
@@ -421,7 +439,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
 	      --disable-nls \
 	      --program-prefix=$(TARGET)- \
 	      --enable-multilib \
-	      --enable-gold=default \
+	      --enable-gold \
 	      --enable-threads \
 	      --enable-plugins \
 	) > $(@D)/log.config 2>&1


### PR DESCRIPTION
We should be able to build the older devkits from the sapmachine17 branch. Also bump the GHA JDKs.

fixes #1323
