### PR TITLE
SapMachine #1823: Import async-profiler: Codesign binaries on macOS and cleanups

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -303,22 +303,22 @@ ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+tr
 
     ifneq ($(MACOSX_CODESIGN_MODE), disabled)
       codesign_async_profiler_jdk: $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK)
-          $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
-          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
-          $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
-          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	      $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
+	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
+	      $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
 
       codesign_async_profiler_jre: $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE)
-          $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
-          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
-          $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
-          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	      $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
+	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
+	      $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
     else
       codesign_async_profiler_jdk:
-          $(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+	      $(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
 
       codesign_async_profiler_jre:
-          $(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+	      $(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
     endif
 
     JDK_TARGETS += codesign_async_profiler_jdk

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -250,90 +250,80 @@ endif
 # SapMachine 2024-09-13: import async profiler binaries
 ################################################################################
 # Async profiler import
-# we can reference into the workspace where we download the async profiler;
-# this has to be set via configure
-ifeq ($(ASYNC_PROFILER_IMPORT_ENABLED), true)
-ifeq ($(call isTargetOs, linux macosx), true)
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JDK, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
-    DEST := $(JDK_IMAGE_DIR)/bin, \
-    FILES := asprof, \
-))
+ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+true)
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JRE, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
-    DEST := $(JRE_IMAGE_DIR)/bin, \
-    FILES := asprof, \
-))
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JDK, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
+      DEST := $(JDK_IMAGE_DIR)/bin, \
+      FILES := asprof, \
+  ))
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JDK, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
-    DEST := $(JDK_IMAGE_DIR)/lib, \
-    FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
-))
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JRE, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
+      DEST := $(JRE_IMAGE_DIR)/bin, \
+      FILES := asprof, \
+  ))
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JRE, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
-    DEST := $(JRE_IMAGE_DIR)/lib, \
-    FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
-))
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JDK, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
+      DEST := $(JDK_IMAGE_DIR)/lib, \
+      FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+  ))
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JDK, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
-    DEST := $(JDK_IMAGE_DIR)/legal/async, \
-    FILES := CHANGELOG.md LICENSE README.md, \
-))
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JRE, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
+      DEST := $(JRE_IMAGE_DIR)/lib, \
+      FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+  ))
 
-$(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JRE, \
-    SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
-    DEST := $(JRE_IMAGE_DIR)/legal/async, \
-    FILES := CHANGELOG.md LICENSE README.md, \
-))
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JDK, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
+      DEST := $(JDK_IMAGE_DIR)/legal/async, \
+      FILES := CHANGELOG.md LICENSE README.md, \
+  ))
 
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JRE, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
+      DEST := $(JRE_IMAGE_DIR)/legal/async, \
+      FILES := CHANGELOG.md LICENSE README.md, \
+  ))
 
-JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
-JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
+  JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
+  JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
 
-# SapMachine 2024-09-24: sign async profiler binaries on macOS
-ifeq ($(call isTargetOs, macosx), true)
-# for now we reference the default / default-debug plist entitlements file; maybe asprof needs something special ?
-ifeq ($(MACOSX_CODESIGN_MODE), hardened)
-  CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
-  ASYNC_CODESIGN=true
-  PLIST_FILE=default.plist
-endif
-ifeq ($(MACOSX_CODESIGN_MODE), debug)
-  CODESIGN_APOPTS=-f -s -
-  ASYNC_CODESIGN=true
-  PLIST_FILE=default-debug.plist
-endif
+  ifeq ($(call isTargetOs, macosx), true)
+    ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+      CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
+      PLIST_FILE=default.plist
+    else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+      CODESIGN_APOPTS=-f -s -
+      PLIST_FILE=default-debug.plist
+    endif
 
-ifeq ($(ASYNC_CODESIGN), true)
-codesign_async_profiler_jdk: $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK)
-	$(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
-	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
-	$(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
-	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+    ifneq ($(MACOSX_CODESIGN_MODE), disabled)
+      codesign_async_profiler_jdk: $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK)
+          $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
+          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
+          $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
 
-codesign_async_profiler_jre: $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE)
-	$(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
-	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
-	$(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
-	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
-else
-codesign_async_profiler_jdk:
-	$(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+      codesign_async_profiler_jre: $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE)
+          $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
+          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
+          $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+          $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+    else
+      codesign_async_profiler_jdk:
+          $(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
 
-codesign_async_profiler_jre:
-	$(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
-endif
+      codesign_async_profiler_jre:
+          $(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+    endif
 
-JDK_TARGETS += codesign_async_profiler_jdk
-JRE_TARGETS += codesign_async_profiler_jre
-endif
-
-endif
+    JDK_TARGETS += codesign_async_profiler_jdk
+    JRE_TARGETS += codesign_async_profiler_jre
+  endif
 endif
 
 ################################################################################

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -247,9 +247,8 @@ ifeq ($(GCOV_ENABLED), true)
 
 endif
 
-# SapMachine 2024-09-13: import async profiler binaries
 ################################################################################
-# Async profiler import
+# SapMachine 2024-09-13: Async profiler import
 
 ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+true)
 
@@ -267,32 +266,20 @@ ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+tr
       MACRO := install-file-and-sign, \
   ))
 
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_JARS_TO_JDK, \
-      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
-      DEST := $(JDK_IMAGE_DIR)/lib, \
-      FILES := async-profiler.jar converter.jar, \
-  ))
-
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_JARS_TO_JRE, \
-      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
-      DEST := $(JRE_IMAGE_DIR)/lib, \
-      FILES := async-profiler.jar converter.jar, \
-  ))
-
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JDK, \
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_TO_JDK, \
       SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
-      DEST := $(JDK_IMAGE_DIR)/legal/async, \
-      FILES := CHANGELOG.md LICENSE README.md, \
+      DEST := $(JDK_IMAGE_DIR), \
+      FILES := lib/async-profiler.jar lib/converter.jar legal/async/CHANGELOG.md legal/async/LICENSE legal/async/README.md, \
   ))
 
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JRE, \
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_TO_JRE, \
       SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
-      DEST := $(JRE_IMAGE_DIR)/legal/async, \
-      FILES := CHANGELOG.md LICENSE README.md, \
+      DEST := $(JRE_IMAGE_DIR), \
+      FILES := lib/async-profiler.jar lin/converter.jar legal/async/CHANGELOG.md legal/async/LICENSE legal/async/README.md, \
   ))
 
-  JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_JARS_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
-  JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_JARS_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
+  JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_TO_JDK)
+  JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_TO_JRE)
 endif
 
 ################################################################################

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -254,27 +254,29 @@ endif
 ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+true)
 
   $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JDK, \
-      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
-      DEST := $(JDK_IMAGE_DIR)/bin, \
-      FILES := asprof, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
+      DEST := $(JDK_IMAGE_DIR), \
+      FILES := bin/asprof lib/libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+      MACRO := install-file-and-sign, \
   ))
 
   $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_BIN_TO_JRE, \
-      SRC := $(ASYNC_PROFILER_IMPORT_PATH)/bin, \
-      DEST := $(JRE_IMAGE_DIR)/bin, \
-      FILES := asprof, \
+      SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
+      DEST := $(JRE_IMAGE_DIR), \
+      FILES := bin/asprof lib/libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+      MACRO := install-file-and-sign, \
   ))
 
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JDK, \
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_JARS_TO_JDK, \
       SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
       DEST := $(JDK_IMAGE_DIR)/lib, \
-      FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+      FILES := async-profiler.jar converter.jar, \
   ))
 
-  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LIB_TO_JRE, \
+  $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_JARS_TO_JRE, \
       SRC := $(ASYNC_PROFILER_IMPORT_PATH)/lib, \
       DEST := $(JRE_IMAGE_DIR)/lib, \
-      FILES := async-profiler.jar converter.jar libasyncProfiler$(SHARED_LIBRARY_SUFFIX), \
+      FILES := async-profiler.jar converter.jar, \
   ))
 
   $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JDK, \
@@ -289,41 +291,8 @@ ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+tr
       FILES := CHANGELOG.md LICENSE README.md, \
   ))
 
-  JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
-  JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
-
-  ifeq ($(call isTargetOs, macosx), true)
-    ifeq ($(MACOSX_CODESIGN_MODE), hardened)
-      CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
-      PLIST_FILE=default.plist
-    else ifeq ($(MACOSX_CODESIGN_MODE), debug)
-      CODESIGN_APOPTS=-f -s -
-      PLIST_FILE=default-debug.plist
-    endif
-
-    ifneq ($(MACOSX_CODESIGN_MODE), disabled)
-      codesign_async_profiler_jdk: $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK)
-	      $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
-	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
-	      $(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
-	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
-
-      codesign_async_profiler_jre: $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE)
-	      $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
-	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
-	      $(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
-	      $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
-    else
-      codesign_async_profiler_jdk:
-	      $(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
-
-      codesign_async_profiler_jre:
-	      $(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
-    endif
-
-    JDK_TARGETS += codesign_async_profiler_jdk
-    JRE_TARGETS += codesign_async_profiler_jre
-  endif
+  JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_JARS_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
+  JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_JARS_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
 endif
 
 ################################################################################

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -275,7 +275,7 @@ ifeq ($(call isTargetOs, linux macosx)+$(ASYNC_PROFILER_IMPORT_ENABLED), true+tr
   $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_TO_JRE, \
       SRC := $(ASYNC_PROFILER_IMPORT_PATH), \
       DEST := $(JRE_IMAGE_DIR), \
-      FILES := lib/async-profiler.jar lin/converter.jar legal/async/CHANGELOG.md legal/async/LICENSE legal/async/README.md, \
+      FILES := lib/async-profiler.jar lib/converter.jar legal/async/CHANGELOG.md legal/async/LICENSE legal/async/README.md, \
   ))
 
   JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_TO_JDK)

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -295,6 +295,44 @@ $(eval $(call SetupCopyFiles, COPY_ASYNC_PROFILER_LEGAL_TO_JRE, \
 JDK_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK) $(COPY_ASYNC_PROFILER_LEGAL_TO_JDK)
 JRE_TARGETS += $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE) $(COPY_ASYNC_PROFILER_LEGAL_TO_JRE)
 
+# SapMachine 2024-09-24: sign async profiler binaries on macOS
+ifeq ($(call isTargetOs, macosx), true)
+# for now we reference the default / default-debug plist entitlements file; maybe asprof needs something special ?
+ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+  CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
+  ASYNC_CODESIGN=true
+  PLIST_FILE=default.plist
+endif
+ifeq ($(MACOSX_CODESIGN_MODE), debug)
+  CODESIGN_APOPTS=-f -s -
+  ASYNC_CODESIGN=true
+  PLIST_FILE=default-debug.plist
+endif
+
+ifeq ($(ASYNC_CODESIGN), true)
+codesign_async_profiler_jdk: $(COPY_ASYNC_PROFILER_BIN_TO_JDK) $(COPY_ASYNC_PROFILER_LIB_TO_JDK)
+	$(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/bin/asprof
+	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/bin/asprof
+	$(CODESIGN) --remove-signature $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JDK_IMAGE_DIR)/lib/libasyncProfiler.dylib
+
+codesign_async_profiler_jre: $(COPY_ASYNC_PROFILER_BIN_TO_JRE) $(COPY_ASYNC_PROFILER_LIB_TO_JRE)
+	$(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/bin/asprof
+	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/bin/asprof
+	$(CODESIGN) --remove-signature $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+	$(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) $(JRE_IMAGE_DIR)/lib/libasyncProfiler.dylib
+else
+codesign_async_profiler_jdk:
+	$(ECHO) No JDK Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+
+codesign_async_profiler_jre:
+	$(ECHO) No JRE Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+endif
+
+JDK_TARGETS += codesign_async_profiler_jdk
+JRE_TARGETS += codesign_async_profiler_jre
+endif
+
 endif
 endif
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -228,11 +228,11 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
       [Set import path for downloaded async profiler binaries])])
   if test "x$with_async_profiler_import_path" != x; then
     ASYNC_PROFILER_IMPORT_PATH="$with_async_profiler_import_path"
-    if test -f "$ASYNC_PROFILER_IMPORT_PATH/LICENSE"; then
+    if test -f "$ASYNC_PROFILER_IMPORT_PATH/bin/asprof"; then
       ASYNC_PROFILER_IMPORT_ENABLED=true
-      AC_MSG_NOTICE([LICENSE file exists, enabling async-profiler import])
+      AC_MSG_NOTICE([asprof exists, enabling async-profiler import])
     else
-      AC_MSG_ERROR([Async profiler import path was set, but LICENSE file not found there])
+      AC_MSG_ERROR([async-profiler import path was set, but asprof was not found])
     fi
   fi
   AC_SUBST(ASYNC_PROFILER_IMPORT_PATH)

--- a/make/common/FileUtils.gmk
+++ b/make/common/FileUtils.gmk
@@ -150,29 +150,18 @@ ifeq ($(call isTargetOs, macosx), true)
     PLIST_FILE=default-debug.plist
   endif
 
-  define install-file-and-sign
-	$(call MakeTargetDir)
-	$(RM) '$(call DecodeSpace, $@)'
-        # Work around a weirdness with cp on Macosx. When copying a symlink, if
-        # the target of the link is write protected (e.g. 444), cp will add
-        # write permission for the user on the target file (644). Avoid this by
-        # using ln to create a new link instead.
-	if [ -h '$(call DecodeSpace, $<)' ]; then \
-	  $(LN) -s "`$(READLINK) '$(call DecodeSpace, $<)'`" '$(call DecodeSpace, $@)'; \
-	else \
-	  $(CP) -fRP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
-	fi
-	if [ -n "`$(XATTR) -ls '$(call DecodeSpace, $@)'`" ]; then \
-          $(CHMOD) u+w '$(call DecodeSpace, $@)'; \
-	  $(XATTR) -cs '$(call DecodeSpace, $@)'; \
-	fi
-    ifeq ($(MACOSX_CODESIGN_MODE), disabled)
+  ifeq ($(MACOSX_CODESIGN_MODE), disabled)
+    define install-file-and-sign
+	  $(install-file)
 	  $(ECHO) No Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
-    else
+    endef
+  else
+    define install-file-and-sign
+	  $(install-file)
 	  $(CODESIGN) --remove-signature '$(call DecodeSpace, $@)'
 	  $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) '$(call DecodeSpace, $@)'
-    endif
-  endef
+    endef
+  endif
 else
   define install-file
 	$(call MakeTargetDir)
@@ -180,8 +169,7 @@ else
   endef
   # SapMachine 2024-09-13: import async profiler binaries
   define install-file-and-sign
-	$(call MakeTargetDir)
-	$(CP) -fP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
+	$(install-file)
   endef
 endif
 

--- a/make/common/FileUtils.gmk
+++ b/make/common/FileUtils.gmk
@@ -140,8 +140,46 @@ ifeq ($(call isTargetOs, macosx), true)
 	  $(XATTR) -cs '$(call DecodeSpace, $@)'; \
 	fi
   endef
+
+  # SapMachine 2024-09-13: import async profiler binaries
+  ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+    CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
+    PLIST_FILE=default.plist
+  else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+    CODESIGN_APOPTS=-f -s -
+    PLIST_FILE=default-debug.plist
+  endif
+
+  define install-file-and-sign
+	$(call MakeTargetDir)
+	$(RM) '$(call DecodeSpace, $@)'
+        # Work around a weirdness with cp on Macosx. When copying a symlink, if
+        # the target of the link is write protected (e.g. 444), cp will add
+        # write permission for the user on the target file (644). Avoid this by
+        # using ln to create a new link instead.
+	if [ -h '$(call DecodeSpace, $<)' ]; then \
+	  $(LN) -s "`$(READLINK) '$(call DecodeSpace, $<)'`" '$(call DecodeSpace, $@)'; \
+	else \
+	  $(CP) -fRP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
+	fi
+	if [ -n "`$(XATTR) -ls '$(call DecodeSpace, $@)'`" ]; then \
+          $(CHMOD) u+w '$(call DecodeSpace, $@)'; \
+	  $(XATTR) -cs '$(call DecodeSpace, $@)'; \
+	fi
+    ifeq ($(MACOSX_CODESIGN_MODE), disabled)
+	  $(ECHO) No Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
+    else
+	  $(CODESIGN) --remove-signature '$(call DecodeSpace, $@)'
+	  $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) '$(call DecodeSpace, $@)'
+    endif
+  endef
 else
   define install-file
+	$(call MakeTargetDir)
+	$(CP) -fP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
+  endef
+  # SapMachine 2024-09-13: import async profiler binaries
+  define install-file-and-sign
 	$(call MakeTargetDir)
 	$(CP) -fP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
   endef

--- a/make/common/FileUtils.gmk
+++ b/make/common/FileUtils.gmk
@@ -142,24 +142,22 @@ ifeq ($(call isTargetOs, macosx), true)
   endef
 
   # SapMachine 2024-09-13: import async profiler binaries
-  ifeq ($(MACOSX_CODESIGN_MODE), hardened)
-    CODESIGN_APOPTS=-f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
-    PLIST_FILE=default.plist
-  else ifeq ($(MACOSX_CODESIGN_MODE), debug)
-    CODESIGN_APOPTS=-f -s -
-    PLIST_FILE=default-debug.plist
-  endif
-
   ifeq ($(MACOSX_CODESIGN_MODE), disabled)
     define install-file-and-sign
 	  $(install-file)
 	  $(ECHO) No Async profiler codesigning, codesign mode is $(MACOSX_CODESIGN_MODE)
     endef
   else
+    ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+      CODESIGN_APOPTS="$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime
+    else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+      CODESIGN_APOPTS=-
+      PLIST_APOPT=-debug
+    endif
     define install-file-and-sign
 	  $(install-file)
 	  $(CODESIGN) --remove-signature '$(call DecodeSpace, $@)'
-	  $(CODESIGN) $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/$(PLIST_FILE) '$(call DecodeSpace, $@)'
+	  $(CODESIGN) -f -s $(CODESIGN_APOPTS) --entitlements $(TOPDIR)/make/data/macosxsigning/default$(PLIST_APOPT).plist '$(call DecodeSpace, $@)'
     endef
   endif
 else


### PR DESCRIPTION
https://github.com/SAP/SapMachine/commit/06f965bc6f0407f9a2094e507b9ffe9405e5992d added the option to import previously downloaded async-profiler binaries. However on macOS they miss signing so we add this. The default / default-debug plist entitlements files are used for now.

fixes #1823
