### PR TITLE
SapMachine (17): Cherry-pick 8329109: Threads::print_on() tries to print CPU time for terminated GC threads

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3589,7 +3589,6 @@ void Threads::add(JavaThread* p, bool force_daemon) {
   p->set_on_thread_list();
 
   _number_of_threads++;
-
   oop threadObj = p->threadObj();
   bool daemon = true;
   // Bootstrapping problem: threadObj can be null for initial
@@ -3863,30 +3862,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   }
 
   PrintOnClosure cl(st);
-  cl.do_thread(VMThread::vm_thread());
-  Universe::heap()->gc_threads_do(&cl);
-  if (StringDedup::is_enabled()) {
-    StringDedup::threads_do(&cl);
-  }
-  cl.do_thread(WatcherThread::watcher_thread());
-  cl.do_thread(AsyncLogWriter::instance());
-
-  // SapMachine 2019-11-07: Vitals
-  const Thread* vitals_sampler_thread = sapmachine_vitals::samplerthread();
-  if (vitals_sampler_thread != NULL) {
-    vitals_sampler_thread->print_on(st);
-    st->cr();
-  }
-
-#ifdef LINUX
-  // SapMachine 2022-05-07: HiMemReport
-  const Thread* himem_reporter_thread = sapmachine_vitals::himem_reporter_thread();
-  if (himem_reporter_thread != NULL) {
-    himem_reporter_thread->print_on(st);
-    st->cr();
-  }
-#endif
-
+  non_java_threads_do(&cl);
   st->flush();
 }
 


### PR DESCRIPTION
We want to cherry-pick the backport of [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109) for the July CPU. Due to SapMachine diffs, the upstream patch did not apply cleanly, I had to massage it.

fixes #1502
