### PR TITLE
Vitals: ClassLoaderDataGraph by SamplerThread is unsynchronized

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -183,6 +183,11 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool is_anonymous) :
   NOT_PRODUCT(_dependency_count = 0); // number of class loader dependencies
 
   JFR_ONLY(INIT_ID(this);)
+
+  // SapMachine 2023-07-04 : vitals
+  if (EnableVitals) {
+      sapmachine_vitals::counters::inc_cld_count(has_class_mirror_holder);
+  }
 }
 
 ClassLoaderData::ChunkedHandleList::~ChunkedHandleList() {
@@ -1400,6 +1405,10 @@ bool ClassLoaderDataGraph::do_unloading(bool clean_previous_versions) {
     }
     seen_dead_loader = true;
     loaders_removed++;
+    // SapMachine 2023-07-04 : vitals
+    if (EnableVitals) {
+      sapmachine_vitals::counters::dec_cld_count(data->has_class_mirror_holder());
+    }
     ClassLoaderData* dead = data;
     dead->unload();
     data = data->next();

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -186,7 +186,7 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool is_anonymous) :
 
   // SapMachine 2023-07-04 : vitals
   if (EnableVitals) {
-      sapmachine_vitals::counters::inc_cld_count(has_class_mirror_holder);
+      sapmachine_vitals::counters::inc_cld_count(is_anonymous);
   }
 }
 
@@ -1407,7 +1407,7 @@ bool ClassLoaderDataGraph::do_unloading(bool clean_previous_versions) {
     loaders_removed++;
     // SapMachine 2023-07-04 : vitals
     if (EnableVitals) {
-      sapmachine_vitals::counters::dec_cld_count(data->has_class_mirror_holder());
+      sapmachine_vitals::counters::dec_cld_count(data->is_anonymous());
     }
     ClassLoaderData* dead = data;
     dead->unload();

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -63,9 +63,25 @@ static Lock g_vitals_lock("VitalsLock");
 
 namespace counters {
 
+static volatile size_t g_number_of_clds = 0;
+static volatile size_t g_number_of_anon_clds = 0;
 static volatile size_t g_classes_loaded = 0;
 static volatile size_t g_classes_unloaded = 0;
 static volatile size_t g_threads_created = 0;
+
+void inc_cld_count(bool is_anon_cld) {
+  Atomic::inc(&g_number_of_clds);
+  if (is_anon_cld) {
+    Atomic::inc(&g_number_of_anon_clds);
+  }
+}
+
+void dec_cld_count(bool is_anon_cld) {
+  Atomic::dec(&g_number_of_clds);
+  if (is_anon_cld) {
+    Atomic::dec(&g_number_of_anon_clds);
+  }
+}
 
 void inc_classes_loaded(size_t count) {
   Atomic::add(count, &g_classes_loaded);
@@ -1102,22 +1118,6 @@ static void set_value_in_sample(const Column* col, Sample* sample, T t) {
   }
 }
 
-// Count CLDs
-// Not in 11
-//class CLDCounterClosure: public CLDClosure {
-//public:
-//  int _cnt;
-//  int _anon_cnt;
-//  CLDCounterClosure() : _cnt(0), _anon_cnt(0) {}
-//  void do_cld(ClassLoaderData* cld) {
-//    _cnt ++;
-//    if (cld->has_class_mirror_holder()) {
-//      _anon_cnt ++;
-//    }
-//  }
-//};
-
-
 struct nmt_values_t {
   // How much memory, in total, was committed via mmap
   value_t mapped_total;
@@ -1233,16 +1233,8 @@ void sample_jvm_values(Sample* sample, bool avoid_locking) {
   }
 
   // CLDG
-// (not in 11)
-//  if (!avoid_locking) {
-//    CLDCounterClosure cl;
-//    {
-//      MutexLocker lck(ClassLoaderDataGraph_lock);
-//      ClassLoaderDataGraph::cld_do(&cl);
-//    }
-//    set_value_in_sample(g_col_number_of_clds, sample, cl._cnt);
-//    set_value_in_sample(g_col_number_of_anon_clds, sample, cl._anon_cnt);
-//  }
+  set_value_in_sample(g_col_number_of_clds, sample, counters::g_number_of_clds);
+  set_value_in_sample(g_col_number_of_anon_clds, sample, counters::g_number_of_anon_clds);
 
   // Classes
   set_value_in_sample(g_col_number_of_classes, sample,

--- a/src/hotspot/share/vitals/vitals.hpp
+++ b/src/hotspot/share/vitals/vitals.hpp
@@ -73,6 +73,8 @@ namespace sapmachine_vitals {
   const Thread* samplerthread();
 
   namespace counters {
+    void inc_cld_count(bool is_anon_cld);
+    void dec_cld_count(bool is_anon_cld);
     void inc_classes_loaded(size_t count);
     void inc_classes_unloaded(size_t count);
     void inc_threads_created(size_t count);


### PR DESCRIPTION
This is a backport of https://github.com/SAP/SapMachine/commit/a04a40bdb7c555775674f4873eb62838b15a538d with conflicts.

In sapmachine11 the CLDs were not even counted. So no bug there. With the approach from #1438 we can do it without risk.

Conflicts

- Code related to CLD graph walk is commented out in sapmachine11. The pr just deletes it.
- CLDs have a property `is_anonymous` in sapmachine11. It corresponds to `has_class_mirror_holder` in higher versions (see commit ["fixups"](https://github.com/SAP/SapMachine/pull/1443/commits/66da6288c09bac01c821dba76ee141f383c7290d))

Testing:
jtreg:test/hotspot/jtreg/runtime/Vitals
gtest:vitals/server

fixes #1438 

