### PR TITLE
SapMachine #1370: Fix Vitals: long term table does not show one sample per hour

### DIFF
--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -752,14 +752,14 @@ public:
   }
 };
 
-// sampleTables is a combination of three tables: a short term table, a mid term table, a long term table.
+// sampleTables is a combination of two tables: a short term table, a long term table.
 // It takes care to feed new samples into these tables at the appropriate intervals.
 class SampleTables: public CHeapObj<mtInternal> {
 
   // Short term table: cover one hour, one sample per VitalsSampleInterval (default 10 seconds)
   static const int short_term_span_seconds = 3600;
 
-  // Mid term table: cover 14 days, one sample per hour
+  // Long term table: cover 14 days, one sample per hour
   static const int long_term_span_seconds = short_term_span_seconds * 24 * 14;
   static const int long_term_sample_interval = short_term_span_seconds;
 
@@ -826,7 +826,8 @@ public:
     // only after an initial long term table interval has passed
     _count++;
     // Feed long term table
-    if ((_count % long_term_sample_interval) == 0) {
+    // SapMachine 2023-03-21 Consider VitalsSampleInterval for adding sample to the long term table
+    if ((_count % (long_term_sample_interval / VitalsSampleInterval)) == 0) {
       _long_term_table.add_sample(sample);
     }
   }

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -752,7 +752,7 @@ public:
   }
 };
 
-// sampleTables is a combination of two tables: a short term table, a long term table.
+// sampleTables is a combination of two tables: a short term table and a long term table.
 // It takes care to feed new samples into these tables at the appropriate intervals.
 class SampleTables: public CHeapObj<mtInternal> {
 
@@ -826,7 +826,6 @@ public:
     // only after an initial long term table interval has passed
     _count++;
     // Feed long term table
-    // SapMachine 2023-03-21 Consider VitalsSampleInterval for adding sample to the long term table
     if ((_count % (long_term_sample_interval / VitalsSampleInterval)) == 0) {
       _long_term_table.add_sample(sample);
     }


### PR DESCRIPTION
Consider VitalsSampleInterval for adding sample to the long term table

fixes #1370 

