### PR TITLE
SapMachine #1930: Redirect sap.github.io/SapMachine to sapmachine.io

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -36,13 +36,12 @@ jobs:
           ref: 'main'
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: |
+            redirect_index.html
+            _data/
 
   # Deployment job
   deploy:

--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -34,14 +34,23 @@ jobs:
           token: ${{ secrets.GHE_PAT }}
           github-server-url: https://github.tools.sap
           ref: 'main'
+          sparse-checkout: |
+            redirect_index.html
+            redirect_404.html
+            assets/
+          sparse-checkout-cone-mode: true
+      - name: Prepare site folder
+        run: |
+          mkdir site
+          mv redirect_index.html site/index.html
+          mv redirect_404.html site/404.html
+          mv assets site/
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: |
-            redirect_index.html
-            _data/
+          path: site
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Sets up a redirect to sapmachine.io on sap.github.io/SapMachine

fixes #1930
