### PR TITLE
SapMachine #1332: Vitals log should be less chatty

### DIFF
--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -393,7 +393,7 @@ ALL_VALUES_DO(RESETVAL)
   if (bf.read("/proc/meminfo")) {
 
     if (first_call) {
-      log_debug(vitals)("Read /proc/meminfo: \n%s", bf.text());
+      log_trace(vitals)("Read /proc/meminfo: \n%s", bf.text());
     }
 
     // All values in /proc/meminfo are in KB

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -251,16 +251,16 @@ public:
     // containerized, since I like to know controller paths even for those cases.
 
     _containerized = OSContainer::is_containerized();
-    log_info(vitals)("Vitals cgroup initialization: containerized = %d", _containerized);
+    log_debug(vitals)("Vitals cgroup initialization: containerized = %d", _containerized);
 
     const char* controller_path = sapmachine_get_memory_controller_path();
     if (controller_path == NULL) {
-      log_info(vitals)("Vitals cgroup initialization: controller path NULL");
+      log_debug(vitals)("Vitals cgroup initialization: controller path NULL");
       return false;
     }
     size_t pathlen = ::strlen(controller_path);
     if (pathlen == 0) {
-      log_info(vitals)("Vitals cgroup initialization: controller path empty?");
+      log_debug(vitals)("Vitals cgroup initialization: controller path empty?");
       return false;
     }
     stringStream path;
@@ -270,7 +270,7 @@ public:
       path.print("%s/", controller_path);
     }
 
-    log_info(vitals)("Vitals cgroup initialization: controller path: %s", path.base());
+    log_debug(vitals)("Vitals cgroup initialization: controller path: %s", path.base());
 
     // V1 or V2?
     stringStream ss;
@@ -278,15 +278,15 @@ public:
     struct stat s;
     const bool isv1 = os::file_exists(ss.base());
     if (isv1) {
-      log_info(vitals)("Vitals cgroup initialization: v1");
+      log_debug(vitals)("Vitals cgroup initialization: v1");
     } else  {
       ss.reset();
       ss.print("%smemory.current", path.base());
       if (os::file_exists(ss.base())) {
         // okay, its v2
-        log_info(vitals)("Vitals cgroup initialization: v2");
+        log_debug(vitals)("Vitals cgroup initialization: v2");
       } else {
-        log_info(vitals)("Vitals cgroup initialization: no clue. Giving up.");
+        log_debug(vitals)("Vitals cgroup initialization: no clue. Giving up.");
         return false;
       }
     }
@@ -312,7 +312,7 @@ public:
 #undef STORE_PATH
 
 #define LOG_PATH(variable) \
-    log_info(vitals)("Vitals: %s=%s", #variable, variable == NULL ? "<null>" : variable);
+		log_debug(vitals)("Vitals: %s=%s", #variable, variable == NULL ? "<null>" : variable);
     LOG_PATH(_file_usg)
     LOG_PATH(_file_usgsw)
     LOG_PATH(_file_kusg)

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -1261,7 +1261,6 @@ bool initialize() {
   initialized = true;
 
   log_info(vitals)("Vitals v%x", vitals_version);
-  log_info(vitals)("Initializing vitals...");
 
   // Adjust VitalsSampleInterval
   if (VitalsSampleInterval == 0) {
@@ -1285,7 +1284,8 @@ bool initialize() {
   success = success && initialize_sampler_thread();
 
   if (success) {
-    log_info(vitals)("Vitals intialized. Sample interval: " UINTX_FORMAT " seconds.", VitalsSampleInterval);
+    log_info(vitals)("Vitals initialized.");
+    log_debug(vitals)("Vitals sample interval: " UINTX_FORMAT " seconds.", VitalsSampleInterval);
   } else {
     log_warning(vitals)("Failed to initialize Vitals.");
   }

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -45,7 +45,7 @@ public class TestVitalsValidSampleInterval {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldContain("Vitals initialized.");
-        output.shouldContain("Sample interval: " + interval + " sec");
+        output.shouldContain("Vitals sample interval: " + interval + " seconds");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -44,7 +44,8 @@ public class TestVitalsValidSampleInterval {
                 "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
-        output.shouldContain("Vitals intialized. Sample interval: " + interval + " sec");
+        output.shouldContain("Vitals initialized.");
+        output.shouldContain("Sample interval: " + interval + " sec");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestVitalsValidSampleInterval.java
@@ -39,7 +39,7 @@ public class TestVitalsValidSampleInterval {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:VitalsSampleInterval=" + interval,
                 "-XX:MaxMetaspaceSize=16m",
-                "-Xlog:vitals",
+                "-Xlog:vitals=debug",
                 "-Xmx128m",
                 "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
Lowers the log level for vitals log in cgroup initialization from info to debug/trace.

fixes #1332

