### PR TITLE
SapMachine (11) #1350: Fix build failing with gcc 12.2.1

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2560,7 +2560,7 @@ static int check_matching_lines_from_file(const char* filename, const char* keyw
 
   while (fgets(line, sizeof(line), fp) != NULL) {
     int i = 0;
-    while (keywords_to_match[i] != NULL && line != NULL) {
+    while (keywords_to_match[i] != NULL) {
       if (strstr(line, keywords_to_match[i]) != NULL) {
         fclose(fp);
         return i;


### PR DESCRIPTION
fixes #1350
