### PR TITLE
SapMachine #1583: Include more info in exception used in vitals tests

### DIFF
--- a/test/hotspot/jtreg/runtime/Vitals/VitalsUtils.java
+++ b/test/hotspot/jtreg/runtime/Vitals/VitalsUtils.java
@@ -73,7 +73,8 @@ public class VitalsUtils {
             nLine ++;
         }
         if (nextToMatch < regexes.length) {
-            throw new RuntimeException("Not all matches found. First missing pattern " + nextToMatch + ":" + regexes[nextToMatch]);
+            throw new RuntimeException("Not all matches found. First missing pattern " + nextToMatch + ":" + regexes[nextToMatch] +
+			               "\nOutput: " + String.join("\n", lines));
         }
         return nLine;
     }


### PR DESCRIPTION
We need to see the output which doesn't include the expected message.

fixes #1583

