### PR TITLE
SapMachine (25) #1981: Enable UseCompactObjectHeaders by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -128,7 +128,8 @@ const size_t minimumSymbolTableSize = 1024;
           "(Deprecated) Use 32-bit class pointers in 64-bit VM. "           \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, false,                             \
+  /* SapMachine 2025-06-11: enable UseCompactObjectHeaders by default */    \
+  product(bool, UseCompactObjectHeaders, true,                              \
           "Use compact 64-bit object headers in 64-bit VM")                 \
                                                                             \
   product(int, ObjectAlignmentInBytes, 8,                                   \


### PR DESCRIPTION
(cherry picked from commit d0643c34c39f6518534c39256eb13f345afdff52)

fixes #1981
