### PR TITLE
SapMachine #1823: Fix some tools tests after adding asprof

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -63,6 +63,8 @@ tier1_part3 = \
 # SapMachine 2019-01-24: Add tests where SAPMachine has different behavior to tier1
 tier1_sapmachine = \
     java/net/Socket/ExceptionText.java \
+    tools/launcher/VersionCheck.java \
+    tools/launcher/HelpFlagsTest.java \
     java/util/jar/Manifest/IncludeInExceptionsTest.java \
     jdk/security/JavaDotSecurity/TestJDKIncludeInExceptions.java \
     sun/net/www/http/KeepAliveCache/TestConnectionIDFeature.java \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -61,15 +61,14 @@ tier1_part3 = \
     sun/nio/cs/ISO8859x.java
 
 # SapMachine 2019-01-24: Add tests where SAPMachine has different behavior to tier1
-# SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags; affects tools/launcher
 tier1_sapmachine = \
     java/net/Socket/ExceptionText.java \
-    tools/launcher/VersionCheck.java \
-    tools/launcher/HelpFlagsTest.java \
     java/util/jar/Manifest/IncludeInExceptionsTest.java \
     jdk/security/JavaDotSecurity/TestJDKIncludeInExceptions.java \
     sun/net/www/http/KeepAliveCache/TestConnectionIDFeature.java \
-    sun/security/lib/cacerts/VerifyCACerts.java
+    sun/security/lib/cacerts/VerifyCACerts.java \
+    tools/launcher/HelpFlagsTest.java \
+    tools/launcher/VersionCheck.java
 
 # When adding tests to tier2, make sure they end up in one of the tier2_partX groups
 tier2 = \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -61,6 +61,7 @@ tier1_part3 = \
     sun/nio/cs/ISO8859x.java
 
 # SapMachine 2019-01-24: Add tests where SAPMachine has different behavior to tier1
+# SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags; affects tools/launcher
 tier1_sapmachine = \
     java/net/Socket/ExceptionText.java \
     tools/launcher/VersionCheck.java \

--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -64,7 +64,9 @@ public class HelpFlagsTest extends TestHelper {
         "jmc",
         "jweblauncher",
         "jcontrol",
-        "ssvagent"
+        "ssvagent",
+        // SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags
+        "asprof"
     };
 
     // Lists which tools support which flags.

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -43,6 +43,7 @@ import java.util.Set;
 public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
+    // SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags
     static final String[] BLACKLIST_JOPTION = {
         "controlpanel",
         "jabswitch",
@@ -62,7 +63,8 @@ public class VersionCheck extends TestHelper {
         "jweblauncher",
         "jpackage",
         "ssvagent",
-        "jwebserver"
+        "jwebserver",
+        "asprof"
     };
 
     // tools that do not accept -version
@@ -108,7 +110,8 @@ public class VersionCheck extends TestHelper {
         "rmiregistry",
         "serialver",
         "servertool",
-        "ssvagent"
+        "ssvagent",
+        "asprof"
     };
 
     // expected reference strings

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -43,7 +43,6 @@ import java.util.Set;
 public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
-    // SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags
     static final String[] BLACKLIST_JOPTION = {
         "controlpanel",
         "jabswitch",
@@ -64,6 +63,7 @@ public class VersionCheck extends TestHelper {
         "jpackage",
         "ssvagent",
         "jwebserver",
+        // SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags
         "asprof"
     };
 
@@ -111,6 +111,7 @@ public class VersionCheck extends TestHelper {
         "serialver",
         "servertool",
         "ssvagent",
+        // SapMachine 2024-10-07: asprof was added on some platforms but has different command line flags
         "asprof"
     };
 


### PR DESCRIPTION
The added import of async-profiler (asprof) broke some tests that check command line options of tools, but asprof is unknown to these tests.

fixes #1823
