### PR TITLE
SapMachine (21) #1787: Build jdksapext lib(dll) also on Windows

### DIFF
--- a/make/modules/jdk.sapext/Lib.gmk
+++ b/make/modules/jdk.sapext/Lib.gmk
@@ -25,18 +25,16 @@
 
 include LibCommon.gmk
 
-ifeq ($(call isTargetOsType, unix), true)
-  ##############################################################################
-  ## Build libjdksapext
-  ##############################################################################
+##############################################################################
+## Build libjdksapext
+##############################################################################
 
-  $(eval $(call SetupJdkLibrary, BUILD_LIBJDKSAPEXT, \
-      NAME := jdksapext, \
-      OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB), \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
-  ))
+$(eval $(call SetupJdkLibrary, BUILD_LIBJDKSAPEXT, \
+    NAME := jdksapext, \
+    OPTIMIZATION := LOW, \
+    CFLAGS := $(CFLAGS_JDKLIB), \
+    LDFLAGS := $(LDFLAGS_JDKLIB) \
+        $(call SET_SHARED_LIBRARY_ORIGIN), \
+))
 
-  TARGETS += $(BUILD_LIBJDKSAPEXT)
-endif
+TARGETS += $(BUILD_LIBJDKSAPEXT)


### PR DESCRIPTION
Cherry picked from commit 0e9a934ff0da3171d8270426ea195b7407ea4b5c, I had to make some adaptions because the code in sapmachine21 differs slightly.

fixes #1787
