### PR TITLE
SapMachine(21) #1512: ParallelGC: parallel scanning of large object arrays in old gen during young gc should be disabled by default

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -690,7 +690,12 @@
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \
           range(128, NOT_LP64(512) LP64_ONLY(1024))                         \
-          constraint(GCCardSizeInBytesConstraintFunc,AtParse)
+          constraint(GCCardSizeInBytesConstraintFunc,AtParse)               \
+                                                                            \
+  /* SapMachine 2023-09-25 */                                               \
+  product(bool, UseParallelLargeArrayScanning, false, EXPERIMENTAL,         \
+          "Parallelize scanning of large object arrays in old gen "         \
+          "when scanning roots for parallel young gc")
   // end of GC_FLAGS
 
 DECLARE_FLAGS(GC_FLAGS)


### PR DESCRIPTION
Backport to SapMachine21.

fixes #1512 

