### PR TITLE
SapMachine (22) #1740: Disable experimental and detailed GC events to reduce the file size.

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/gc.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc.jfc
@@ -347,7 +347,7 @@
   </event>
 
   <event name="jdk.MetaspaceChunkFreeListSummary">
-    <setting name="enabled">true</setting>
+    <setting name="enabled">false</setting>
   </event>
 
   <event name="jdk.GarbageCollection">
@@ -492,7 +492,7 @@
   </event>
 
   <event name="jdk.ShenandoahHeapRegionInformation">
-    <setting name="enabled">true</setting>
+    <setting name="enabled">false</setting>
     <setting name="period">everyChunk</setting>
   </event>
 
@@ -785,35 +785,35 @@
   </event>
 
   <event name="jdk.ZPageAllocation">
-    <setting name="enabled">true</setting>
+    <setting name="enabled">false</setting>
     <setting name="stackTrace">false</setting>
     <setting name="threshold">1 ms</setting>
   </event>
 
-  <event name="jdk.ZRelocationSet">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
+    <event name="jdk.ZRelocationSet">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
 
-  <event name="jdk.ZRelocationSetGroup">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
+    <event name="jdk.ZRelocationSetGroup">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
 
-  <event name="jdk.ZStatisticsCounter">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
+    <event name="jdk.ZStatisticsCounter">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
 
-  <event name="jdk.ZStatisticsSampler">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
+    <event name="jdk.ZStatisticsSampler">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
 
-  <event name="jdk.ZThreadPhase">
-    <setting name="enabled">true</setting>
-    <setting name="threshold">0 ms</setting>
-  </event>
+    <event name="jdk.ZThreadPhase">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
 
   <event name="jdk.ZUncommit">
     <setting name="enabled">true</setting>

--- a/src/jdk.jfr/share/conf/jfr/gc.jfc
+++ b/src/jdk.jfr/share/conf/jfr/gc.jfc
@@ -790,30 +790,30 @@
     <setting name="threshold">1 ms</setting>
   </event>
 
-    <event name="jdk.ZRelocationSet">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">0 ms</setting>
-    </event>
+  <event name="jdk.ZRelocationSet">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
-    <event name="jdk.ZRelocationSetGroup">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">0 ms</setting>
-    </event>
+  <event name="jdk.ZRelocationSetGroup">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
-    <event name="jdk.ZStatisticsCounter">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">0 ms</setting>
-    </event>
+  <event name="jdk.ZStatisticsCounter">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
-    <event name="jdk.ZStatisticsSampler">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">0 ms</setting>
-    </event>
+  <event name="jdk.ZStatisticsSampler">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
-    <event name="jdk.ZThreadPhase">
-      <setting name="enabled">false</setting>
-      <setting name="threshold">0 ms</setting>
-    </event>
+  <event name="jdk.ZThreadPhase">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
   <event name="jdk.ZUncommit">
     <setting name="enabled">true</setting>


### PR DESCRIPTION
(cherry picked from commit https://github.com/SAP/SapMachine/commit/503578bc19c1bdeeee774bd628f9cac3a2253e07)

Didn't apply clean. Resolved conflicts manually.

fixes #1740