### PR TITLE
Build jdksapext lib(dll) also on Windows

### DIFF
--- a/make/modules/jdk.sapext/Lib.gmk
+++ b/make/modules/jdk.sapext/Lib.gmk
@@ -25,15 +25,13 @@
 
 include LibCommon.gmk
 
-ifeq ($(call isTargetOsType, unix), true)
-  ##############################################################################
-  ## Build libjdksapext
-  ##############################################################################
+##############################################################################
+## Build libjdksapext
+##############################################################################
 
-  $(eval $(call SetupJdkLibrary, BUILD_LIBJDKSAPEXT, \
-      NAME := jdksapext, \
-      OPTIMIZATION := LOW, \
-  ))
+$(eval $(call SetupJdkLibrary, BUILD_LIBJDKSAPEXT, \
+    NAME := jdksapext, \
+    OPTIMIZATION := LOW, \
+))
 
-  TARGETS += $(BUILD_LIBJDKSAPEXT)
-endif
+TARGETS += $(BUILD_LIBJDKSAPEXT)


### PR DESCRIPTION
Build the jdksapext lib not on Unix only.

fixes #1787 

