### PR TITLE
SapMachine (17) #1670: Fix occurence of nullptr in jcmd GC.heap_dump patch

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -518,7 +518,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
 
   // SapMachine 2024-05-10: HeapDumpPath for jcmd
   if (!_filename.is_set()) {
-    if (HeapDumpPath != nullptr) {
+    if (HeapDumpPath != NULL) {
       // use HeapDumpPath (file or directory is possible)
       use_heapdump_path = true;
     } else {


### PR DESCRIPTION
An instance of "nullptr" sneaked in, which is not correct in JDK 17 codebase.

fixes #1670
