### PR TITLE
SapMachine(11): Compile malloc tracer only for glibc versions < 2.32, and fix tests

### DIFF
--- a/src/hotspot/os/linux/malloctrace/assertHandling.cpp
+++ b/src/hotspot/os/linux/malloctrace/assertHandling.cpp
@@ -29,7 +29,7 @@
 #include "malloctrace/mallocTrace.hpp"
 #include "runtime/atomic.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -55,4 +55,4 @@ bool prepare_assert() {
 
 } // namespace sap
 
-#endif // #ifdef __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/assertHandling.hpp
+++ b/src/hotspot/os/linux/malloctrace/assertHandling.hpp
@@ -26,9 +26,10 @@
 #ifndef OS_LINUX_MALLOCTRACE_ASSERTHANDLING_HPP
 #define OS_LINUX_MALLOCTRACE_ASSERTHANDLING_HPP
 
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 

--- a/src/hotspot/os/linux/malloctrace/locker.cpp
+++ b/src/hotspot/os/linux/malloctrace/locker.cpp
@@ -25,9 +25,10 @@
 
 #include "precompiled.hpp"
 #include "malloctrace/locker.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include <pthread.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -36,4 +37,4 @@ pthread_mutex_t Locker::_pthread_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 } // namespace sap
 
-#endif // #ifdef __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/locker.hpp
+++ b/src/hotspot/os/linux/malloctrace/locker.hpp
@@ -27,10 +27,11 @@
 #define OS_LINUX_MALLOCTRACE_LOCKER_HPP
 
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include <pthread.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -73,6 +74,6 @@ public:
 
 } // namespace sap
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_LOCKER_HPP

--- a/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
@@ -37,7 +37,7 @@
 
 #include <malloc.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 namespace sap {
 
@@ -375,4 +375,4 @@ void MallocTracer::print_on_error(outputStream* st) {
 
 } // namespace sap
 
-#endif // GLIBC
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/mallocTrace.hpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTrace.hpp
@@ -29,7 +29,17 @@
 #include "memory/allocation.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+// MallocTracer needs glibc malloc hooks. Unfortunately, glibc removed them with 2.32.
+// If we built against a newer glibc, there is no point in even trying to resolve
+// them dynamically, since the binary will not run with older glibc's anyway. Therefore
+// we can just disable them at built time.
+#if defined(__GLIBC__)
+#if (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 31)
+#define HAVE_GLIBC_MALLOC_HOOKS
+#endif
+#endif
+
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -47,6 +57,6 @@ public:
 
 }
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_MALLOCTRACE_HPP

--- a/src/hotspot/os/linux/malloctrace/mallocTraceDCmd.cpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTraceDCmd.cpp
@@ -33,7 +33,7 @@
 
 namespace sap {
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 // By default, lets use nmt-like capturing. I see (very rarely) crashes with backtrace(3)
 // on x86. backtrace(3) gives us better callstack but runs a (small) risk of crashing, especially
@@ -83,9 +83,13 @@ void MallocTraceDCmd::execute(DCmdSource source, TRAPS) {
 }
 #else
 void MallocTraceDCmd::execute(DCmdSource source, TRAPS) {
+#ifdef __GLIBC__
+  _output->print_cr("Glibc too new. Needs glibc version <= 2.31.");
+#else
   _output->print_cr("Not a glibc system.");
+#endif
 }
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 static const char* const usage_for_option =
   "Valid Values:\n"

--- a/src/hotspot/os/linux/malloctrace/siteTable.cpp
+++ b/src/hotspot/os/linux/malloctrace/siteTable.cpp
@@ -27,6 +27,7 @@
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "malloctrace/siteTable.hpp"
 #include "runtime/frame.inline.hpp"
 #include "utilities/debug.hpp"
@@ -35,7 +36,7 @@
 
 #include <malloc.h>
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 // Pulled from JDK17 (see os::print_function_and_library_name()).
 // Note: Abridged version, does not handle function descriptors, which only concerns ppc64.
@@ -288,4 +289,4 @@ void SiteTable::print_table(outputStream* st, bool all) const {
 
 } // namespace sap
 
-#endif // GLIBC
+#endif // HAVE_GLIBC_MALLOC_HOOKS

--- a/src/hotspot/os/linux/malloctrace/siteTable.hpp
+++ b/src/hotspot/os/linux/malloctrace/siteTable.hpp
@@ -27,9 +27,10 @@
 #define OS_LINUX_MALLOCTRACE_SITETABLE_HPP
 
 #include "malloctrace/assertHandling.hpp"
+#include "malloctrace/mallocTrace.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 class outputStream;
 
@@ -207,6 +208,6 @@ public:
 
 } // namespace sap
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // OS_LINUX_MALLOCTRACE_SITETABLE_HPP

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5802,14 +5802,18 @@ jint os::init_2(void) {
     set_coredump_filter(FILE_BACKED_SHARED_BIT);
   }
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
   // SapMachine 2021-09-01: malloc-trace
   if (EnableMallocTrace) {
     sap::MallocTracer::enable();
   }
 #else
   if (!FLAG_IS_DEFAULT(EnableMallocTrace)) {
+#ifdef __GLIBC__
+    warning("EnableMallocTrace ignored (Glibc too new. Needs glibc version <= 2.31.)");
+#else
     warning("Not a glibc system. EnableMallocTrace ignored.");
+#endif
   }
 #endif // __GLIBC__
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -554,12 +554,12 @@ void before_exit(JavaThread* thread) {
   }
 
 #ifdef LINUX
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
   // SapMachine 2021-09-01: malloc-trace
   if (PrintMallocTraceAtExit) {
     sap::MallocTracer::print(tty, true);
   }
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 #endif
 
   if (JvmtiExport::should_post_thread_life()) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1066,7 +1066,7 @@ void VMError::report(outputStream* st, bool _verbose) {
      }
 
   // SapMachine 2021-09-01: malloc-trace
-#if defined(LINUX) && defined(__GLIBC__)
+#if defined(LINUX) && defined(HAVE_GLIBC_MALLOC_HOOKS)
   STEP("printing Malloc Trace info")
 
     if (_verbose) {
@@ -1253,7 +1253,7 @@ void VMError::print_vm_info(outputStream* st) {
   st->print_cr("vm_info: %s", Abstract_VM_Version::internal_vm_info_string());
   st->cr();
 
-#if defined(LINUX) && defined(__GLIBC__)
+#if defined(LINUX) && defined(HAVE_GLIBC_MALLOC_HOOKS)
   // SapMachine 2021-09-01: malloc-trace
   st->print_cr("sapmachine malloc trace");
   sap::MallocTracer::print_on_error(st);

--- a/test/hotspot/gtest/malloctrace/test_site_table.cpp
+++ b/test/hotspot/gtest/malloctrace/test_site_table.cpp
@@ -27,6 +27,7 @@
 #ifdef LINUX
 
 #include "jvm.h"
+#include "malloctrace/mallocTrace.hpp"
 #include "malloctrace/siteTable.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
@@ -34,7 +35,7 @@
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 
-#ifdef __GLIBC__
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
 
 using sap::SiteTable;
 
@@ -188,6 +189,6 @@ TEST_VM(MallocTrace, site_table_random) {
   destroy_site_table(table);
 }
 
-#endif // __GLIBC__
+#endif // HAVE_GLIBC_MALLOC_HOOKS
 
 #endif // LINUX

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTest.java
@@ -59,6 +59,7 @@ public class MallocTraceTest {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                     option, "-XX:+PrintMallocTraceAtExit", "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.reportDiagnosticSummary();
             output.shouldHaveExitValue(0);
 
             // Ignore output for Alpine

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocTraceTestHelpers.java
@@ -21,7 +21,7 @@ public class MallocTraceTestHelpers {
     }
 
     public static boolean GlibcSupportsMallocHooks() throws Throwable {
-        return GlibVersion() < 0x222; // 0x0223 aka 2.34
+        return GlibVersion() < 0x220; // 2.32
     }
 
 }


### PR DESCRIPTION
We should cherry-pick the change to compile malloc tracer only for glibc versions < 2.32 to SapMachine 11 as well to cater for the upcoming bump to Ubuntu 22 in GHA. I made a few minor modifications to the changelist from SapMachine 17.

fixes #1482
