### PR TITLE
SapMachine #1348: Fix jtreg test jdk/jfr/api/recording/settings/TestGetConfigurations.java

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/gc_details.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc_details.jfc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration version="2.0" label="gc_details" description="Configuration for all GC related events. Higher impact caused by heap inspection initiated GCs to get heap satistics. Large recording size." provider="SAP SE">
+<configuration version="2.0" label="gc_details" description="Configuration for all GC related events. Higher impact caused by heap inspection initiated GCs to get heap statistics. Large recording size." provider="SAP SE">
 
   <event name="jdk.ThreadAllocationStatistics">
     <setting name="enabled">true</setting>

--- a/test/jdk/jdk/jfr/api/recording/settings/TestGetConfigurations.java
+++ b/test/jdk/jdk/jfr/api/recording/settings/TestGetConfigurations.java
@@ -48,10 +48,21 @@ public class TestGetConfigurations {
     private static final String PROFILE_CONFIG_DESCRIPTION = "Low overhead configuration for profiling, typically around 2 % overhead.";
     private static final String PROFILE_CONFIG_PROVIDER = "Oracle";
 
+    //SapMachine 2023-02-20 Add the two additional configs and checks
+    private static final String GC_CONFIG_NAME = "gc";
+    private static final String GC_CONFIG_LABEL = "gc";
+    private static final String GC_CONFIG_DESCRIPTION = "Configuration for GC related events. No stack traces. Small recording size.";
+    private static final String GC_CONFIG_PROVIDER = "SAP SE";
+
+    private static final String GC_DETAILS_CONFIG_NAME = "gc_details";
+    private static final String GC_DETAILS_CONFIG_LABEL = "gc_details";
+    private static final String GC_DETAILS_CONFIG_DESCRIPTION = "Configuration for all GC related events. Higher impact caused by heap inspection initiated GCs to get heap statistics. Large recording size.";
+    private static final String GC_DETAILS_CONFIG_PROVIDER = "SAP SE";
+
     public static void main(String[] args) throws Throwable {
         List<Configuration> predefinedConfigs = Configuration.getConfigurations();
         Asserts.assertNotNull(predefinedConfigs, "List of predefined configs is null");
-        Asserts.assertEquals(predefinedConfigs.size(), 2, "Expected exactly two predefined configurations");
+        Asserts.assertEquals(predefinedConfigs.size(), 4, "Expected exactly four predefined configurations");
 
         Configuration defaultConfig = findConfigByName(predefinedConfigs, DEFAULT_CONFIG_NAME);
         Asserts.assertNotNull(defaultConfig, "Config '" + DEFAULT_CONFIG_NAME + "' not found");
@@ -64,6 +75,18 @@ public class TestGetConfigurations {
         Asserts.assertEquals(profileConfig.getLabel(), PROFILE_CONFIG_LABEL);
         Asserts.assertEquals(profileConfig.getDescription(), PROFILE_CONFIG_DESCRIPTION);
         Asserts.assertEquals(profileConfig.getProvider(), PROFILE_CONFIG_PROVIDER);
+
+        Configuration gcConfig = findConfigByName(predefinedConfigs, GC_CONFIG_NAME);
+        Asserts.assertNotNull(gcConfig, "Config '" + GC_CONFIG_NAME + "' not found");
+        Asserts.assertEquals(gcConfig.getLabel(), GC_CONFIG_LABEL);
+        Asserts.assertEquals(gcConfig.getDescription(), GC_CONFIG_DESCRIPTION);
+        Asserts.assertEquals(gcConfig.getProvider(), GC_CONFIG_PROVIDER);
+
+        Configuration gcDetailsConfig = findConfigByName(predefinedConfigs, GC_DETAILS_CONFIG_NAME);
+        Asserts.assertNotNull(gcDetailsConfig, "Config '" + GC_DETAILS_CONFIG_NAME + "' not found");
+        Asserts.assertEquals(gcDetailsConfig.getLabel(), GC_DETAILS_CONFIG_LABEL);
+        Asserts.assertEquals(gcDetailsConfig.getDescription(), GC_DETAILS_CONFIG_DESCRIPTION);
+        Asserts.assertEquals(gcDetailsConfig.getProvider(), GC_DETAILS_CONFIG_PROVIDER);
     }
 
     private static Configuration findConfigByName(List<Configuration> configs, String name) {

--- a/test/jdk/jdk/jfr/api/recording/settings/TestGetConfigurations.java
+++ b/test/jdk/jdk/jfr/api/recording/settings/TestGetConfigurations.java
@@ -62,6 +62,7 @@ public class TestGetConfigurations {
     public static void main(String[] args) throws Throwable {
         List<Configuration> predefinedConfigs = Configuration.getConfigurations();
         Asserts.assertNotNull(predefinedConfigs, "List of predefined configs is null");
+        //SapMachine 2023-02-20 Add the two additional configs and checks
         Asserts.assertEquals(predefinedConfigs.size(), 4, "Expected exactly four predefined configurations");
 
         Configuration defaultConfig = findConfigByName(predefinedConfigs, DEFAULT_CONFIG_NAME);
@@ -76,6 +77,7 @@ public class TestGetConfigurations {
         Asserts.assertEquals(profileConfig.getDescription(), PROFILE_CONFIG_DESCRIPTION);
         Asserts.assertEquals(profileConfig.getProvider(), PROFILE_CONFIG_PROVIDER);
 
+        //SapMachine 2023-02-20 Add the two additional configs and checks
         Configuration gcConfig = findConfigByName(predefinedConfigs, GC_CONFIG_NAME);
         Asserts.assertNotNull(gcConfig, "Config '" + GC_CONFIG_NAME + "' not found");
         Asserts.assertEquals(gcConfig.getLabel(), GC_CONFIG_LABEL);


### PR DESCRIPTION
Test failed after two additional JFR configuration files were added with https://github.com/SAP/SapMachine/pull/1336

fixes #1348

