### PR TITLE
SapMachine #1350: Fix build failing with gcc 12.2.1

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2258,7 +2258,7 @@ static int check_matching_lines_from_file(const char* filename, const char* keyw
 
   while (fgets(line, sizeof(line), fp) != NULL) {
     int i = 0;
-    while (keywords_to_match[i] != NULL && line != NULL) {
+    while (keywords_to_match[i] != NULL) {
       if (strstr(line, keywords_to_match[i]) != NULL) {
         fclose(fp);
         return i;


### PR DESCRIPTION
Fixes the build when gcc 12.2 is used, this gcc version complains about unneeded NULL checks. Observed with Alpine 3.17 build container.

fixes #1350

