### PR TITLE
SapMachine #1982: Omit some cds archives in the delivery of SapMachine

### DIFF
--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           platform: alpine-linux-x64
 
+      # SapMachine 2025-06-11: reduce number of cds/jsa archives
       - name: 'Configure'
         run: >
           bash configure
@@ -92,6 +93,7 @@ jobs:
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
+          --with-vendor-name="SAP SE"
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -162,6 +162,7 @@ jobs:
           sudo rm -rf sysroot/
         if: steps.create-sysroot.outcome != 'success' && steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
+      # SapMachine 2025-06-11: reduce number of cds/jsa archives
       - name: 'Configure'
         run: >
           bash configure
@@ -175,6 +176,7 @@ jobs:
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}
           --with-sysroot=sysroot
           --with-jmod-compress=zip-1
+          --with-vendor-name="SAP SE"
           CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
           CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -116,6 +116,7 @@ jobs:
           sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
+      # SapMachine 2025-06-11: reduce number of cds/jsa archives
       - name: 'Configure'
         run: >
           bash configure
@@ -127,6 +128,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
+          --with-vendor-name="SAP SE"
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -95,6 +95,7 @@ jobs:
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
 
+      # SapMachine 2025-06-11: reduce number of cds/jsa archives
       - name: 'Configure'
         run: >
           bash configure
@@ -106,6 +107,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
+          --with-vendor-name="SAP SE"
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -119,6 +119,7 @@ jobs:
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 
+      # SapMachine 2025-06-11: reduce number of cds/jsa archives
       - name: 'Configure'
         run: >
           bash configure
@@ -130,6 +131,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
           --with-jmod-compress=zip-1
+          --with-vendor-name="SAP SE"
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -194,21 +194,23 @@ define CreateCDSArchive
 endef
 
 ifeq ($(BUILD_CDS_ARCHIVE), true)
-  $(foreach v, $(JVM_VARIANTS), \
-    $(eval $(call CreateCDSArchive,$v,)) \
-  )
+  # SapMachine 2025-06-11: reduce number of cds/jsa archives
+  #$(foreach v, $(JVM_VARIANTS), \
+  #  $(eval $(call CreateCDSArchive,$v,)) \
+  #)
 
+  # SapMachine 2025-06-11: reduce number of cds/jsa archives
   ifeq ($(call isTargetCpuBits, 64), true)
-    $(foreach v, $(JVM_VARIANTS), \
-      $(eval $(call CreateCDSArchive,$v,_nocoops)) \
-    )
+    #$(foreach v, $(JVM_VARIANTS), \
+    #  $(eval $(call CreateCDSArchive,$v,_nocoops)) \
+    #)
     ifeq ($(BUILD_CDS_ARCHIVE_COH), true)
       $(foreach v, $(JVM_VARIANTS), \
         $(eval $(call CreateCDSArchive,$v,_coh)) \
       )
-      $(foreach v, $(JVM_VARIANTS), \
-        $(eval $(call CreateCDSArchive,$v,_nocoops_coh)) \
-      )
+      # $(foreach v, $(JVM_VARIANTS), \
+      #   $(eval $(call CreateCDSArchive,$v,_nocoops_coh)) \
+      # )
     endif
   endif
 endif

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -193,13 +193,12 @@ define CreateCDSArchive
   JRE_TARGETS += $$($1_$2_gen_cds_archive_jre)
 endef
 
+# SapMachine 2025-06-11: reduce number of cds/jsa archives
 ifeq ($(BUILD_CDS_ARCHIVE), true)
-  # SapMachine 2025-06-11: reduce number of cds/jsa archives
   #$(foreach v, $(JVM_VARIANTS), \
   #  $(eval $(call CreateCDSArchive,$v,)) \
   #)
 
-  # SapMachine 2025-06-11: reduce number of cds/jsa archives
   ifeq ($(call isTargetCpuBits, 64), true)
     #$(foreach v, $(JVM_VARIANTS), \
     #  $(eval $(call CreateCDSArchive,$v,_nocoops)) \

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -56,8 +56,10 @@ requires.extraPropDefns.vmOpts = \
     -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
     --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+# SapMachine 2025-06-11: reduce number of cds/jsa archives
 requires.properties= \
     sun.arch.data.model \
+    vm.vendor \
     vm.simpleArch \
     vm.bits \
     vm.flightRecorder \

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -120,8 +120,8 @@ public class CompressedCPUSpecificClassSpaceReservation {
     }
 
     public static void main(String[] args) throws Exception {
-        // SapMachine 2025-06-11: -Xshare:on does not work with -XX:-UseCompactObjectHeaders
-        // because of the reduced number of jsa cds archives
+        // SapMachine 2025-06-11: reduce number of cds/jsa archives
+        // -Xshare:on can only be used for a configuration for which we have a jsa cds archive.
         //System.out.println("Test with CDS");
         //do_test(true);
         System.out.println("Test without CDS");

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -120,8 +120,10 @@ public class CompressedCPUSpecificClassSpaceReservation {
     }
 
     public static void main(String[] args) throws Exception {
-        System.out.println("Test with CDS");
-        do_test(true);
+        // SapMachine 2025-06-11: -Xshare:on does not work with -XX:-UseCompactObjectHeaders
+        // because of the reduced number of jsa cds archives
+        //System.out.println("Test with CDS");
+        //do_test(true);
         System.out.println("Test without CDS");
         do_test(false);
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
@@ -38,6 +38,8 @@
 /*
  * @test id=no_coh_cds
  * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
  * @requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
  * @requires os.family != "aix"
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
@@ -22,30 +22,32 @@
  * questions.
  */
 
+// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some subtests fail, omit them
+
 /*
- * @test id=no_coh_no_cds
- * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * @library /test/lib
- * @requires vm.bits == 64 & vm.debug == true & vm.flagless
- * @requires os.family != "aix"
- * @modules java.base/jdk.internal.misc
+ * test id=no_coh_no_cds
+ * summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
+ * library /test/lib
+ * requires vm.bits == 64 & vm.debug == true & vm.flagless
+ * requires os.family != "aix"
+ * modules java.base/jdk.internal.misc
  *          java.management
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run driver AccessZeroNKlassHitsProtectionZone no_coh_no_cds
+ * build jdk.test.whitebox.WhiteBox
+ * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * run driver AccessZeroNKlassHitsProtectionZone no_coh_no_cds
  */
 
 /*
- * @test id=no_coh_cds
- * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * @requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
- * @requires os.family != "aix"
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
+ * test id=no_coh_cds
+ * summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
+ * requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
+ * requires os.family != "aix"
+ * library /test/lib
+ * modules java.base/jdk.internal.misc
  *          java.management
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run driver AccessZeroNKlassHitsProtectionZone no_coh_cds
+ * build jdk.test.whitebox.WhiteBox
+ * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * run driver AccessZeroNKlassHitsProtectionZone no_coh_cds
  */
 
 /*

--- a/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
@@ -22,32 +22,30 @@
  * questions.
  */
 
-// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some subtests fail, omit them
-
 /*
- * test id=no_coh_no_cds
- * summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * library /test/lib
- * requires vm.bits == 64 & vm.debug == true & vm.flagless
- * requires os.family != "aix"
- * modules java.base/jdk.internal.misc
+ * @test id=no_coh_no_cds
+ * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
+ * @library /test/lib
+ * @requires vm.bits == 64 & vm.debug == true & vm.flagless
+ * @requires os.family != "aix"
+ * @modules java.base/jdk.internal.misc
  *          java.management
- * build jdk.test.whitebox.WhiteBox
- * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * run driver AccessZeroNKlassHitsProtectionZone no_coh_no_cds
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run driver AccessZeroNKlassHitsProtectionZone no_coh_no_cds
  */
 
 /*
- * test id=no_coh_cds
- * summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
- * requires os.family != "aix"
- * library /test/lib
- * modules java.base/jdk.internal.misc
+ * @test id=no_coh_cds
+ * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
+ * @requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
+ * @requires os.family != "aix"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
  *          java.management
- * build jdk.test.whitebox.WhiteBox
- * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * run driver AccessZeroNKlassHitsProtectionZone no_coh_cds
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run driver AccessZeroNKlassHitsProtectionZone no_coh_cds
  */
 
 /*

--- a/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
+++ b/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
@@ -22,19 +22,19 @@
  *
  */
 
-// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
-
 /*
- * test
- * summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
- * bug 8353504
- * requires vm.cds
- * requires vm.flagless
- * requires vm.flavor == "server"
- * comment This test doesn't work on Windows because it depends on symlinks
- * requires os.family != "windows"
- * library /test/lib appcds
- * run driver NonJVMVariantLocation
+ * @test
+ * @summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
+ * @bug 8353504
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @requires vm.flavor == "server"
+ * @comment This test doesn't work on Windows because it depends on symlinks
+ * @requires os.family != "windows"
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
+ * @library /test/lib appcds
+ * @run driver NonJVMVariantLocation
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
+++ b/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
@@ -22,17 +22,19 @@
  *
  */
 
+// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
+
 /*
- * @test
- * @summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
- * @bug 8353504
- * @requires vm.cds
- * @requires vm.flagless
- * @requires vm.flavor == "server"
- * @comment This test doesn't work on Windows because it depends on symlinks
- * @requires os.family != "windows"
- * @library /test/lib appcds
- * @run driver NonJVMVariantLocation
+ * test
+ * summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
+ * bug 8353504
+ * requires vm.cds
+ * requires vm.flagless
+ * requires vm.flavor == "server"
+ * comment This test doesn't work on Windows because it depends on symlinks
+ * requires os.family != "windows"
+ * library /test/lib appcds
+ * run driver NonJVMVariantLocation
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -21,17 +21,17 @@
  * questions.
  */
  
-// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
-
 /*
- * test TestCDSVMCrash
- * summary Verify that an exception is thrown when the VM crashes during executeAndLog
- * requires vm.cds
- * requires vm.flagless
- * modules java.base/jdk.internal.misc
- * library /test/lib
- * run driver TestCDSVMCrash
- * bug 8306583
+ * @test TestCDSVMCrash
+ * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver TestCDSVMCrash
+ * @bug 8306583
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -20,16 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+ 
+// SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
 
 /*
- * @test TestCDSVMCrash
- * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
- * @requires vm.cds
- * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- * @library /test/lib
- * @run driver TestCDSVMCrash
- * @bug 8306583
+ * test TestCDSVMCrash
+ * summary Verify that an exception is thrown when the VM crashes during executeAndLog
+ * requires vm.cds
+ * requires vm.flagless
+ * modules java.base/jdk.internal.misc
+ * library /test/lib
+ * run driver TestCDSVMCrash
+ * bug 8306583
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
- 
+
 /*
  * @test TestCDSVMCrash
  * @summary Verify that an exception is thrown when the VM crashes during executeAndLog

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -22,41 +22,9 @@
  * questions.
  */
 
-/**
- * @test id=nocoops_nocoh
- * @summary Test Loading of default archives in all configurations
- * @requires vm.cds
- * @requires vm.cds.write.archived.java.heap
- * @requires vm.bits == 64
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
- * @run driver TestDefaultArchiveLoading nocoops_nocoh
- */
-
-/**
- * @test id=nocoops_coh
- * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
- * @requires vm.cds
- * @requires vm.cds.write.archived.java.heap
- * @requires vm.bits == 64
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
- * @run driver TestDefaultArchiveLoading nocoops_coh
- */
-
-/**
- * @test id=coops_nocoh
- * @summary Test Loading of default archives in all configurations
- * @requires vm.cds
- * @requires vm.cds.write.archived.java.heap
- * @requires vm.bits == 64
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
- * @run driver TestDefaultArchiveLoading coops_nocoh
- */
+// SapMachine 2025-06-11: reduce number of cds/jsa archives
+// this means some sub tests like nocoops do not work any more because the archive
+// is removed
 
 /**
  * @test id=coops_coh

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -25,11 +25,11 @@
 /**
  * @test id=nocoops_nocoh
  * @summary Test Loading of default archives in all configurations
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
- * @requires vm.vendor != "SAP SE"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -39,11 +39,11 @@
 /**
  * @test id=nocoops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
- * @requires vm.vendor != "SAP SE"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -53,6 +53,8 @@
 /**
  * @test id=coops_nocoh
  * @summary Test Loading of default archives in all configurations
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
@@ -68,8 +70,6 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
- * @requires vm.vendor != "SAP SE"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -27,6 +27,42 @@
 // is removed
 
 /**
+ * test id=nocoops_nocoh
+ * summary Test Loading of default archives in all configurations
+ * requires vm.cds
+ * requires vm.cds.write.archived.java.heap
+ * requires vm.bits == 64
+ * library /test/lib
+ * modules java.base/jdk.internal.misc
+ *          java.management
+ * run driver TestDefaultArchiveLoading nocoops_nocoh
+ */
+
+/**
+ * test id=nocoops_coh
+ * summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
+ * requires vm.cds
+ * requires vm.cds.write.archived.java.heap
+ * requires vm.bits == 64
+ * library /test/lib
+ * modules java.base/jdk.internal.misc
+ *          java.management
+ * run driver TestDefaultArchiveLoading nocoops_coh
+ */
+
+/**
+ * test id=coops_nocoh
+ * summary Test Loading of default archives in all configurations
+ * requires vm.cds
+ * requires vm.cds.write.archived.java.heap
+ * requires vm.bits == 64
+ * library /test/lib
+ * modules java.base/jdk.internal.misc
+ *          java.management
+ * run driver TestDefaultArchiveLoading coops_nocoh
+ */
+
+/**
  * @test id=coops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
  * @requires vm.cds

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -22,44 +22,44 @@
  * questions.
  */
 
-// SapMachine 2025-06-11: reduce number of cds/jsa archives
-// this means some sub tests like nocoops do not work any more because the archive
-// is removed
-
 /**
- * test id=nocoops_nocoh
- * summary Test Loading of default archives in all configurations
- * requires vm.cds
- * requires vm.cds.write.archived.java.heap
- * requires vm.bits == 64
- * library /test/lib
- * modules java.base/jdk.internal.misc
+ * @test id=nocoops_nocoh
+ * @summary Test Loading of default archives in all configurations
+ * @requires vm.cds
+ * @requires vm.cds.write.archived.java.heap
+ * @requires vm.bits == 64
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
  *          java.management
- * run driver TestDefaultArchiveLoading nocoops_nocoh
+ * @run driver TestDefaultArchiveLoading nocoops_nocoh
  */
 
 /**
- * test id=nocoops_coh
- * summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
- * requires vm.cds
- * requires vm.cds.write.archived.java.heap
- * requires vm.bits == 64
- * library /test/lib
- * modules java.base/jdk.internal.misc
+ * @test id=nocoops_coh
+ * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
+ * @requires vm.cds
+ * @requires vm.cds.write.archived.java.heap
+ * @requires vm.bits == 64
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
  *          java.management
- * run driver TestDefaultArchiveLoading nocoops_coh
+ * @run driver TestDefaultArchiveLoading nocoops_coh
  */
 
 /**
- * test id=coops_nocoh
- * summary Test Loading of default archives in all configurations
- * requires vm.cds
- * requires vm.cds.write.archived.java.heap
- * requires vm.bits == 64
- * library /test/lib
- * modules java.base/jdk.internal.misc
+ * @test id=coops_nocoh
+ * @summary Test Loading of default archives in all configurations
+ * @requires vm.cds
+ * @requires vm.cds.write.archived.java.heap
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
  *          java.management
- * run driver TestDefaultArchiveLoading coops_nocoh
+ * @run driver TestDefaultArchiveLoading coops_nocoh
  */
 
 /**
@@ -68,6 +68,8 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -39,8 +39,6 @@
 /**
  * @test id=nocoops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
- * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
- * @requires vm.vendor != "SAP SE"
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -52,25 +52,23 @@
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom
  */
 
-// SapMachine 2025-06-11: reduce number of cds/jsa archives
-// this means that the zgc/nocoops subtest does not work any more because the archive
-// is removed
-
 /**
- * test id=custom-cl-zgc
- * requires vm.cds.custom.loaders
- * requires vm.gc.Z
- * summary Test dumptime_table entries are removed with zgc eager class unloading
- * bug 8274935
- * library /test/lib
+ * @test id=custom-cl-zgc
+ * @requires vm.cds.custom.loaders
+ * @requires vm.gc.Z
+ * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
+ * @requires vm.vendor != "SAP SE"
+ * @summary Test dumptime_table entries are removed with zgc eager class unloading
+ * @bug 8274935
+ * @library /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
- * modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.misc
  *          jdk.httpserver
- * build jdk.test.whitebox.WhiteBox
- * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
  */
 
 import com.sun.net.httpserver.HttpExchange;

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -56,8 +56,6 @@
  * @test id=custom-cl-zgc
  * @requires vm.cds.custom.loaders
  * @requires vm.gc.Z
- * @comment SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
- * @requires vm.vendor != "SAP SE"
  * @summary Test dumptime_table entries are removed with zgc eager class unloading
  * @bug 8274935
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -56,6 +56,23 @@
 // this means that the zgc/nocoops subtest does not work any more because the archive
 // is removed
 
+/**
+ * test id=custom-cl-zgc
+ * requires vm.cds.custom.loaders
+ * requires vm.gc.Z
+ * summary Test dumptime_table entries are removed with zgc eager class unloading
+ * bug 8274935
+ * library /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
+ * modules java.base/jdk.internal.misc
+ *          jdk.httpserver
+ * build jdk.test.whitebox.WhiteBox
+ * run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
+ */
+
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -52,22 +52,9 @@
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom
  */
 
-/**
- * @test id=custom-cl-zgc
- * @requires vm.cds.custom.loaders
- * @requires vm.gc.Z
- * @summary Test dumptime_table entries are removed with zgc eager class unloading
- * @bug 8274935
- * @library /test/lib
- *          /test/hotspot/jtreg/runtime/cds/appcds
- *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
- * @modules java.base/jdk.internal.misc
- *          jdk.httpserver
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
- */
+// SapMachine 2025-06-11: reduce number of cds/jsa archives
+// this means that the zgc/nocoops subtest does not work any more because the archive
+// is removed
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
@@ -32,7 +32,9 @@
  * @library /test/lib
  * @run main RedefineClassHelper
  * @run driver RedefineSharedClass xshare-off
- * @run driver RedefineSharedClass xshare-on
+ *
+ * SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
+ * run driver RedefineSharedClass xshare-on
  */
 import java.io.InputStream;
 import java.io.IOException;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
@@ -32,8 +32,7 @@
  * @library /test/lib
  * @run main RedefineClassHelper
  * @run driver RedefineSharedClass xshare-off
- *
- * SapMachine 2025-06-11: reduce number of cds/jsa archives makes some (sub)tests fail, omit them
+ * SapMachine 2025-06-11: reduce number of cds/jsa archives, test would fail
  * run driver RedefineSharedClass xshare-on
  */
 import java.io.InputStream;

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -100,6 +100,8 @@ public class VMProps implements Callable<Map<String, String>> {
         log("Entering call()");
         SafeMap map = new SafeMap();
         map.put("vm.flavor", this::vmFlavor);
+        // SapMachine 2025-06-11: reduce number of cds/jsa archives
+        map.put("vm.vendor", this::vmVendor);
         map.put("vm.compMode", this::vmCompMode);
         map.put("vm.bits", this::vmBits);
         map.put("vm.flightRecorder", this::vmFlightRecorder);
@@ -196,6 +198,14 @@ public class VMProps implements Callable<Map<String, String>> {
             return m.group(1).toLowerCase();
         }
         return errorWithMessage("Can't get VM flavor from 'java.vm.name'");
+    }
+
+    // SapMachine 2025-06-11: reduce number of cds/jsa archives
+    /**
+     * @return VM vendor through the "java.vm.vendor" property.
+     */
+    protected String vmVendor() {
+        return System.getProperty("java.vm.vendor");
     }
 
     /**


### PR DESCRIPTION
Due to project Liliput / compact object headers (https://openjdk.org/jeps/519) the number of CDS archives delivered with the JVM increased to 4.
This increases the disc space requirements of the JVM as well as download costs.
We decrease the number of CDS archives delivered with the JVM to 1.
This reduces the JDK/JRE image size by ~ 45M .

fixes #1982
