### PR TITLE
SapMachine (20): Backport JDK-8300692 to enable Alpine build

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -433,6 +433,7 @@ else
           $(BUILD_LIBFREETYPE_CFLAGS), \
       EXTRA_HEADER_DIRS := $(BUILD_LIBFREETYPE_HEADER_DIRS), \
       DISABLED_WARNINGS_microsoft := 4267 4244 4996, \
+      DISABLED_WARNINGS_gcc := dangling-pointer stringop-overflow, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
   ))


### PR DESCRIPTION
Backport-of: 8300692: GCC 12 reports some compiler warnings in bundled freetype, a6c2a2ae79be6810dca55b13bfc8a7625f25d48d (cherry picked from commit 5138f5a964471c3ef37716fe46fa158322133b9f)

fixes #1371 
