### PR TITLE
SapMachine (11) #1541: Vital extremas doesn't handle invalid values correctly

### DIFF
--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -94,8 +94,8 @@ public:
       return false;
     }
 
-    size_t bytes_read = ::fread(_buf, 1, bufsize, f);
-    _buf[bufsize - 1] = '\0';
+    size_t bytes_read = ::fread(_buf, 1, bufsize - 1, f);
+    _buf[bytes_read] = '\0';
 
     ::fclose(f);
 

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -870,6 +870,8 @@ public:
 
             bool should_log = (column->extremum() == MAX) && (sample->value(idx) > extremum_sample->value(idx));
             should_log |= (column->extremum() == MIN) && (sample->value(idx) < extremum_sample->value(idx));
+            should_log &= sample->value(idx) != INVALID_VALUE;
+            should_log |= extremum_sample->value(idx) == INVALID_VALUE;
 
             if (should_log) {
               Sample* last_extremum_sample = _last_extremum_samples.sample_at(idx);


### PR DESCRIPTION
Downport the fix to SapMachine 11.

fixes #1541

