### PR TITLE
Fix file socket transport test on Windows

### DIFF
--- a/test/jdk/com/sun/jdi/FileSocketTransportTest.java
+++ b/test/jdk/com/sun/jdi/FileSocketTransportTest.java
@@ -94,6 +94,16 @@ public class FileSocketTransportTest {
         }
 
         String socketName = "test.socket";
+        if (Platform.isWindows()) {
+            UnixDomainSocketAddress addr = UnixDomainSocketAddress.of(socketName);
+
+            try {
+                SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+            } catch (UnsupportedOperationException e) {
+                // Windows version is too old to support unix domain sockets.
+                return;
+            }
+        }
 
         List<String> opts = new ArrayList<>();
         opts.add("-agentlib:jdwp=transport=dt_filesocket,address=" +

--- a/test/jdk/com/sun/jdi/FileSocketTransportTest.java
+++ b/test/jdk/com/sun/jdi/FileSocketTransportTest.java
@@ -95,9 +95,9 @@ public class FileSocketTransportTest {
 
         if (Platform.isWindows()) {
             try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
-                // Just see if we can create an unix domain socket on Windows.
+                // Just see if we can create a unix domain socket on Windows.
             } catch (UnsupportedOperationException e) {
-                // Windows version is too old to support unix domain sockets.
+                System.out.println("Windows version is too old to support unix domain sockets.");
                 return;
             }
         }

--- a/test/jdk/com/sun/jdi/FileSocketTransportTest.java
+++ b/test/jdk/com/sun/jdi/FileSocketTransportTest.java
@@ -93,17 +93,16 @@ public class FileSocketTransportTest {
             System.exit(1);
         }
 
-        String socketName = "test.socket";
         if (Platform.isWindows()) {
-            UnixDomainSocketAddress addr = UnixDomainSocketAddress.of(socketName);
-
-            try {
-                SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+            try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+                // Just see if we can create an unix domain socket on Windows.
             } catch (UnsupportedOperationException e) {
                 // Windows version is too old to support unix domain sockets.
                 return;
             }
         }
+
+        String socketName = "test.socket";
 
         List<String> opts = new ArrayList<>();
         opts.add("-agentlib:jdwp=transport=dt_filesocket,address=" +


### PR DESCRIPTION
This will not run the FileSocketTransportTest on Windows versions which don't support Unix Domain Sockets.

fixes #1690

