### PR TITLE
Fix freeing unallocated memory in filesocket implementation in sapmachine11

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_filesocket/fileSocketTransport.c
@@ -119,7 +119,13 @@ static jdwpTransportError JNICALL fileSocketTransport_StartListening(jdwpTranspo
         return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;
     }
 
-    *actual_address = (char*) address;
+    *actual_address = (*callback->alloc)((int)strlen(address) + 1);
+
+    if (*actual_address == NULL) {
+        return JDWPTRANSPORT_ERROR_OUT_OF_MEMORY;
+    } else {
+        strcpy(*actual_address, address);
+    }
 
     if (strlen(address) <= MAX_FILE_SOCKET_PATH_LEN) {
         strcpy(path, address);


### PR DESCRIPTION
This fixes a memory problem in the filesocket implementation in sapmachine11 from PR 1618.

fixes #1611
