### PR TITLE
SapMachine (23 )#1550: Disable use of backtrace() on PPC platforms by default

### DIFF
--- a/src/hotspot/os/posix/malloctrace/mallocTracePosix.cpp
+++ b/src/hotspot/os/posix/malloctrace/mallocTracePosix.cpp
@@ -2449,6 +2449,7 @@ public:
 void MallocTraceEnablePeriodicTask::task() {
   enable_from_flags();
   enable_delayed_dump();
+  disenroll();
 }
 
 } // namespace mallocStatImpl

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -578,7 +578,7 @@ const int ObjectAlignmentInBytes = 8;
           "malloc trace if enabled at startup.")                            \
           range(1, 1000)                                                    \
                                                                             \
-  product(bool, MallocTraceUseBacktrace, true,                              \
+  product(bool, MallocTraceUseBacktrace, PPC_ONLY(false) NOT_PPC(true),     \
           "If set we use the backtrace() call to sample the stacks of "     \
           "the malloc trace if enabled at startup. Note that while this "   \
           "creates better stack traces, it is also slower and not "         \


### PR DESCRIPTION
Also add a missing disenroll() call to the delayed enabling task.

(cherry picked from commit fe527476e3346d0a845987aa33a725f14c7d9e1a)

fixes #1550
