### PR TITLE
SapMachine #1375: Backport the JITRestart JFR event to sapmachine11

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1422,6 +1422,7 @@ void CodeCache::report_codemem_full(int code_blob_type, bool print) {
     event.set_adaptorCount(heap->adapter_count());
     event.set_unallocatedCapacity(heap->unallocated_capacity());
     event.set_fullCount(heap->full_count());
+    event.set_codeCacheMaxCapacity(CodeCache::max_capacity());
     event.commit();
   }
 }

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -458,7 +458,7 @@
     <Field type="ulong" contentType="bytes" name="used" label="Used" />
   </Event>
 
-  <Event name="JitRestart" category="Java Virtual Machine, Compiler" label="JIT Restart" stackTrace="false" startTime="false" thread="true">
+  <Event name="JITRestart" category="Java Virtual Machine, Compiler" label="JIT Restart" stackTrace="false" startTime="false" thread="true">
     <Field type="int" contentType="bytes" name="freedMemory" label="Freed Memory" />
     <Field type="ulong" contentType="bytes" name="codeCacheMaxCapacity" label="Code Cache Maximum Capacity" />
   </Event>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -458,6 +458,11 @@
     <Field type="ulong" contentType="bytes" name="used" label="Used" />
   </Event>
 
+  <Event name="JitRestart" category="Java Virtual Machine, Compiler" label="JIT Restart" stackTrace="false" startTime="false" thread="true">
+    <Field type="int" contentType="bytes" name="freedMemory" label="Freed Memory" />
+    <Field type="ulong" contentType="bytes" name="codeCacheMaxCapacity" label="Code Cache Maximum Capacity" />
+  </Event>
+
   <Event name="Compilation" category="Java Virtual Machine, Compiler" label="Compilation" thread="true">
     <Field type="Method" name="method" label="Java Method" />
     <Field type="uint" name="compileId" label="Compilation Identifier" relation="CompileId" />
@@ -511,6 +516,7 @@
     <Field type="int" name="adaptorCount" label="Adaptors" />
     <Field type="ulong" contentType="bytes" name="unallocatedCapacity" label="Unallocated" />
     <Field type="int" name="fullCount" label="Full Count" />
+    <Field type="ulong" contentType="bytes" name="codeCacheMaxCapacity" label="Code Cache Maximum Capacity" />
   </Event>
 
   <Event name="SafepointBegin" category="Java Virtual Machine, Runtime, Safepoint" label="Safepoint Begin" description="Safepointing begin" thread="true">

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -539,7 +539,7 @@ void NMethodSweeper::sweep_code_cache() {
     CompileBroker::set_should_compile_new_jobs(CompileBroker::run_compilation);
     log.debug("restart compiler");
     log_sweep("restart_compiler");
-    EventJitRestart event;
+    EventJITRestart event;
     event.set_freedMemory(freed_memory);
     event.set_codeCacheMaxCapacity(CodeCache::max_capacity());
     event.commit();

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -513,11 +513,6 @@ void NMethodSweeper::sweep_code_cache() {
     _peak_sweep_time = MAX2(_peak_sweep_time, _total_time_this_sweep);
   }
 
-  EventSweepCodeCache event(UNTIMED);
-  if (event.should_commit()) {
-    post_sweep_event(&event, sweep_start_counter, sweep_end_counter, (s4)_traversals, swept_count, flushed_count, zombified_count);
-  }
-
 #ifdef ASSERT
   if(PrintMethodFlushing) {
     tty->print_cr("### sweeper:      sweep time(" JLONG_FORMAT "): ", sweep_time.value());
@@ -544,6 +539,15 @@ void NMethodSweeper::sweep_code_cache() {
     CompileBroker::set_should_compile_new_jobs(CompileBroker::run_compilation);
     log.debug("restart compiler");
     log_sweep("restart_compiler");
+    EventJitRestart event;
+    event.set_freedMemory(freed_memory);
+    event.set_codeCacheMaxCapacity(CodeCache::max_capacity());
+    event.commit();
+  }
+
+  EventSweepCodeCache event(UNTIMED);
+  if (event.should_commit()) {
+    post_sweep_event(&event, sweep_start_counter, sweep_end_counter, (s4)_traversals, swept_count, flushed_count, zombified_count);
   }
 }
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -464,6 +464,10 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
+    <event name="jdk.JitRestart">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
     <event name="jdk.CodeSweeperConfiguration">
       <setting name="enabled" control="compiler-enabled">true</setting>
       <setting name="period">beginChunk</setting>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -464,7 +464,7 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
-    <event name="jdk.JitRestart">
+    <event name="jdk.JITRestart">
       <setting name="enabled" control="compiler-enabled">true</setting>
     </event>
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -464,6 +464,10 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
+    <event name="jdk.JitRestart">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
     <event name="jdk.CodeSweeperConfiguration">
       <setting name="enabled" control="compiler-enabled">true</setting>
       <setting name="period">beginChunk</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -464,7 +464,7 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
-    <event name="jdk.JitRestart">
+    <event name="jdk.JITRestart">
       <setting name="enabled" control="compiler-enabled">true</setting>
     </event>
 

--- a/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
@@ -66,7 +66,7 @@ public class TestJitRestart {
     private static boolean testWithBlobType(BlobType btype, long availableSize) throws Exception {
         Recording r = new Recording();
         r.enable(EventNames.CodeCacheFull);
-        r.enable(EventNames.JitRestart);
+        r.enable(EventNames.JITRestart);
         r.start();
         long addr = WHITE_BOX.allocateCodeBlob(availableSize, btype.id);
         WHITE_BOX.freeCodeBlob(addr);
@@ -79,7 +79,7 @@ public class TestJitRestart {
 
         for (RecordedEvent evt: events) {
             System.out.println(evt);
-            if (evt.getEventType().getName().equals("jdk.JitRestart")) {
+            if (evt.getEventType().getName().equals("jdk.JITRestart")) {
                 Events.assertField(evt, "codeCacheMaxCapacity").notEqual(0L);
                 Events.assertField(evt, "freedMemory").notEqual(0L);
                 return true;

--- a/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
@@ -1,12 +1,10 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -36,61 +34,58 @@ import sun.hotspot.WhiteBox;
 import sun.hotspot.code.BlobType;
 
 /**
- * @test TestCodeCacheFull
+ * @test TestJitRestart
  * @requires vm.hasJFR
  *
  * @library /test/lib
  * @modules jdk.jfr
  *          jdk.management.jfr
  * @build sun.hotspot.WhiteBox
- * @run main ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *     -XX:+SegmentedCodeCache -XX:-UseLargePages jdk.jfr.event.compiler.TestCodeCacheFull
- * @run main/othervm -Xbootclasspath/a:.
- *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *     -XX:-SegmentedCodeCache jdk.jfr.event.compiler.TestCodeCacheFull
+ *     -XX:+SegmentedCodeCache -XX:-UseLargePages jdk.jfr.event.compiler.TestJitRestart
  */
-public class TestCodeCacheFull {
+public class TestJitRestart {
 
     public static void main(String[] args) throws Exception {
+        boolean foundJitRestart = false;
         for (BlobType btype : BlobType.getAvailable()) {
-            testWithBlobType(btype, calculateAvailableSize(btype));
+            boolean jr = testWithBlobType(btype, calculateAvailableSize(btype));
+            if (jr) {
+                System.out.println("JIT restart event found for BlobType " + btype);
+                foundJitRestart = true;
+            }
         }
+        Asserts.assertTrue(foundJitRestart, "No JIT restart event found");
     }
 
-    private static void testWithBlobType(BlobType btype, long availableSize) throws Exception {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    private static boolean testWithBlobType(BlobType btype, long availableSize) throws Exception {
         Recording r = new Recording();
         r.enable(EventNames.CodeCacheFull);
+        r.enable(EventNames.JitRestart);
         r.start();
-        WhiteBox.getWhiteBox().allocateCodeBlob(availableSize, btype.id);
+        long addr = WHITE_BOX.allocateCodeBlob(availableSize, btype.id);
+        WHITE_BOX.freeCodeBlob(addr);
+        WHITE_BOX.forceNMethodSweep();
         r.stop();
 
         List<RecordedEvent> events = Events.fromRecording(r);
+        System.out.println("# events:" + events.size());
         Events.hasEvents(events);
-        RecordedEvent event = events.get(0);
 
-        String codeBlobType = Events.assertField(event, "codeBlobType").notNull().getValue();
-        BlobType blobType = blobTypeFromName(codeBlobType);
-        Asserts.assertTrue(blobType.allowTypeWhenOverflow(blobType), "Unexpected overflow BlobType " + blobType.id);
-        Events.assertField(event, "entryCount").atLeast(0);
-        Events.assertField(event, "methodCount").atLeast(0);
-        Events.assertEventThread(event);
-        Events.assertField(event, "fullCount").atLeast(0);
-        Events.assertField(event, "startAddress").notEqual(0L);
-        Events.assertField(event, "commitedTopAddress").notEqual(0L);
-        Events.assertField(event, "reservedTopAddress").notEqual(0L);
-        Events.assertField(event, "codeCacheMaxCapacity").notEqual(0L);
-    }
-
-    private static BlobType blobTypeFromName(String codeBlobTypeName) throws Exception {
-        for (BlobType t : BlobType.getAvailable()) {
-            if (t.beanName.equals(codeBlobTypeName)) {
-                return t;
+        for (RecordedEvent evt: events) {
+            System.out.println(evt);
+            if (evt.getEventType().getName().equals("jdk.JitRestart")) {
+                Events.assertField(evt, "codeCacheMaxCapacity").notEqual(0L);
+                Events.assertField(evt, "freedMemory").notEqual(0L);
+                return true;
             }
         }
-        throw new Exception("Unexpected event " + codeBlobTypeName);
+        return false;
     }
 
     // Compute the available size for this BlobType by taking into account

--- a/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
@@ -24,6 +24,7 @@
 package jdk.jfr.event.compiler;
 
 import java.util.List;
+import java.util.Comparator;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
@@ -50,15 +51,15 @@ import sun.hotspot.code.BlobType;
 public class TestJitRestart {
 
     public static void main(String[] args) throws Exception {
-        boolean foundJitRestart = false;
+        boolean checkJitRestartCompilation = false;
         for (BlobType btype : BlobType.getAvailable()) {
             boolean jr = testWithBlobType(btype, calculateAvailableSize(btype));
             if (jr) {
-                System.out.println("JIT restart event found for BlobType " + btype);
-                foundJitRestart = true;
+                System.out.println("JIT restart event / Compilation event check for BlobType " + btype + " was successful");
+                checkJitRestartCompilation = true;
             }
         }
-        Asserts.assertTrue(foundJitRestart, "No JIT restart event found");
+        Asserts.assertTrue(checkJitRestartCompilation, "No JIT restart event found and unexpected compilation seen");
     }
 
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
@@ -66,6 +67,7 @@ public class TestJitRestart {
     private static boolean testWithBlobType(BlobType btype, long availableSize) throws Exception {
         Recording r = new Recording();
         r.enable(EventNames.CodeCacheFull);
+        r.enable(EventNames.Compilation);
         r.enable(EventNames.JITRestart);
         r.start();
         long addr = WHITE_BOX.allocateCodeBlob(availableSize, btype.id);
@@ -74,18 +76,34 @@ public class TestJitRestart {
         r.stop();
 
         List<RecordedEvent> events = Events.fromRecording(r);
+        System.out.println("---------------------------------------------");
         System.out.println("# events:" + events.size());
         Events.hasEvents(events);
+        events.sort(Comparator.comparing(RecordedEvent::getStartTime));
 
+        boolean compilationCanHappen = true;
         for (RecordedEvent evt: events) {
             System.out.println(evt);
+            if (evt.getEventType().getName().equals("jdk.CodeCacheFull")) {
+                System.out.println("--> jdk.CodeCacheFull found");
+                compilationCanHappen = false;
+            }
+            if (evt.getEventType().getName().equals("jdk.Compilation") && !compilationCanHappen) {
+                return false;
+            }
             if (evt.getEventType().getName().equals("jdk.JITRestart")) {
+                System.out.println("--> jdk.JitRestart found");
                 Events.assertField(evt, "codeCacheMaxCapacity").notEqual(0L);
                 Events.assertField(evt, "freedMemory").notEqual(0L);
+                System.out.println("JIT restart event found for BlobType " + btype);
                 return true;
             }
         }
-        return false;
+        System.out.println("---------------------------------------------");
+
+        // in some seldom cases we do not see the JitRestart event; but then
+        // do not fail (as long as no compilation happened before)
+        return true;
     }
 
     // Compute the available size for this BlobType by taking into account

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -146,6 +146,7 @@ public class EventNames {
     public final static String CodeCacheFull = PREFIX + "CodeCacheFull";
     public final static String ObjectAllocationInNewTLAB = PREFIX + "ObjectAllocationInNewTLAB";
     public final static String ObjectAllocationOutsideTLAB = PREFIX + "ObjectAllocationOutsideTLAB";
+    public final static String JitRestart = PREFIX + "JitRestart";
 
     // OS
     public final static String OSInformation = PREFIX + "OSInformation";

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -146,7 +146,7 @@ public class EventNames {
     public final static String CodeCacheFull = PREFIX + "CodeCacheFull";
     public final static String ObjectAllocationInNewTLAB = PREFIX + "ObjectAllocationInNewTLAB";
     public final static String ObjectAllocationOutsideTLAB = PREFIX + "ObjectAllocationOutsideTLAB";
-    public final static String JitRestart = PREFIX + "JitRestart";
+    public final static String JITRestart = PREFIX + "JITRestart";
 
     // OS
     public final static String OSInformation = PREFIX + "OSInformation";


### PR DESCRIPTION
WhiteBox usage had to be adjusted in the test, when backporting from 17 to 11. Backport is not clean because of some diff in the strides (e.g. src/hotspot/share/jfr/metadata/metadata.xml and test/lib/jdk/test/lib/jfr/EventNames.java ) but fits in mostly well in the codebase of 11.

fixes #1375
