### PR TITLE
Vitals: ClassLoaderDataGraph by SamplerThread is unsynchronized

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -178,6 +178,11 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool has_class_mirror_ho
   NOT_PRODUCT(_dependency_count = 0); // number of class loader dependencies
 
   JFR_ONLY(INIT_ID(this);)
+
+  // SapMachine 2023-07-04 : vitals
+  if (EnableVitals) {
+      sapmachine_vitals::counters::inc_cld_count(has_class_mirror_holder);
+  }
 }
 
 ClassLoaderData::ChunkedHandleList::~ChunkedHandleList() {

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -505,6 +505,10 @@ bool ClassLoaderDataGraph::do_unloading() {
     } else {
       // Found dead CLD.
       loaders_removed++;
+      // SapMachine 2023-07-04 : vitals
+      if (EnableVitals) {
+        sapmachine_vitals::counters::dec_cld_count(data->has_class_mirror_holder());
+      }
       seen_dead_loader = true;
       data->unload();
 

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -71,6 +71,8 @@ namespace sapmachine_vitals {
   const Thread* samplerthread();
 
   namespace counters {
+    void inc_cld_count(bool is_anon_cld);
+    void dec_cld_count(bool is_anon_cld);
     void inc_classes_loaded(size_t count);
     void inc_classes_unloaded(size_t count);
     void inc_threads_created(size_t count);


### PR DESCRIPTION
Avoid the unsynchronized ClassLoaderDataGraph walk in `sample_jvm_values`.
Instead, update counters whenever a CLD is added/removed.

Testing:

- vmTestbase/vm/mlvm/hiddenloader/stress/byteMutation/Test.java (the reproducer)
- GHA
- jtreg:test/hotspot/jtreg/runtime/Vitals
- gtest:vitals/server

fixes #1438

