### PR TITLE
SapMachine #1512: ParallelGC: parallel scanning of large object arrays in old gen during young gc should be disabled by default

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -695,7 +695,7 @@
           constraint(GCCardSizeInBytesConstraintFunc,AtParse)               \
                                                                             \
   /* SapMachine 2023-09-25 */                                               \
-  product(bool, UseParallelLargeArrayScanning, false,                       \
+  product(bool, UseParallelLargeArrayScanning, false, EXPERIMENTAL,         \
           "Parallelize scanning of large object arrays in old gen "         \
           "when scanning roots for parallel young gc")
   // end of GC_FLAGS

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -692,7 +692,12 @@
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \
           range(128, NOT_LP64(512) LP64_ONLY(1024))                         \
-          constraint(GCCardSizeInBytesConstraintFunc,AtParse)
+          constraint(GCCardSizeInBytesConstraintFunc,AtParse)               \
+                                                                            \
+  /* SapMachine 2023-09-25 */                                               \
+  product(bool, UseParallelLargeArrayScanning, false,                       \
+          "Parallelize scanning of large object arrays in old gen "         \
+          "when scanning roots for parallel young gc")
   // end of GC_FLAGS
 
 DECLARE_FLAGS(GC_FLAGS)


### PR DESCRIPTION
Introduce new vm option `UseParallelLargeArrayScanning` which controls parallel scanning of large object arrays in the old generation during young collections.

`UseParallelLargeArrayScanning` is disabled by default.

fixes #1512 

