### PR TITLE
8359336: javac crashes with NPE while iterating params of MethodSymbol (Preliminary version)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -131,6 +131,8 @@ public class ClassReader {
      */
     public boolean saveParameterNames;
 
+    private final boolean addTypeAnnotationsToSymbol;
+
     /**
      * The currently selected profile.
      */
@@ -296,6 +298,8 @@ public class ClassReader {
         typevars = WriteableScope.create(syms.noSymbol);
 
         lintClassfile = Lint.instance(context).isEnabled(LintCategory.CLASSFILE);
+
+        addTypeAnnotationsToSymbol = options.getBoolean("addTypeAnnotationsToSymbol", false);
 
         initAttributeReaders();
     }
@@ -2258,7 +2262,9 @@ public class ClassReader {
                 currentClassFile = classFile;
                 List<Attribute.TypeCompound> newList = deproxyTypeCompoundList(proxies);
                 sym.setTypeAttributes(newList.prependList(sym.getRawTypeAttributes()));
-                addTypeAnnotationsToSymbol(sym, newList);
+                if (addTypeAnnotationsToSymbol) {
+                    addTypeAnnotationsToSymbol(sym, newList);
+                }
             } finally {
                 currentClassFile = previousClassFile;
             }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
@@ -80,7 +80,7 @@ public class CompletionErrorOnEnclosingType {
                 new JavacTask(tb)
                         .outdir(out)
                         .classpath(out)
-                        .options("-XDrawDiagnostics")
+                        .options("-XDrawDiagnostics", "-XDaddTypeAnnotationsToSymbol=true")
                         .files(src.resolve("C.java"))
                         .run(Expect.FAIL)
                         .writeAll()

--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -33,7 +33,7 @@
  *          jdk.compiler/com.sun.tools.javac.util
  * @build JavacTestingAbstractProcessor DPrinter BasicAnnoTests
  * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests.java
- * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests
+ * @compile/process -XDaccessInternalAPI -XDaddTypeAnnotationsToSymbol=true -processor BasicAnnoTests -proc:only BasicAnnoTests
  */
 
 import java.io.PrintWriter;


### PR DESCRIPTION
See https://github.com/openjdk/jdk21u-dev/pull/1916

fixes #2001
