### PR TITLE
SapMachine #1657: Reenable logging test

### DIFF
--- a/test/hotspot/gtest/logging/test_logSelectionList.cpp
+++ b/test/hotspot/gtest/logging/test_logSelectionList.cpp
@@ -30,13 +30,11 @@
 #include "logTestUtils.inline.hpp"
 #include "unittest.hpp"
 
-// SapMachine 2024-02-08
-// temporary disable this test since it is failing in SapMachine. Opened JDK-8325508 to clarify.
-// TEST(LogSelectionList, combination_limit) {
-//   size_t max_combinations = LogSelectionList::MaxSelections;
-//   EXPECT_GT(max_combinations, LogTagSet::ntagsets())
-//       << "Combination limit not sufficient for configuring all available tag sets";
-// }
+TEST(LogSelectionList, combination_limit) {
+  size_t max_combinations = LogSelectionList::MaxSelections;
+  EXPECT_GT(max_combinations, LogTagSet::ntagsets())
+      << "Combination limit not sufficient for configuring all available tag sets";
+}
 
 TEST(LogSelectionList, parse) {
   char buf[256];


### PR DESCRIPTION
After [JDK-8327098](https://bugs.openjdk.org/browse/JDK-8327098) went in upstream, we can reenable gtest `TEST(LogSelectionList, combination_limit)`.

fixes #1657
