### PR TITLE
SapMachine (11) #1512: ParallelGC: parallel scanning of large object arrays in old gen during young gc should be disabled by default

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -191,7 +191,8 @@ void PSCardTable::scan_objects_in_range(PSPromotionManager* pm,
   while (obj_addr < end) {
     oop obj = cast_to_oop(obj_addr);
     assert(oopDesc::is_oop(obj), "inv");
-    assert(!obj->is_objArray() || obj->size() < large_obj_arr_min_words(), "inv");
+    assert(!UseParallelLargeArrayScanning || !obj->is_objArray() ||
+           obj->size() < large_obj_arr_min_words(), "inv");
     prefetch_write(obj_addr);
     pm->push_contents(obj);
     obj_addr += obj->size();
@@ -294,7 +295,9 @@ void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
       int obj_sz = cast_to_oop(obj_addr)->size();
       HeapWord* obj_end_addr = obj_addr + obj_sz;
       // large arrays starting in this stripe are scanned here
-      if (obj_sz >= large_obj_arr_min_words() && cast_to_oop(obj_addr)->is_objArray() &&
+      if (UseParallelLargeArrayScanning &&
+          obj_sz >= large_obj_arr_min_words() &&
+          cast_to_oop(obj_addr)->is_objArray() &&
           obj_addr >= cur_stripe_addr) {
         // the last condition is not redundant as we can reach here if an obj starts at space_top
         obj_end_addr = cur_stripe_end_addr;
@@ -369,6 +372,8 @@ void PSCardTable::scavenge_large_array_stripe(ObjectStartArray* start_array,
                                               HeapWord* stripe_addr,
                                               HeapWord* stripe_end_addr,
                                               HeapWord* space_top) {
+  if (!UseParallelLargeArrayScanning) return;
+
   const size_t stripe_size_in_words = num_cards_in_stripe * card_size_in_words;
 
   HeapWord* large_arr_addr = start_array->object_start(stripe_addr);

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -850,6 +850,11 @@
   product(uintx, GCDrainStackTargetSize, 64,                                \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, max_juint)
+          range(0, max_juint)                                               \
+                                                                            \
+  /* SapMachine 2023-09-25 */                                               \
+  experimental(bool, UseParallelLargeArrayScanning, false,                  \
+          "Parallelize scanning of large object arrays in old gen "         \
+          "when scanning roots for parallel young gc")
 
 #endif // SHARE_GC_SHARED_GC_GLOBALS_HPP


### PR DESCRIPTION
Backport to SapMachine11.

fixes #1512
