### PR TITLE
SapMachine (23) #1693: Fix initialization of JavaLangProcessAccess

### DIFF
--- a/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
+++ b/src/hotspot/os/linux/malloctrace/mallocTrace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2024 SAP SE. All rights reserved.
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -25,6 +25,9 @@
 
 package java.lang;
 
+// SapMachine 2024-07-01: process group extension
+import jdk.internal.access.JavaLangProcessAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Blocker;
 import jdk.internal.util.StaticProperty;
 
@@ -109,6 +112,18 @@ public abstract class Process {
     private Charset inputCharset;
     private BufferedReader errorReader;
     private Charset errorCharset;
+
+    // SapMachine 2024-07-01: process group extension
+    static {
+        SharedSecrets.setJavaLangProcessAccess(
+            new JavaLangProcessAccess() {
+                @Override
+                public void destroyProcessGroup(Process leader, boolean force) throws IOException {
+                    ((ProcessImpl)leader).terminateProcessGroup(force);
+                }
+            }
+        );
+    }
 
     /**
      * Default constructor for Process.

--- a/src/java.base/unix/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/unix/classes/java/lang/ProcessImpl.java
@@ -47,8 +47,6 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
-//SapMachine 2024-07-01: process group extension
-import jdk.internal.access.JavaLangProcessAccess;
 import jdk.internal.util.OperatingSystem;
 import jdk.internal.util.StaticProperty;
 import sun.security.action.GetPropertyAction;
@@ -576,7 +574,7 @@ final class ProcessImpl extends Process {
     // SapMachine 2024-07-01: process group extension
     private static native int terminateProcessGroup(long pid, boolean force);
 
-    private void terminateProcessGroup(boolean force) throws IOException {
+    void terminateProcessGroup(boolean force) throws IOException {
         int rc = terminateProcessGroup(pid, force);
         if (rc != 0) {
             throw new IOException("Failed to kill process group (errno = " + rc + ")");
@@ -585,15 +583,6 @@ final class ProcessImpl extends Process {
 
     static {
         init();
-        // SapMachine 2024-07-01: process group extension
-        SharedSecrets.setJavaLangProcessAccess(
-            new JavaLangProcessAccess() {
-                @Override
-                public void destroyProcessGroup(Process leader, boolean force) throws IOException {
-                    ((ProcessImpl)leader).terminateProcessGroup(force);
-                }
-            }
-        );
     }
 
     /**

--- a/src/java.base/windows/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/windows/classes/java/lang/ProcessImpl.java
@@ -45,8 +45,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
-//SapMachine 2024-07-01: process group extension
-import jdk.internal.access.JavaLangProcessAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.misc.Blocker;
@@ -62,18 +60,6 @@ import sun.security.action.GetPropertyAction;
 final class ProcessImpl extends Process {
     private static final JavaIOFileDescriptorAccess fdAccess
         = SharedSecrets.getJavaIOFileDescriptorAccess();
-
-    // SapMachine 2024-07-01: process group extension
-    static {
-        SharedSecrets.setJavaLangProcessAccess(
-            new JavaLangProcessAccess() {
-                @Override
-                public void destroyProcessGroup(Process leader, boolean force) {
-                    ((ProcessImpl)leader).terminateProcessGroup(force);
-                }
-            }
-        );
-    }
 
     // Windows platforms support a forcible kill signal.
     static final boolean SUPPORTS_NORMAL_TERMINATION = false;
@@ -679,7 +665,7 @@ final class ProcessImpl extends Process {
     // SapMachine 2024-07-01: process group extension
     private static native void terminateProcessGroup(long hJob);
 
-    private void terminateProcessGroup(boolean force) {
+    void terminateProcessGroup(boolean force) {
         if (hJob == 0) {
             destroy();
         } else {


### PR DESCRIPTION
(cherry picked from commit 32cfd1865848364f004da243636a3951c188754a)

fixes #1693
