### PR TITLE
SapMachine (17) #1482: Enable updated GHA workflow from OpenJDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,9 @@ jobs:
 
   select:
     name: 'Select platforms'
-    # pr-jdk-17.0.9+3: runs-on: ubuntu-22.04
     # SapMachine 2022-06-23: On 'pull_request' we only want to run GHA if the PR comes from a remote repo. Otherwise we have the run on 'push' already as a check.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x86: ${{ steps.include.outputs.linux-x86 }}
@@ -332,8 +331,7 @@ jobs:
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:
     name: 'Remove bundle artifacts'
-    # pr-jdk-17.0.9+3 ; runs-on: ubuntu-22.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # SapMachine 2022-06-23: On 'pull_request' we only want to run GHA if the PR comes from a remote repo. Otherwise we have the run on 'push' already as a check.
     if: ${{ github.event_name != 'pull_request' || github.repository != 'SAP/SapMachine' }}
     needs:

--- a/src/hotspot/os/linux/malloctrace/assertHandling.cpp
+++ b/src/hotspot/os/linux/malloctrace/assertHandling.cpp
@@ -29,7 +29,7 @@
 #include "malloctrace/mallocTrace.hpp"
 #include "runtime/atomic.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -55,4 +55,4 @@ bool prepare_assert() {
 
 } // namespace sap
 
-#endif // #ifdef __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/assertHandling.hpp
+++ b/src/hotspot/os/linux/malloctrace/assertHandling.hpp
@@ -26,9 +26,10 @@
 #ifndef OS_LINUX_MALLOCTRACE_ASSERTHANDLING_HPP
 #define OS_LINUX_MALLOCTRACE_ASSERTHANDLING_HPP
 
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 

--- a/src/hotspot/os/linux/malloctrace/locker.cpp
+++ b/src/hotspot/os/linux/malloctrace/locker.cpp
@@ -25,9 +25,10 @@
 
 #include "precompiled.hpp"
 #include "malloctrace/locker.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include <pthread.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -36,4 +37,4 @@ pthread_mutex_t Locker::_pthread_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 } // namespace sap
 
-#endif // #ifdef __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/locker.hpp
+++ b/src/hotspot/os/linux/malloctrace/locker.hpp
@@ -27,10 +27,11 @@
 #define OS_LINUX_MALLOCTRACE_LOCKER_HPP
 
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include <pthread.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -73,6 +74,6 @@ public:
 
 } // namespace sap
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_LOCKER_HPP

--- a/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
@@ -37,7 +37,7 @@
 
 #include <malloc.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -375,4 +375,4 @@ void MallocTracer::print_on_error(outputStream* st) {
 
 } // namespace sap
 
-#endif // GLIBC
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/mallocTrace.hpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTrace.hpp
@@ -29,7 +29,17 @@
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+// MallocTracer needs glibc malloc hooks. Unfortunately, glibc removed them with 2.32.
+// If we built against a newer glibc, there is no point in even trying to resolve
+// them dynamically, since the binary will not run with older glibc's anyway. Therefore
+// we can just disable them at built time.
+#if defined(__GLIBC__)
+#if (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 31)
+#define HAVE_GLIBC_MALLOC_HOOKS
+#endif
+#endif
+
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -47,6 +57,6 @@ public:
 
 }
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_MALLOCTRACE_HPP

--- a/src/hotspot/os/linux/malloctrace/mallocTraceDCmd.cpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTraceDCmd.cpp
@@ -32,7 +32,7 @@
 
 namespace sap {
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 // By default, lets use nmt-like capturing. I see (very rarely) crashes with backtrace(3)
 // on x86. backtrace(3) gives us better callstack but runs a (small) risk of crashing, especially
@@ -82,9 +82,13 @@ void MallocTraceDCmd::execute(DCmdSource source, TRAPS) {
 }
 #else
 void MallocTraceDCmd::execute(DCmdSource source, TRAPS) {
+#ifdef __GLIBC__
+  _output->print_cr("Glibc too new. Needs glibc version <= 2.31.");
+#else
   _output->print_cr("Not a glibc system.");
+#endif
 }
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 static const char* const usage_for_option =
   "Valid Values:\n"

--- a/src/hotspot/os/linux/malloctrace/siteTable.cpp
+++ b/src/hotspot/os/linux/malloctrace/siteTable.cpp
@@ -27,6 +27,7 @@
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "malloctrace/siteTable.hpp"
 #include "runtime/frame.inline.hpp"
 #include "utilities/debug.hpp"
@@ -35,7 +36,7 @@
 
 #include <malloc.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -235,4 +236,4 @@ void SiteTable::print_table(outputStream* st, bool all) const {
 
 } // namespace sap
 
-#endif // GLIBC
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/siteTable.hpp
+++ b/src/hotspot/os/linux/malloctrace/siteTable.hpp
@@ -27,9 +27,10 @@
 #define OS_LINUX_MALLOCTRACE_SITETABLE_HPP
 
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -207,6 +208,6 @@ public:
 
 } // namespace sap
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_SITETABLE_HPP

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4791,14 +4791,18 @@ jint os::init_2(void) {
     }
   }
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
   // SapMachine 2021-09-01: malloc-trace
   if (EnableMallocTrace) {
     sap::MallocTracer::enable();
   }
 #else
   if (!FLAG_IS_DEFAULT(EnableMallocTrace)) {
+#ifdef __GLIBC__
+    warning("EnableMallocTrace ignored (Glibc too new. Needs glibc version <= 2.31.)");
+#else
     warning("Not a glibc system. EnableMallocTrace ignored.");
+#endif
   }
 #endif // __GLIBC__
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -517,12 +517,12 @@ void before_exit(JavaThread* thread, bool halt) {
   if (DumpPerfMapAtExit) {
     CodeCache::write_perf_map();
   }
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
   // SapMachine 2021-09-01: malloc-trace
   if (PrintMallocTraceAtExit) {
     sap::MallocTracer::print(tty, true);
   }
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 #endif
 
   if (JvmtiExport::should_post_thread_life()) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1270,7 +1270,7 @@ void VMError::report(outputStream* st, bool _verbose) {
      }
 
   // SapMachine 2021-09-01: malloc-trace
-#if defined(LINUX) && defined(__GLIBC__)
+#if defined(LINUX) && defined(HAVE_GLIBC_MALLOC_HOOKS)
   STEP("printing Malloc Trace info")
 
     if (_verbose) {
@@ -1470,7 +1470,7 @@ void VMError::print_vm_info(outputStream* st) {
   st->print_cr("vm_info: %s", VM_Version::internal_vm_info_string());
   st->cr();
 
-#if defined(LINUX) && defined(__GLIBC__)
+#if defined(LINUX) && defined(HAVE_GLIBC_MALLOC_HOOKS)
   // SapMachine 2021-09-01: malloc-trace
   st->print_cr("sapmachine malloc trace");
   sap::MallocTracer::print_on_error(st);

--- a/test/hotspot/gtest/malloctrace/test_site_table.cpp
+++ b/test/hotspot/gtest/malloctrace/test_site_table.cpp
@@ -27,6 +27,7 @@
 #ifdef LINUX
 
 #include "jvm_io.h"
+#include "malloctrace/mallocTrace.hpp"
 #include "malloctrace/siteTable.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
@@ -34,7 +35,7 @@
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 using sap::SiteTable;
 using sap::Stack;
@@ -189,6 +190,6 @@ TEST_VM(MallocTrace, site_table_random) {
   destroy_site_table(table);
 }
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // LINUX

--- a/test/hotspot/gtest/malloctrace/test_tracer.cpp
+++ b/test/hotspot/gtest/malloctrace/test_tracer.cpp
@@ -36,7 +36,7 @@
 #include "unittest.hpp"
 #include <malloc.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 using sap::MallocTracer;
 
@@ -171,6 +171,6 @@ TEST_VM(MallocTrace, tracer_mixed_all) {
 #endif
 }
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // LINUX

--- a/test/hotspot/jtreg/ProblemList-SapMachine.txt
+++ b/test/hotspot/jtreg/ProblemList-SapMachine.txt
@@ -154,6 +154,14 @@ runtime/CompressedOops/UseCompressedOops.java                                   
 runtime/logging/loadLibraryTest/LoadLibraryTest.java                                 generic-all
 
 ###############################################################################
+# New failures detected after GA of 17.0.5 (e.g. seen only in jdk11u-dev after branching 17.0.5 to jdk17u)
+
+# SapMachine 2022-12-30 test has timeouts, vector API is rather slow on ppc
+#
+# maybe test changes of 8276151 would improve test speed?
+compiler/vectorapi/VectorCastShape64Test.java                                        generic-ppc64,linux-ppc64le
+
+###############################################################################
 # Tests known to be failing in SapMachine due to SapMachine specific setup.
 
 # SapMachine 2018-10-05

--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -39,8 +39,8 @@ import java.util.Map;
 @Artifact(organization = "gov.nist.math", name = "scimark", revision = "2.0", extension = "zip")
 public class Scimark {
     public static void main(String... args) throws Exception {
+        // SapMachine 2018-07-06: Prefer Scimark classpath from system property.
         String sciMark2Cp = System.getProperty("SCIMARK_2_CP");
-
         if (sciMark2Cp == null) {
             Map<String, Path> artifacts;
             try {
@@ -51,11 +51,11 @@ public class Scimark {
             }
             sciMark2Cp = artifacts.get("gov.nist.math.scimark-2.0").toString();
         }
+
         OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(
             "-cp", sciMark2Cp,
             "jnt.scimark2.commandline", "-large")
             .start());
-        System.out.println(output.getOutput());
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
@@ -59,6 +59,7 @@ public class MallocTraceTest {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                     option, "-XX:+PrintMallocTraceAtExit", "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.reportDiagnosticSummary();
             output.shouldHaveExitValue(0);
 
             // Ignore output for Alpine

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
@@ -21,7 +21,7 @@ public class MallocTraceTestHelpers {
     }
 
     public static boolean GlibcSupportsMallocHooks() throws Throwable {
-        return GlibVersion() < 0x222; // 0x0223 aka 2.34
+        return GlibVersion() < 0x220; // 2.32
     }
 
 }


### PR DESCRIPTION
Some updates to enable latest GHA environment with SapMachine 17.

I also added two minor changes to comments and to a test list.

fixes #1482
