### PR TITLE
Don't use libc allocations directly in malloc trace

### DIFF
--- a/src/hotspot/os/posix/malloctrace/mallocTracePosix.cpp
+++ b/src/hotspot/os/posix/malloctrace/mallocTracePosix.cpp
@@ -40,10 +40,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 
-#if !defined(__APPLE__)
-#include <malloc.h>
-#endif
-
 // To test in jtreg tests use
 // JTREG="JAVA_OPTIONS=-XX:+UseMallocHooks -XX:+MallocTraceAtStartup -XX:MallocTraceDumpCount=10 -XX:MallocTraceDumpInterval=10s -XX:MallocTraceDumpDelay=10s -XX:MallocTraceDumpOutput=`pwd`/mtrace_@pid.txt -XX:ErrorFile=`pwd`/hs_err%p.log"
 
@@ -972,7 +968,7 @@ void* MallocStatisticImpl::malloc_hook(size_t size, void* caller_address) {
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, (address) malloc, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) malloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -990,7 +986,7 @@ void* MallocStatisticImpl::calloc_hook(size_t elems, size_t size, void* caller_a
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, (address) calloc, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) calloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -1028,7 +1024,7 @@ void* MallocStatisticImpl::realloc_hook(void* ptr, size_t size, void* caller_add
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, (address) realloc, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) realloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -1061,7 +1057,7 @@ int MallocStatisticImpl::posix_memalign_hook(void** ptr, size_t align, size_t si
 
   if ((result == 0) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, (address) posix_memalign, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) posix_memalign_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(*ptr, hash, nr_of_frames, frames);
@@ -1078,15 +1074,10 @@ int MallocStatisticImpl::posix_memalign_hook(void** ptr, size_t align, size_t si
 void* MallocStatisticImpl::memalign_hook(size_t align, size_t size, void* caller_address) {
   void* result = real_malloc_funcs->memalign(align, size);
   uint64_t hash = ptr_hash(result);
-#if !defined(__APPLE__)
-  address real_func = (address) memalign;
-#else
-  address real_func = (address) memalign_hook;
-#endif
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, real_func, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) memalign_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -1103,15 +1094,10 @@ void* MallocStatisticImpl::memalign_hook(size_t align, size_t size, void* caller
 void* MallocStatisticImpl::aligned_alloc_hook(size_t align, size_t size, void* caller_address) {
   void* result = real_malloc_funcs->aligned_alloc(align, size);
   uint64_t hash = ptr_hash(result);
-#if !defined(__APPLE__)
-  address real_func = (address) aligned_alloc;
-#else
-  address real_func = (address) aligned_alloc_hook;
-#endif
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, real_func, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) aligned_alloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -1128,15 +1114,10 @@ void* MallocStatisticImpl::aligned_alloc_hook(size_t align, size_t size, void* c
 void* MallocStatisticImpl::valloc_hook(size_t size, void* caller_address) {
   void* result = real_malloc_funcs->valloc(size);
   uint64_t hash = ptr_hash(result);
-#if defined(__GLIBC__) || defined(__APPLE__)
-  address real_func = (address) valloc;
-#else
-  address real_func = (address) valloc_hook;
-#endif
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, real_func, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) valloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);
@@ -1153,15 +1134,10 @@ void* MallocStatisticImpl::valloc_hook(size_t size, void* caller_address) {
 void* MallocStatisticImpl::pvalloc_hook(size_t size, void* caller_address) {
   void* result = real_malloc_funcs->pvalloc(size);
   uint64_t hash = ptr_hash(result);
-#if defined(__GLIBC__)
-  address real_func = (address) pvalloc;
-#else
-  address real_func = (address) pvalloc_hook;
-#endif
 
   if ((result != nullptr) && should_track(hash) && !malloc_suspended()) {
     address frames[MAX_FRAMES + FRAMES_TO_SKIP];
-    int nr_of_frames = capture_stack(frames, real_func, (address) caller_address);
+    int nr_of_frames = capture_stack(frames, (address) pvalloc_hook, (address) caller_address);
 
     if (_track_free) {
       record_allocation(result, hash, nr_of_frames, frames);

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocHooksTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocHooksTest.java
@@ -839,8 +839,15 @@ class MallocTraceExpectedStatistic {
 
             for (int j = 0; j < actual.nrOfStacks(); ++j) {
                 Stack stack = actual.getStack(j);
+                String expected;
 
-                if (stack.getFunction(0).startsWith(funcs[i] + (Platform.isOSX() ? "_interpose " : " "))) {
+                if (Platform.isOSX()) {
+                    expected = funcs[i] + "_interpose";
+                } else {
+                    expected = "sap::mallocStatImpl::MallocStatisticImpl::" + funcs[i] + "_hook";
+                }
+
+                if (stack.getFunction(0).startsWith(expected)) {
                     assertFalse(found, "Found entry for " + funcs[i] + " more than once");
                     long expected_bytes = bytes[i] / nth;
                     long expected_count = counts[i] / nth;

--- a/test/hotspot/jtreg/runtime/malloctrace/MallocHooksTest.java
+++ b/test/hotspot/jtreg/runtime/malloctrace/MallocHooksTest.java
@@ -839,13 +839,7 @@ class MallocTraceExpectedStatistic {
 
             for (int j = 0; j < actual.nrOfStacks(); ++j) {
                 Stack stack = actual.getStack(j);
-                String expected;
-
-                if (Platform.isOSX()) {
-                    expected = funcs[i] + "_interpose";
-                } else {
-                    expected = "sap::mallocStatImpl::MallocStatisticImpl::" + funcs[i] + "_hook";
-                }
+                String expected = "sap::mallocStatImpl::MallocStatisticImpl::" + funcs[i] + "_hook";
 
                 if (stack.getFunction(0).startsWith(expected)) {
                     assertFalse(found, "Found entry for " + funcs[i] + " more than once");


### PR DESCRIPTION
Removes the use of 'naked' allocation functions in the malloc trace. This is in preparation to openjdk removing the access to these.

fixes #1961
