### PR TITLE
FileSocketTransportTest fails in SapMachine17

### DIFF
--- a/test/jdk/com/sun/jdi/FileSocketTransportTest.java
+++ b/test/jdk/com/sun/jdi/FileSocketTransportTest.java
@@ -90,7 +90,7 @@ public class FileSocketTransportTest {
         opts.add("--sleep");
 
         // First check if we get the expected errors.
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 opts.toArray(new String[0]));
         Process proc = pb.start();
         new Thread(() -> {


### PR DESCRIPTION
Adjusts the FileSocketTransportTest  to the renaming of methods inthe ProcessTools class.

fixes #1886
