### PR TITLE
SapMachine #1981: Enable UseCompactObjectHeaders by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -128,7 +128,8 @@ const size_t minimumSymbolTableSize = 1024;
           "(Deprecated) Use 32-bit class pointers in 64-bit VM. "           \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, false,                             \
+  /* SapMachine 2025-06-11: enable UseCompactObjectHeaders by default */    \
+  product(bool, UseCompactObjectHeaders, true,                              \
           "Use compact 64-bit object headers in 64-bit VM")                 \
                                                                             \
   product(int, ObjectAlignmentInBytes, 8,                                   \


### PR DESCRIPTION
UseCompactObjectHeaders is not experimental any more and this feature will save us some memory; so enable it by default in SapMachine.

fixes #1981 
