### PR TITLE
SapMachine #1670: Improve patch for jcmd GC.heap_dump modification

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -492,10 +492,10 @@ void FinalizerInfoDCmd::execute(DCmdSource source, TRAPS) {
 }
 
 #if INCLUDE_SERVICES // Heap dumping/inspection supported
-// SapMachine 2024-05-10: HeapDumpPath for jcmd
 HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
                            DCmdWithParser(output, heap),
-  _filename("filename","Name of the dump file", "STRING", false, "if no filename was specified, but -XX:HeapDumpPath=hdp is set, path hdp is taken"),
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  _filename("filename", "Name of the dump file", "STRING", false, "if no filename was specified, but -XX:HeapDumpPath=<hdp> is set, path <hdp> is taken"),
   _all("-all", "Dump all objects, including unreachable objects",
        "BOOLEAN", false, "false"),
   _gzip("-gz", "If specified, the heap dump is written in gzipped format "
@@ -554,12 +554,11 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // Request a full GC before heap dump if _all is false
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
-  HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-
   // SapMachine 2024-05-10: HeapDumpPath for jcmd
   if (use_heapdump_path) {
-    dumper.dump_to(output(), (int)level, _overwrite.value(), (uint)parallel);
+    HeapDumper::dump_heap(!_all.value(), output(), (int)level, _overwrite.value(), (uint)parallel);
   } else {
+    HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
     dumper.dump(_filename.value(), output(), (int)level, _overwrite.value(), (uint)parallel);
   }
 }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2600,99 +2600,6 @@ void VM_HeapDumper::dump_vthread(oop vt, AbstractDumpWriter* segment_writer) {
   thread_dumper.dump_stack_refs(segment_writer);
 }
 
-// SapMachine 2024-05-10: HeapDumpPath for jcmd
-static uint dump_file_seq = 0;
-
-// helper function to create the heap dump path name
-// the caller must free the returned pointer
-static char* alloc_and_create_heapdump_pathname() {
-  static char base_path[JVM_MAXPATHLEN] = {'\0'};
-  char* my_path;
-  const int max_digit_chars = 20;
-
-  const char* dump_file_name = "java_pid";
-  const char* dump_file_ext  = HeapDumpGzipLevel > 0 ? ".hprof.gz" : ".hprof";
-
-  // The dump file defaults to java_pid<pid>.hprof in the current working
-  // directory. HeapDumpPath=<file> can be used to specify an alternative
-  // dump file name or a directory where dump file is created.
-  if (dump_file_seq == 0) { // first time in, we initialize base_path
-    // Calculate potentially longest base path and check if we have enough
-    // allocated statically.
-    const size_t total_length =
-                      (HeapDumpPath == nullptr ? 0 : strlen(HeapDumpPath)) +
-                      strlen(os::file_separator()) + max_digit_chars +
-                      strlen(dump_file_name) + strlen(dump_file_ext) + 1;
-    if (total_length > sizeof(base_path)) {
-      warning("Cannot create heap dump file.  HeapDumpPath is too long.");
-      return nullptr;
-    }
-
-    bool use_default_filename = true;
-    if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
-      // HeapDumpPath=<file> not specified
-    } else {
-      strcpy(base_path, HeapDumpPath);
-      // check if the path is a directory (must exist)
-      DIR* dir = os::opendir(base_path);
-      if (dir == nullptr) {
-        use_default_filename = false;
-      } else {
-        // HeapDumpPath specified a directory. We append a file separator
-        // (if needed).
-        os::closedir(dir);
-        size_t fs_len = strlen(os::file_separator());
-        if (strlen(base_path) >= fs_len) {
-          char* end = base_path;
-          end += (strlen(base_path) - fs_len);
-          if (strcmp(end, os::file_separator()) != 0) {
-            strcat(base_path, os::file_separator());
-          }
-        }
-      }
-    }
-    // If HeapDumpPath wasn't a file name then we append the default name
-    if (use_default_filename) {
-      const size_t dlen = strlen(base_path);  // if heap dump dir specified
-      jio_snprintf(&base_path[dlen], sizeof(base_path)-dlen, "%s%d%s",
-                   dump_file_name, os::current_process_id(), dump_file_ext);
-    }
-    const size_t len = strlen(base_path) + 1;
-    my_path = (char*)os::malloc(len, mtInternal);
-    if (my_path == nullptr) {
-      warning("Cannot create heap dump file.  Out of system memory.");
-      return nullptr;
-    }
-    strncpy(my_path, base_path, len);
-  } else {
-    // Append a sequence number id for dumps following the first
-    const size_t len = strlen(base_path) + max_digit_chars + 2; // for '.' and \0
-    my_path = (char*)os::malloc(len, mtInternal);
-    if (my_path == nullptr) {
-      warning("Cannot create heap dump file.  Out of system memory.");
-      return nullptr;
-    }
-    jio_snprintf(my_path, len, "%s.%d", base_path, dump_file_seq);
-  }
-  dump_file_seq++;   // increment seq number for next time we dump
-  return my_path;
-}
-
-
-int HeapDumper::dump_to(outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
-  if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
-    return -1;
-  }
-  // SapMachine 2024-05-10: HeapDumpPath for jcmd
-  char* h_path = alloc_and_create_heapdump_pathname();
-  if (h_path != nullptr) {
-    int res = dump(h_path, out, compression, overwrite, num_dump_threads);
-    os::free(h_path);
-    return res;
-  }
-  return -1;
-}
-
 // dump the heap to given path.
 int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
   assert(path != nullptr && strlen(path) > 0, "path missing");
@@ -2829,7 +2736,8 @@ void HeapDumper::set_error(char const* error) {
 // Called by out-of-memory error reporting by a single Java thread
 // outside of a JVM safepoint
 void HeapDumper::dump_heap_from_oome() {
-  HeapDumper::dump_heap(true);
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  HeapDumper::dump_heap(false, true);
 }
 
 // Called by error reporting by a single Java thread outside of a JVM safepoint,
@@ -2838,16 +2746,94 @@ void HeapDumper::dump_heap_from_oome() {
 // general use, however, this method will need modification to prevent
 // inteference when updating the static variables base_path and dump_file_seq below.
 void HeapDumper::dump_heap() {
-  HeapDumper::dump_heap(false);
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  HeapDumper::dump_heap(false, false);
 }
 
-void HeapDumper::dump_heap(bool oome) {
+// SapMachine 2024-05-10: HeapDumpPath for jcmd
+void HeapDumper::dump_heap(bool gc_before_heap_dump, outputStream* out, int compression, bool overwrite, uint parallel_thread_num) {
+  HeapDumper::dump_heap(gc_before_heap_dump, false, out, compression, overwrite, parallel_thread_num);
+}
+
+// SapMachine 2024-05-10: HeapDumpPath for jcmd
+void HeapDumper::dump_heap(bool gc_before_heap_dump, bool oome, outputStream* out, int compression, bool overwrite, uint parallel_thread_num) {
+  static char base_path[JVM_MAXPATHLEN] = {'\0'};
+  static uint dump_file_seq = 0;
+  char* my_path;
+  const int max_digit_chars = 20;
+
+  const char* dump_file_name = "java_pid";
   // SapMachine 2024-05-10: HeapDumpPath for jcmd
-  char* h_path = alloc_and_create_heapdump_pathname();
-  if (h_path != nullptr) {
-    HeapDumper dumper(false /* no GC before heap dump */,
-                      oome  /* pass along out-of-memory-error flag */);
-    dumper.dump(h_path, tty, HeapDumpGzipLevel);
-    os::free(h_path);
+  const int ziplevel = compression < 0 ? HeapDumpGzipLevel : compression;
+  const char* dump_file_ext  = ziplevel > 0 ? ".hprof.gz" : ".hprof";
+
+  // The dump file defaults to java_pid<pid>.hprof in the current working
+  // directory. HeapDumpPath=<file> can be used to specify an alternative
+  // dump file name or a directory where dump file is created.
+  if (dump_file_seq == 0) { // first time in, we initialize base_path
+    // Calculate potentially longest base path and check if we have enough
+    // allocated statically.
+    const size_t total_length =
+                      (HeapDumpPath == nullptr ? 0 : strlen(HeapDumpPath)) +
+                      strlen(os::file_separator()) + max_digit_chars +
+                      strlen(dump_file_name) + strlen(dump_file_ext) + 1;
+    if (total_length > sizeof(base_path)) {
+      warning("Cannot create heap dump file.  HeapDumpPath is too long.");
+      return;
+    }
+
+    bool use_default_filename = true;
+    if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
+      // HeapDumpPath=<file> not specified
+    } else {
+      strcpy(base_path, HeapDumpPath);
+      // check if the path is a directory (must exist)
+      DIR* dir = os::opendir(base_path);
+      if (dir == nullptr) {
+        use_default_filename = false;
+      } else {
+        // HeapDumpPath specified a directory. We append a file separator
+        // (if needed).
+        os::closedir(dir);
+        size_t fs_len = strlen(os::file_separator());
+        if (strlen(base_path) >= fs_len) {
+          char* end = base_path;
+          end += (strlen(base_path) - fs_len);
+          if (strcmp(end, os::file_separator()) != 0) {
+            strcat(base_path, os::file_separator());
+          }
+        }
+      }
+    }
+    // If HeapDumpPath wasn't a file name then we append the default name
+    if (use_default_filename) {
+      const size_t dlen = strlen(base_path);  // if heap dump dir specified
+      jio_snprintf(&base_path[dlen], sizeof(base_path)-dlen, "%s%d%s",
+                   dump_file_name, os::current_process_id(), dump_file_ext);
+    }
+    const size_t len = strlen(base_path) + 1;
+    my_path = (char*)os::malloc(len, mtInternal);
+    if (my_path == nullptr) {
+      warning("Cannot create heap dump file.  Out of system memory.");
+      return;
+    }
+    strncpy(my_path, base_path, len);
+  } else {
+    // Append a sequence number id for dumps following the first
+    const size_t len = strlen(base_path) + max_digit_chars + 2; // for '.' and \0
+    my_path = (char*)os::malloc(len, mtInternal);
+    if (my_path == nullptr) {
+      warning("Cannot create heap dump file.  Out of system memory.");
+      return;
+    }
+    jio_snprintf(my_path, len, "%s.%d", base_path, dump_file_seq);
   }
+  dump_file_seq++;   // increment seq number for next time we dump
+
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  HeapDumper dumper(gc_before_heap_dump /* GC before heap dump */,
+                    oome  /* pass along out-of-memory-error flag */);
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  dumper.dump(my_path, out, ziplevel, overwrite, parallel_thread_num);
+  os::free(my_path);
 }

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -49,7 +49,8 @@ class HeapDumper : public StackObj {
   // internal timer.
   elapsedTimer* timer()                 { return &_t; }
 
-  static void dump_heap(bool oome);
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  static void dump_heap(bool gc_before_heap_dump, bool oome, outputStream* out = tty, int compression = -1, bool overwrite = false, uint parallel_thread_num = default_num_of_dump_threads());
 
  public:
   HeapDumper(bool gc_before_heap_dump) :
@@ -63,15 +64,15 @@ class HeapDumper : public StackObj {
   // parallel_thread_num >= 0 indicates thread numbers of parallel object dump.
   int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, uint parallel_thread_num = default_num_of_dump_threads());
 
-  // same as dump with path parameter, but uses the preset HeapDumpPath file or directory
-  int dump_to(outputStream* out, int compression, bool overwrite, uint parallel_thread_num);
-
   // returns error message (resource allocated), or null if no error
   char* error_as_C_string() const;
 
   static void dump_heap()    NOT_SERVICES_RETURN;
 
   static void dump_heap_from_oome()    NOT_SERVICES_RETURN;
+
+  // SapMachine 2024-05-10: HeapDumpPath for jcmd
+  static void dump_heap(bool gc_before_heap_dump, outputStream* out, int compression, bool overwrite, uint parallel_thread_num)    NOT_SERVICES_RETURN;
 
   // Parallel thread number for heap dump, initialize based on active processor count.
   static uint default_num_of_dump_threads() {

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -2799,9 +2799,9 @@ an \f[V]OutOfMemoryError\f[R] exception is thrown.
 \f[V]-XX:HeapDumpPath=\f[R]\f[I]path\f[R]
 Sets the path and file name for writing the heap dump provided by the
 heap profiler (HPROF) when the \f[V]-XX:+HeapDumpOnOutOfMemoryError\f[R]
-option is set or a heap dump is triggered by \f[V]jcmd GC.heap_dump\f[R] without specifying a path.
-In case of HeapDumpOnOutOfMemoryError, by default, the file is created in the current
-working directory, and it\[aq]s named \f[V]java_pid<pid>.hprof\f[R] where \f[V]<pid>\f[R] is
+option is set.
+By default, the file is created in the current working directory, and
+it\[aq]s named \f[V]java_pid<pid>.hprof\f[R] where \f[V]<pid>\f[R] is
 the identifier of the process that caused the error.
 The following example shows how to set the default file explicitly
 (\f[V]%p\f[R] represents the current process identifier):

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -335,9 +335,7 @@ fewer.
 .PP
 \f[I]arguments\f[R]:
 .IP \[bu] 2
-\f[I]filename\f[R]: The name of the dump file; in case no file is specified
-but -XX:HeapDumpPath=path is set, the path provided by HeapDumpPath is used
-(STRING, no default value)
+\f[I]filename\f[R]: The name of the dump file (STRING, no default value)
 .RE
 .TP
 \f[V]GC.heap_info\f[R]


### PR DESCRIPTION
The SapMachine [commit to modify the jcmd GC.heap_dump](ab72d4e43a708764b3e6a6173e9f2999cf4bc17d) was taken directly from the OpenJDK proposal. In that form, however, it creates a too large upstream diff which could be reduced.

fixes #1670
