### PR TITLE
Added missing unregisters for NMT

### DIFF
--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -65,6 +65,7 @@ public:
   // Override as JavaThread::post_run() calls JavaThread::exit which
   // expects a valid thread object oop.
   virtual void post_run() {
+    unregister_thread_stack_with_NMT();
     Threads::remove(this, false);
     this->smr_delete();
   }
@@ -114,6 +115,7 @@ public:
   // Override as JavaThread::post_run() calls JavaThread::exit which
   // expects a valid thread object oop. And we need to call signal.
   void post_run() {
+    unregister_thread_stack_with_NMT();
     Threads::remove(this, false);
     _post->signal();
     this->smr_delete();


### PR DESCRIPTION
Unregister the thread stack in the gtests too, so we don't have a leak.

