### PR TITLE
SapMachine #1994: Debug coding for javac/javadoc issue JDK-8359336

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2331,15 +2331,14 @@ public class ClassReader {
             ListBuffer<Type> argtypes = new ListBuffer<>();
             int i = 0;
 
+            // SapMachine 2025-06-17: Analysis output for JDK-8359336
             if (s.params == null) {
                 System.out.println("Analyse JDK-8359336");
                 System.out.println("Symbol name: " + s.name);
                 if (s.owner != null) System.out.println("       owner: " + s.owner.name);
                 System.out.println("       toString: " + s.toString());
                 if (s.owner != null) System.out.println("       owner.toString: " + s.owner.toString());
-            }
-
-            if (s.params != null) {
+            } else {
                 for (Symbol.VarSymbol param : s.params) {
                     param.type = addTypeAnnotations(param.type, methodFormalParameter(i++));
                     argtypes.add(param.type);
@@ -2362,6 +2361,7 @@ public class ClassReader {
                 mt.recvtype = addTypeAnnotations(mt.recvtype, TargetType.METHOD_RECEIVER);
             }
 
+            // SapMachine 2025-06-17: Analysis output for JDK-8359336
             if (s.params == null) {
                 System.out.println("Method type name:");
                 System.out.println("            toString: " + mt.toString());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2330,9 +2330,20 @@ public class ClassReader {
             MethodType mt = (MethodType) t;
             ListBuffer<Type> argtypes = new ListBuffer<>();
             int i = 0;
-            for (Symbol.VarSymbol param : s.params) {
-                param.type = addTypeAnnotations(param.type, methodFormalParameter(i++));
-                argtypes.add(param.type);
+
+            if (s.params == null) {
+                System.out.println("Analyse JDK-8359336");
+                System.out.println("Symbol name: " + s.name);
+                if (s.owner != null) System.out.println("       owner: " + s.owner.name);
+                System.out.println("       toString: " + s.toString());
+                if (s.owner != null) System.out.println("       owner.toString: " + s.owner.toString());
+            }
+
+            if (s.params != null) {
+                for (Symbol.VarSymbol param : s.params) {
+                    param.type = addTypeAnnotations(param.type, methodFormalParameter(i++));
+                    argtypes.add(param.type);
+                }
             }
             mt.argtypes = argtypes.toList();
             ListBuffer<Type> thrown = new ListBuffer<>();
@@ -2350,6 +2361,18 @@ public class ClassReader {
             if (mt.recvtype != null) {
                 mt.recvtype = addTypeAnnotations(mt.recvtype, TargetType.METHOD_RECEIVER);
             }
+
+            if (s.params == null) {
+                System.out.println("Method type name:");
+                System.out.println("            toString: " + mt.toString());
+                System.out.println("            recvtype: " + (mt.recvtype == null ? "null" : mt.recvtype.toString()));
+
+                // Cause original crash
+                for (Symbol.VarSymbol param : s.params) {
+                    System.out.println(param);
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Our pre-release testing unveiled an issue with javac/javadoc in sapmachine 21.

We opened https://bugs.openjdk.org/browse/JDK-8359336 for this.

Add some debug coding so we can narrow down on the source code that causes this.
The colleagues need a regular pre-release build to test this.

fixes #1994