### PR TITLE
SapMachine #1740: Disable experimental and detailed GC events

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/gc.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc.jfc
@@ -200,16 +200,6 @@
       <setting name="threshold">10 ms</setting>
     </event>
 
-    <event name="jdk.SafepointCleanup">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">10 ms</setting>
-    </event>
-
-    <event name="jdk.SafepointCleanupTask">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">10 ms</setting>
-    </event>
-
     <event name="jdk.SafepointEnd">
       <setting name="enabled">false</setting>
       <setting name="threshold">10 ms</setting>
@@ -368,7 +358,7 @@
     </event>
 
     <event name="jdk.MetaspaceChunkFreeListSummary">
-      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="enabled" control="gc-enabled-normal">false</setting>
     </event>
 
     <event name="jdk.GarbageCollection">
@@ -518,7 +508,7 @@
     </event>
 
     <event name="jdk.ShenandoahHeapRegionInformation">
-      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="enabled" control="gc-enabled-high">false</setting>
       <setting name="period">everyChunk</setting>
     </event>
 
@@ -694,7 +684,7 @@
     </event>
 
     <event name="jdk.ObjectAllocationSample">
-      <setting name="enabled" control="object-allocation-enabled">true</setting>
+      <setting name="enabled" control="object-allocation-enabled">false</setting>
       <setting name="throttle" control="allocation-profiling">150/s</setting>
       <setting name="stackTrace">false</setting>
     </event>
@@ -838,33 +828,33 @@
     </event>
 
     <event name="jdk.ZPageAllocation">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="stackTrace">false</setting>
       <setting name="threshold">1 ms</setting>
     </event>
 
     <event name="jdk.ZRelocationSet">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 
     <event name="jdk.ZRelocationSetGroup">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 
     <event name="jdk.ZStatisticsCounter">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 
     <event name="jdk.ZStatisticsSampler">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 
     <event name="jdk.ZThreadPhase">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 


### PR DESCRIPTION
Removed old Safepoint events.

fixes #1740 

