### PR TITLE
Updates to sapmachine.io landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: SapMachine
 email: sapmachine@sap.com
 description: >- # this means to ignore newlines until "baseurl:"
-  An OpenJDK release maintained and supported by SAP
+  The OpenJDK release maintained and supported by SAP
 twitter_username: SweetSapMachine
 github_username:  SapMachine
 

--- a/index.md
+++ b/index.md
@@ -3,28 +3,18 @@ layout: default
 title: SapMachine
 ---
 
-<img align="right" width="350" src="assets/images/logo_circular.svg">
+**SapMachine** is a free, open-source, non-commercial, cross-platform, and fully-functional production-grade version of the Open Java Development Kit (OpenJDK).
+Built and supported by SAP, it provides a robust and reliable Java environment.
 
-# SapMachine
-This project contains a downstream version of the [OpenJDK](http://openjdk.java.net/) project. It is used to build and maintain a SAP supported version of OpenJDK for SAP customers and partners who wish to use OpenJDK to run their applications.
+<img align="left" width="240" src="assets/images/logo_circular.svg" alt="Logo of SapMachine">
 
-We want to stress that this is clearly a "*friendly fork*". SAP is committed to ensuring the continued success of the Java platform. SAP is: 
+Following the release cadence of the OpenJDK, a new feature release is shipped every six months, with one designated as a long-term support release every two years.
+Update releases for active versions are provided every quarter. So SapMachine offers long-term support, regular performance improvements and timely security updates.
 
-* A member of the [JCP Executive committee](https://jcp.org/en/participation/committee) since 2001 and recently served in the [JSR 379 (Java SE 9)](https://www.jcp.org/en/jsr/detail?id=379), [JSR 383 (Java SE 18.3)](https://www.jcp.org/en/jsr/detail?id=383), [JSR 384 (Java SE 11)](https://www.jcp.org/en/jsr/detail?id=384), [JSR 386 (Java SE 12)](https://www.jcp.org/en/jsr/detail?id=386), [JSR 388 (Java SE 13)](https://www.jcp.org/en/jsr/detail?id=388), [JSR 389 (Java SE 14)](https://www.jcp.org/en/jsr/detail?id=389), [JSR 390 (Java SE 15)](https://www.jcp.org/en/jsr/detail?id=390), [JSR 391 (Java SE 16)](https://www.jcp.org/en/jsr/detail?id=391), [JSR 392 (Java SE 17)](https://www.jcp.org/en/jsr/detail?id=392), [JSR 393 (Java SE 18)](https://www.jcp.org/en/jsr/detail?id=393), [JSR 394 (Java SE 19)](https://www.jcp.org/en/jsr/detail?id=394), [JSR 395 (Java SE 20)](https://www.jcp.org/en/jsr/detail?id=395), [JSR 396 (Java SE 21)](https://www.jcp.org/en/jsr/detail?id=396) and [JSR 397 (Java SE 22)](https://www.jcp.org/en/jsr/detail?id=397) Expert Groups.
+For SAP, the default JDK is SapMachine. It is the engine of countless applications and services, in cloud deployments as well as standalone on-premise installations at both, SAP and its customers.
 
-* Among the biggest external contributors to the OpenJDK project (see fix ratio for OpenJDK [11](https://blogs.oracle.com/java-platform-group/building-jdk-11-together), [12](https://blogs.oracle.com/java-platform-group/the-arrival-of-java-12), [13](https://blogs.oracle.com/java-platform-group/the-arrival-of-java-13), [14](https://blogs.oracle.com/java-platform-group/the-arrival-of-java-14), [15](https://blogs.oracle.com/java-platform-group/the-arrival-of-java-15), [16](https://inside.java/2021/03/16/the-arrival-of-java16/), [17](https://inside.java/2021/09/14/the-arrival-of-java17/), [18](https://inside.java/2022/03/22/the-arrival-of-java18/), [19](https://inside.java/2022/09/20/the-arrival-of-java-19/), [20](https://inside.java/2023/03/21/the-arrival-of-java-20/), [21](https://inside.java/2023/09/19/the-arrival-of-java-21/), [22](https://inside.java/2024/03/19/the-arrival-of-java-22/)).
-
-* Leading the [OpenJDK 17 updates project](https://wiki.openjdk.java.net/display/JDKUpdates/JDK+17u) and heavily supporting the [OpenJDK 11](https://wiki.openjdk.java.net/display/JDKUpdates/JDK11u) and [OpenJDK 21](https://wiki.openjdk.java.net/display/JDKUpdates/JDK+21u) updates projects.
-
-* Leading the [PowerPC/AIX porting project](http://openjdk.java.net/projects/ppc-aix-port/).
-
-* Contributing many new features inspired by Java stakeholders within SAP to the OpenJDK project. This ensures such features are available in long reach and for everybody. Rarely we add such features to SapMachine directly to keep the diff of this project as small as possible. 
-
-* Creating tools for developers
-    * [JFR Event Collection](https://sapmachine.io/jfrevents/): Information on all JFR events for a specific JDK
-    * [AP-Loader](https://github.com/jvm-profiling-tools/ap-loader): AsyncProfiler in a single cross-platform JAR
-* [Blogging](https://github.com/SAP/SapMachine/wiki/Blogs) and [Presenting](https://github.com/SAP/SapMachine/wiki/Presentations) at Java conferences all over the globe 
-    
+SapMachine is available on a variety of Operating System/CPU architecture combinations, and it is certified to adhere to the Java SE standard.
+It can serve as a drop-in replacement for any JDK in Java-based applications, ranging from small desktop applications to high-performance, large-scale server applications.
 
 ## Download
 
@@ -48,28 +38,29 @@ We want to stress that this is clearly a "*friendly fork*". SAP is committed to 
 </div>
 
 <div class="download_filter">
-  <input type="checkbox" id="sapmachine_lts_checkbox" name="lts"
-         checked>
+  <input type="checkbox" id="sapmachine_lts_checkbox" name="lts" checked>
   <label for="lts">Long Term Support Releases (LTS)</label>
 
-  <input type="checkbox" id="sapmachine_nonlts_checkbox" name="nonlts"
-         checked>
+  <input type="checkbox" id="sapmachine_nonlts_checkbox" name="nonlts" checked>
   <label for="nonlts">Short Term Support Releases</label>
 
   <input type="checkbox" id="sapmachine_ea_checkbox" name="ea">
   <label for="ea">Pre-Releases</label>
 </div>
 
-## Releases
-
-SapMachine follows the generic release strategy of OpenJDK with Long Term Support (LTS) releases and updates every three months.  Details can be found on the [Maintenance and Support](https://github.com/SAP/SapMachine/wiki/Maintenance-and-Support) page.
-All [releases](https://github.com/SAP/SapMachine/releases), including nightly snapshots, are available on GitHub.
-The latest release for any SapMachine major version can be found at `https://sap.github.io/SapMachine/latest/#MAJOR` (e.g. [SapMachine 21](latest/21)). A description how to directly download the latest stable version of SapMachine for your OS-architecture can be found in the FAQ [Is-there-a-fix-link-to-download-the-latest-stable-version-of-SapMachine](https://github.com/SAP/SapMachine/wiki/Frequently-Asked-Questions#Is-there-a-fix-link-to-download-the-latest-stable-version-of-SapMachine).
-
 ## Documentation
+
 Check out our [FAQ's](https://github.com/SAP/SapMachine/wiki/Frequently-Asked-Questions) and [wikipages](https://github.com/SAP/SapMachine/wiki) for information about:
+
 * [Installation](https://github.com/SAP/SapMachine/wiki/Installation) and [Docker Images](https://github.com/SAP/SapMachine/wiki/Docker-Images)
 * [Certifications and Java Compatibility](https://github.com/SAP/SapMachine/wiki/Certification-and-Java-Compatibility)
+* [Features contributed by SAP to OpenJDK](https://github.com/SAP/SapMachine/wiki/Features-Contributed-by-SAP)
+* [Differences between SapMachine and OpenJDK](https://github.com/SAP/SapMachine/wiki/Differences-between-SapMachine-and-OpenJDK).
 
 ## License
-This project is run under the same licensing terms as the upstream OpenJDK project. Please see the [LICENSE](https://github.com/SAP/SapMachine/blob/sapmachine/LICENSE) file in the top-level directory for more information.
+
+This project is OpenSource and as an OpenJDK-distribution, SapMachine is free to use for everyone accepting the [GPLv2 license](https://github.com/SAP/SapMachine/blob/sapmachine/LICENSE).
+
+<hr>
+
+2017-2024 by [SAP SE](https://www.sap.com)


### PR DESCRIPTION
The sapmachine.io landing page should be cleaned up and improved a little bit which includes removing important information bloat and should move the download section more upwards.