### PR TITLE
SapMachine #1627: Update gc.jfc and gc_details.jfc

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/gc.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc.jfc
@@ -1,858 +1,935 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Recommended way to edit .jfc files is to use the configure command of
+     the 'jfr' tool, i.e. jfr configure, or JDK Mission Control
+     see Window -> Flight Recorder Template Manager
+-->
+
 <configuration version="2.0" label="gc" description="Configuration for GC related events. No stack traces. Small recording size." provider="SAP SE">
 
-  <event name="jdk.ThreadAllocationStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ClassLoadingStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ClassLoaderStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.JavaThreadStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.SymbolTableStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.StringTableStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.ThreadStart">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ThreadEnd">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ThreadSleep">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.ThreadPark">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadStart">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadEnd">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadPinned">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadSubmitFailed">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorEnter">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorWait">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorInflate">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SyncOnValueBasedClass">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreeze">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ContinuationThaw">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreezeFast">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreezeSlow">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationThawFast">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationThawSlow">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ReservedStackActivation">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ClassLoad">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ClassDefine">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.RedefineClasses">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.RetransformClasses">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ClassRedefinition">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ClassUnload">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.JVMInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.InitialSystemProperty">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ExecutionSample">
-    <setting name="enabled">false</setting>
-    <setting name="period">20 ms</setting>
-  </event>
-
-  <event name="jdk.NativeMethodSample">
-    <setting name="enabled">false</setting>
-    <setting name="period">20 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointBegin">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointStateSynchronization">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointCleanup">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointCleanupTask">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointEnd">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.ExecuteVMOperation">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.Shutdown">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ThreadDump">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.IntFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.UnsignedIntFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.LongFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.UnsignedLongFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.DoubleFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.BooleanFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.StringFlag">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.IntFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.UnsignedIntFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.LongFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.UnsignedLongFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.DoubleFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.BooleanFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.StringFlagChanged">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ObjectCount">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.GCConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.GCHeapConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.YoungGenerationConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.GCTLABConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.GCSurvivorConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ObjectCountAfterGC">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.GCHeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PSHeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1HeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceGCThreshold">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceAllocationFailure">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.MetaspaceOOM">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.MetaspaceChunkFreeListSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.SystemGC">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ParallelOldGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.YoungGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.OldGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.G1GarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePause">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel1">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel2">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel3">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel4">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhaseConcurrent">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhaseConcurrentLevel1">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCReferenceStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GCCPUTime">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromotionFailed">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.EvacuationFailed">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.EvacuationInformation">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1MMU">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1EvacuationYoungStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1EvacuationOldStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GCPhaseParallel">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.G1BasicIHOP">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1AdaptiveIHOP">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromoteObjectInNewPLAB">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromoteObjectOutsidePLAB">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ConcurrentModeFailure">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.AllocationRequiringGC">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.TenuringDistribution">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1HeapRegionInformation">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.G1HeapRegionTypeChange">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ShenandoahHeapRegionInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ShenandoahHeapRegionStateChange">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.OldObjectSample">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="cutoff">0 ns</setting>
-  </event>
-
-  <event name="jdk.NativeMemoryUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.NativeMemoryUsageTotal">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.CompilerConfiguration">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.CompilerStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.Compilation">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">1000 ms</setting>
-  </event>
-
-  <event name="jdk.CompilerPhase">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">60 s</setting>
-  </event>
-
-  <event name="jdk.CompilationFailure">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.CompilerInlining">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.JITRestart">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.CodeCacheConfiguration">
-    <setting name="enabled">false</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.CodeCacheStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.CodeCacheFull">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.OSInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.VirtualizationInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ContainerConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ContainerCPUUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerCPUThrottling">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerMemoryUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerIOUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.CPUInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ThreadContextSwitchRate">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.CPULoad">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ThreadCPULoad">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.CPUTimeStampCounter">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.SystemProcess">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.ProcessStart">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.NetworkUtilization">
-    <setting name="enabled">false</setting>
-    <setting name="period">5 s</setting>
-  </event>
-
-  <event name="jdk.InitialEnvironmentVariable">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.PhysicalMemory">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationInNewTLAB">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationOutsideTLAB">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationSample">
-    <setting name="enabled">false</setting>
-    <setting name="throttle">150/s</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.NativeLibrary">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ModuleRequire">
-    <setting name="enabled">false</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.ModuleExport">
-    <setting name="enabled">false</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.FileForce">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.FileRead">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.FileWrite">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SocketRead">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SocketWrite">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.Deserialization">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.InitialSecurityProperty">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.SecurityPropertyModification">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.SecurityProviderService">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.TLSHandshake">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.X509Validation">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.X509Certificate">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.JavaExceptionThrow">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.JavaErrorThrow">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.ExceptionStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ActiveRecording">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ActiveSetting">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.Flush">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">0 ns</setting>
-  </event>
-
-  <event name="jdk.DataLoss">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.DumpReason">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ZAllocationStall">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZPageAllocation">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">1 ms</setting>
-  </event>
-
-  <event name="jdk.ZRelocationSet">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZRelocationSetGroup">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZStatisticsCounter">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZStatisticsSampler">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZThreadPhase">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZUncommit">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZUnmap">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.Deoptimization">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.HeapDump">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">0 ns</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.DirectBufferStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">5 s</setting>
-  </event>
-
-  <event name="jdk.GCLocker">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">1 s</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.FinalizerStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-
+    <event name="jdk.ResidentSetSize">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadAllocationStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ClassLoadingStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ClassLoaderStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.JavaThreadStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.SymbolTableStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.StringTableStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.ThreadStart">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ThreadEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ThreadSleep">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadPark">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadStart">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadPinned">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadSubmitFailed">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorEnter">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorWait">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorInflate">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SyncOnValueBasedClass">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreeze">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ContinuationThaw">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreezeFast">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreezeSlow">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationThawFast">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationThawSlow">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ReservedStackActivation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ClassLoad">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassDefine">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.RedefineClasses">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.RetransformClasses">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassRedefinition">
+      <setting name="enabled" control="class-loading">false</setting>
+    </event>
+
+    <event name="jdk.ClassUnload">
+      <setting name="enabled" control="class-loading">false</setting>
+    </event>
+
+    <event name="jdk.JVMInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.InitialSystemProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ExecutionSample">
+      <setting name="enabled" control="method-sampling-enabled">false</setting>
+      <setting name="period" control="method-sampling-java-interval">20 ms</setting>
+    </event>
+
+    <event name="jdk.NativeMethodSample">
+      <setting name="enabled" control="method-sampling-enabled">false</setting>
+      <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointBegin">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointStateSynchronization">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanup">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanupTask">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointEnd">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.ExecuteVMOperation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.Shutdown">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ThreadDump">
+      <setting name="enabled" control="thread-dump-enabled">false</setting>
+      <setting name="period" control="thread-dump">everyChunk</setting>
+    </event>
+
+    <event name="jdk.IntFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlag">
+      <setting name="enabled">false</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.LongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.DoubleFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.BooleanFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.StringFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.IntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.LongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DoubleFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.BooleanFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.StringFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ObjectCount">
+      <setting name="enabled" control="gc-enabled-all">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.YoungGenerationConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCTLABConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCSurvivorConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectCountAfterGC">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryPoolUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PSHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceGCThreshold">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceAllocationFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.MetaspaceOOM">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.MetaspaceChunkFreeListSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SystemGC">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ParallelOldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.YoungGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.OldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePause">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel1">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel2">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel3">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel4">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrent">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrentLevel1">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrentLevel2">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCReferenceStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GCCPUTime">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromotionFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationInformation">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1MMU">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationYoungStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationOldStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GCPhaseParallel">
+      <setting name="enabled" control="gc-enabled-normal">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1BasicIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1AdaptiveIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectInNewPLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectOutsidePLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.ConcurrentModeFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.AllocationRequiringGC">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.TenuringDistribution">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionTypeChange">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionStateChange">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+    </event>
+
+    <event name="jdk.OldObjectSample">
+      <setting name="enabled" control="old-objects-enabled">true</setting>
+      <setting name="stackTrace" control="old-objects-stack-trace">false</setting>
+      <setting name="cutoff" control="old-objects-cutoff">0 ns</setting>
+    </event>
+
+    <event name="jdk.NativeMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.NativeMemoryUsageTotal">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.CompilerConfiguration">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CompilerStatistics">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.Compilation">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="threshold" control="compiler-compilation-threshold">1000 ms</setting>
+    </event>
+
+    <event name="jdk.CompilerPhase">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="threshold" control="compiler-phase-threshold">60 s</setting>
+    </event>
+
+    <event name="jdk.CompilationFailure">
+      <setting name="enabled" control="compiler-enabled-failure">false</setting>
+    </event>
+
+    <event name="jdk.CompilerInlining">
+      <setting name="enabled" control="compiler-enabled-failure">false</setting>
+    </event>
+
+    <event name="jdk.JITRestart">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.CodeCacheConfiguration">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheStatistics">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheFull">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.OSInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.VirtualizationInformation">
+     <setting name="enabled">true</setting>
+     <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerConfiguration">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUThrottling">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerMemoryUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerIOUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.CPUInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ThreadContextSwitchRate">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadCPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPUTimeStampCounter">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SystemProcess">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ProcessStart">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.NetworkUtilization">
+      <setting name="enabled">false</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.CompilerQueueUtilization">
+      <setting name="enabled">false</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.InitialEnvironmentVariable">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.PhysicalMemory">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.SwapSpace">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationInNewTLAB">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationOutsideTLAB">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationSample">
+      <setting name="enabled" control="object-allocation-enabled">true</setting>
+      <setting name="throttle" control="allocation-profiling">150/s</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.NativeLibrary">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.NativeLibraryLoad">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.NativeLibraryUnload">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ModuleRequire">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ModuleExport">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.FileForce">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.FileRead">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.FileWrite">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SocketRead">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="socket-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SocketWrite">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="socket-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.Deserialization">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.SerializationMisdeclaration">
+        <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.InitialSecurityProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SecurityPropertyModification">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.SecurityProviderService">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.TLSHandshake">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.X509Validation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.X509Certificate">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.JavaExceptionThrow">
+      <setting name="enabled" control="enable-exceptions">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.JavaErrorThrow">
+      <setting name="enabled" control="enable-errors">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.ExceptionStatistics">
+      <setting name="enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ActiveRecording">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ActiveSetting">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.Flush">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ns</setting>
+    </event>
+
+    <event name="jdk.DataLoss">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DumpReason">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ZAllocationStall">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZPageAllocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSet">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSetGroup">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsCounter">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsSampler">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZThreadPhase">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUncommit">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUnmap">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZYoungGarbageCollection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZOldGarbageCollection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.Deoptimization">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.HeapDump">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ns</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.DirectBufferStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.GCLocker">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">1 s</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.FinalizerStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.JavaAgent">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.NativeAgent">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.DeprecatedInvocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="level">forRemoval</setting>
+    </event>
 
 
 
@@ -883,7 +960,7 @@
   carry the control attribute.
   -->
     <control>
-     <selection name="gc" default="normal" label="Garbage Collector">
+      <selection name="gc" default="normal" label="Garbage Collector">
         <option label="Off" name="off">off</option>
         <option label="Normal" name="normal">normal</option>
         <option label="Detailed" name="detailed">detailed</option>
@@ -928,7 +1005,7 @@
       </selection>
 
       <condition name="object-allocation-enabled" true="true" false="false">
-	 <not>
+        <not>
           <test name="allocation-profiling" operator="equal" value="off"/>
         </not>
       </condition>
@@ -1076,7 +1153,6 @@
       <text name="socket-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">20 ms</text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
-
     </control>
 
 </configuration>

--- a/src/jdk.jfr/share/conf/jfr/gc_details.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc_details.jfc
@@ -1,858 +1,935 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Recommended way to edit .jfc files is to use the configure command of
+     the 'jfr' tool, i.e. jfr configure, or JDK Mission Control
+     see Window -> Flight Recorder Template Manager
+-->
+
 <configuration version="2.0" label="gc_details" description="Configuration for all GC related events. Higher impact caused by heap inspection initiated GCs to get heap statistics. Large recording size." provider="SAP SE">
 
-  <event name="jdk.ThreadAllocationStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ClassLoadingStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ClassLoaderStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.JavaThreadStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.SymbolTableStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.StringTableStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.ThreadStart">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ThreadEnd">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ThreadSleep">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.ThreadPark">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadStart">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadEnd">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadPinned">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.VirtualThreadSubmitFailed">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorEnter">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorWait">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.JavaMonitorInflate">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SyncOnValueBasedClass">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreeze">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ContinuationThaw">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreezeFast">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationFreezeSlow">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationThawFast">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ContinuationThawSlow">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ReservedStackActivation">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ClassLoad">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ClassDefine">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.RedefineClasses">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.RetransformClasses">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ClassRedefinition">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ClassUnload">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.JVMInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.InitialSystemProperty">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ExecutionSample">
-    <setting name="enabled">true</setting>
-    <setting name="period">20 ms</setting>
-  </event>
-
-  <event name="jdk.NativeMethodSample">
-    <setting name="enabled">true</setting>
-    <setting name="period">20 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointBegin">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointStateSynchronization">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointCleanup">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointCleanupTask">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.SafepointEnd">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.ExecuteVMOperation">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">10 ms</setting>
-  </event>
-
-  <event name="jdk.Shutdown">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ThreadDump">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.IntFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.UnsignedIntFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.LongFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.UnsignedLongFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.DoubleFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.BooleanFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.StringFlag">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.IntFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.UnsignedIntFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.LongFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.UnsignedLongFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.DoubleFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.BooleanFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.StringFlagChanged">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ObjectCount">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.GCConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.GCHeapConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.YoungGenerationConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.GCTLABConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.GCSurvivorConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ObjectCountAfterGC">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GCHeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PSHeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1HeapSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceGCThreshold">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceAllocationFailure">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceOOM">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.MetaspaceChunkFreeListSummary">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.SystemGC">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ParallelOldGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.YoungGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.OldGarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.G1GarbageCollection">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePause">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel1">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel2">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel3">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhasePauseLevel4">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhaseConcurrent">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCPhaseConcurrentLevel1">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.GCReferenceStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GCCPUTime">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromotionFailed">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.EvacuationFailed">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.EvacuationInformation">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1MMU">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1EvacuationYoungStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1EvacuationOldStatistics">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.GCPhaseParallel">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.G1BasicIHOP">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1AdaptiveIHOP">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromoteObjectInNewPLAB">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.PromoteObjectOutsidePLAB">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ConcurrentModeFailure">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.AllocationRequiringGC">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.TenuringDistribution">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.G1HeapRegionInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.G1HeapRegionTypeChange">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.ShenandoahHeapRegionInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ShenandoahHeapRegionStateChange">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.OldObjectSample">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-    <setting name="cutoff">0 ns</setting>
-  </event>
-
-  <event name="jdk.NativeMemoryUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.NativeMemoryUsageTotal">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.CompilerConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.CompilerStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.Compilation">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">1000 ms</setting>
-  </event>
-
-  <event name="jdk.CompilerPhase">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">60 s</setting>
-  </event>
-
-  <event name="jdk.CompilationFailure">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.CompilerInlining">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.JITRestart">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.CodeCacheConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.CodeCacheStatistics">
-    <setting name="enabled">false</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.CodeCacheFull">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.OSInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.VirtualizationInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ContainerConfiguration">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ContainerCPUUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerCPUThrottling">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerMemoryUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.ContainerIOUsage">
-    <setting name="enabled">true</setting>
-    <setting name="period">30 s</setting>
-  </event>
-
-  <event name="jdk.CPUInformation">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.ThreadContextSwitchRate">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.CPULoad">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ThreadCPULoad">
-    <setting name="enabled">true</setting>
-    <setting name="period">10 s</setting>
-  </event>
-
-  <event name="jdk.CPUTimeStampCounter">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.SystemProcess">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.ProcessStart">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.NetworkUtilization">
-    <setting name="enabled">true</setting>
-    <setting name="period">5 s</setting>
-  </event>
-
-  <event name="jdk.InitialEnvironmentVariable">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.PhysicalMemory">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationInNewTLAB">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationOutsideTLAB">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ObjectAllocationSample">
-    <setting name="enabled">true</setting>
-    <setting name="throttle">150/s</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.NativeLibrary">
-    <setting name="enabled">true</setting>
-    <setting name="period">everyChunk</setting>
-  </event>
-
-  <event name="jdk.ModuleRequire">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.ModuleExport">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-  <event name="jdk.FileForce">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.FileRead">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.FileWrite">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SocketRead">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.SocketWrite">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">20 ms</setting>
-  </event>
-
-  <event name="jdk.Deserialization">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.InitialSecurityProperty">
-    <setting name="enabled">true</setting>
-    <setting name="period">beginChunk</setting>
-  </event>
-
-  <event name="jdk.SecurityPropertyModification">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.SecurityProviderService">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.TLSHandshake">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.X509Validation">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.X509Certificate">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.JavaExceptionThrow">
-    <setting name="enabled">false</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.JavaErrorThrow">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.ExceptionStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">1000 ms</setting>
-  </event>
-
-  <event name="jdk.ActiveRecording">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ActiveSetting">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.Flush">
-    <setting name="enabled">false</setting>
-    <setting name="threshold">0 ns</setting>
-  </event>
-
-  <event name="jdk.DataLoss">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.DumpReason">
-    <setting name="enabled">true</setting>
-  </event>
-
-  <event name="jdk.ZAllocationStall">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZPageAllocation">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">true</setting>
-    <setting name="threshold">1 ms</setting>
-  </event>
-
-  <event name="jdk.ZRelocationSet">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZRelocationSetGroup">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZStatisticsCounter">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZStatisticsSampler">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZThreadPhase">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZUncommit">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.ZUnmap">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
-
-  <event name="jdk.Deoptimization">
-    <setting name="enabled">true</setting>
-    <setting name="stackTrace">false</setting>
-  </event>
-
-  <event name="jdk.HeapDump">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ns</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.DirectBufferStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">5 s</setting>
-  </event>
-
-  <event name="jdk.GCLocker">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">1 s</setting>
-    <setting name="stackTrace">true</setting>
-  </event>
-
-  <event name="jdk.FinalizerStatistics">
-    <setting name="enabled">true</setting>
-    <setting name="period">endChunk</setting>
-  </event>
-
-
+    <event name="jdk.ResidentSetSize">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadAllocationStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ClassLoadingStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ClassLoaderStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.JavaThreadStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.SymbolTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.StringTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.ThreadStart">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ThreadEnd">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ThreadSleep">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadPark">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadStart">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadPinned">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.VirtualThreadSubmitFailed">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorEnter">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorWait">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorInflate">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SyncOnValueBasedClass">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreeze">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ContinuationThaw">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreezeFast">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationFreezeSlow">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationThawFast">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ContinuationThawSlow">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.ReservedStackActivation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ClassLoad">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassDefine">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.RedefineClasses">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.RetransformClasses">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassRedefinition">
+      <setting name="enabled" control="class-loading">false</setting>
+    </event>
+
+    <event name="jdk.ClassUnload">
+      <setting name="enabled" control="class-loading">false</setting>
+    </event>
+
+    <event name="jdk.JVMInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.InitialSystemProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ExecutionSample">
+      <setting name="enabled" control="method-sampling-enabled">false</setting>
+      <setting name="period" control="method-sampling-java-interval">20 ms</setting>
+    </event>
+
+    <event name="jdk.NativeMethodSample">
+      <setting name="enabled" control="method-sampling-enabled">false</setting>
+      <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointBegin">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointStateSynchronization">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanup">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanupTask">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointEnd">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.ExecuteVMOperation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.Shutdown">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ThreadDump">
+      <setting name="enabled" control="thread-dump-enabled">true</setting>
+      <setting name="period" control="thread-dump">everyChunk</setting>
+    </event>
+
+    <event name="jdk.IntFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.LongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.DoubleFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.BooleanFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.StringFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.IntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.LongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DoubleFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.BooleanFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.StringFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ObjectCount">
+      <setting name="enabled" control="gc-enabled-all">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.YoungGenerationConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCTLABConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCSurvivorConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectCountAfterGC">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryPoolUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PSHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceGCThreshold">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceAllocationFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.MetaspaceOOM">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.MetaspaceChunkFreeListSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SystemGC">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ParallelOldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.YoungGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.OldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePause">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel1">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel2">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel3">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel4">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrent">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrentLevel1">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrentLevel2">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCReferenceStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GCCPUTime">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromotionFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationInformation">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1MMU">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationYoungStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationOldStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GCPhaseParallel">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1BasicIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1AdaptiveIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectInNewPLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectOutsidePLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.ConcurrentModeFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.AllocationRequiringGC">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.TenuringDistribution">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionTypeChange">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionStateChange">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.OldObjectSample">
+      <setting name="enabled" control="old-objects-enabled">true</setting>
+      <setting name="stackTrace" control="old-objects-stack-trace">true</setting>
+      <setting name="cutoff" control="old-objects-cutoff">0 ns</setting>
+    </event>
+
+    <event name="jdk.NativeMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.NativeMemoryUsageTotal">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.CompilerConfiguration">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CompilerStatistics">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.Compilation">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="threshold" control="compiler-compilation-threshold">1000 ms</setting>
+    </event>
+
+    <event name="jdk.CompilerPhase">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="threshold" control="compiler-phase-threshold">60 s</setting>
+    </event>
+
+    <event name="jdk.CompilationFailure">
+      <setting name="enabled" control="compiler-enabled-failure">false</setting>
+    </event>
+
+    <event name="jdk.CompilerInlining">
+      <setting name="enabled" control="compiler-enabled-failure">false</setting>
+    </event>
+
+    <event name="jdk.JITRestart">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.CodeCacheConfiguration">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheStatistics">
+      <setting name="enabled" control="compiler-enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheFull">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.OSInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.VirtualizationInformation">
+     <setting name="enabled">true</setting>
+     <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerConfiguration">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUThrottling">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerMemoryUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerIOUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.CPUInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ThreadContextSwitchRate">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadCPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPUTimeStampCounter">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SystemProcess">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ProcessStart">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.NetworkUtilization">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.CompilerQueueUtilization">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.InitialEnvironmentVariable">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.PhysicalMemory">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.SwapSpace">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationInNewTLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationOutsideTLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationSample">
+      <setting name="enabled" control="object-allocation-enabled">true</setting>
+      <setting name="throttle" control="allocation-profiling">150/s</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.NativeLibrary">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.NativeLibraryLoad">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.NativeLibraryUnload">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ModuleRequire">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ModuleExport">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.FileForce">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.FileRead">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.FileWrite">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="file-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SocketRead">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="socket-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.SocketWrite">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="threshold" control="socket-threshold">20 ms</setting>
+    </event>
+
+    <event name="jdk.Deserialization">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.SerializationMisdeclaration">
+        <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.InitialSecurityProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SecurityPropertyModification">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.SecurityProviderService">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.TLSHandshake">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.X509Validation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.X509Certificate">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.JavaExceptionThrow">
+      <setting name="enabled" control="enable-exceptions">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.JavaErrorThrow">
+      <setting name="enabled" control="enable-errors">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ExceptionStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ActiveRecording">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ActiveSetting">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.Flush">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ns</setting>
+    </event>
+
+    <event name="jdk.DataLoss">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DumpReason">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ZAllocationStall">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZPageAllocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSet">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSetGroup">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsCounter">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsSampler">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZThreadPhase">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUncommit">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUnmap">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZYoungGarbageCollection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZOldGarbageCollection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.Deoptimization">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+    </event>
+
+    <event name="jdk.HeapDump">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ns</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.DirectBufferStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.GCLocker">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">1 s</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.FinalizerStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.JavaAgent">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.NativeAgent">
+      <setting name="enabled">false</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.DeprecatedInvocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">false</setting>
+      <setting name="level">forRemoval</setting>
+    </event>
 
 
 
@@ -883,7 +960,7 @@
   carry the control attribute.
   -->
     <control>
-     <selection name="gc" default="normal" label="Garbage Collector">
+      <selection name="gc" default="normal" label="Garbage Collector">
         <option label="Off" name="off">off</option>
         <option label="Normal" name="normal">normal</option>
         <option label="Detailed" name="detailed">detailed</option>
@@ -928,7 +1005,7 @@
       </selection>
 
       <condition name="object-allocation-enabled" true="true" false="false">
-	 <not>
+        <not>
           <test name="allocation-profiling" operator="equal" value="off"/>
         </not>
       </condition>
@@ -1076,7 +1153,6 @@
       <text name="socket-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">20 ms</text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
-
     </control>
 
 </configuration>


### PR DESCRIPTION
- Add new/missing events.
- Enable helpful events missing in gc.jfc.
- Disable event jdk.GCPhaseParallel that is too detailed(occupy 85% of the recording in case of G1GC) and not that helpful in gc.jfc

fixes #1627 

