### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We want to stress that this is clearly a "*friendly fork*". SAP is committed to 
 Check out the [Download](https://sap.github.io/SapMachine/#download) section on [https://sapmachine.io](https://sapmachine.io).
 
 ## Documentation
-Check out our [FAQ's](https://github.com/SAP/SapMachine/wiki/Frequently-Asked-Questions) and [wikipages](https://github.com/SAP/SapMachine/wiki) for information about:
+Check out our [FAQs](https://github.com/SAP/SapMachine/wiki/Frequently-Asked-Questions) and [wikipages](https://github.com/SAP/SapMachine/wiki) for information about:
 * [Installation](https://github.com/SAP/SapMachine/wiki/Installation) and [Docker Images](https://github.com/SAP/SapMachine/wiki/Docker-Images)
 * [Certifications and Java Compatibility](https://github.com/SAP/SapMachine/wiki/Certification-and-Java-Compatibility)
 * [SapMachine Development Process](https://github.com/SAP/SapMachine/wiki/SapMachine-Development-Process)


### PR DESCRIPTION
There is no apostrophe for plural s in English (also not in German BTW).

(Link: Its not possessive - see https://www.oxfordlearnersdictionaries.com/grammar/online-grammar/possessive-s-and-s.)

fixes #480
