### PR TITLE
SapMachine (24): Backport of JDK-8346880: [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected"

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -162,7 +162,24 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 }
 
 pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {
-    return unix_getParentPidAndTimings(env, pid, total, start);
+    pid_t the_pid = pid;
+    struct procentry64 ProcessBuffer;
+
+    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1) <= 0) {
+        return -1;
+    }
+
+    // Validate the pid before returning the info
+    if (kill(pid, 0) < 0) {
+        return -1;
+    }
+
+    *total = ((ProcessBuffer.pi_ru.ru_utime.tv_sec + ProcessBuffer.pi_ru.ru_stime.tv_sec) * 1000000000L) +
+             ((ProcessBuffer.pi_ru.ru_utime.tv_usec + ProcessBuffer.pi_ru.ru_stime.tv_usec));
+
+    *start = ProcessBuffer.pi_start * (jlong)1000;
+
+    return (pid_t) ProcessBuffer.pi_ppid;
 }
 
 void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {


### PR DESCRIPTION
Backport-of: f9b11332eccd8a8ffb4128308f442b209d07a3b1

fixes #1502
