### PR TITLE
Redirect jfrevents pages on old Github Pages URL

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -39,6 +39,7 @@ jobs:
             redirect_404.html
             assets/
             jfrevents/
+            html-include/
           sparse-checkout-cone-mode: true
       - name: Prepare site folder
         run: |
@@ -47,6 +48,7 @@ jobs:
           mv redirect_404.html site/404.html
           mv assets site/
           mv jfrevents site/
+          mv html-include site/
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -38,6 +38,7 @@ jobs:
             redirect_index.html
             redirect_404.html
             assets/
+            jfrevents/
           sparse-checkout-cone-mode: true
       - name: Prepare site folder
         run: |
@@ -45,6 +46,7 @@ jobs:
           mv redirect_index.html site/index.html
           mv redirect_404.html site/404.html
           mv assets site/
+          mv jfrevents site/
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
Sets up a redirect to sap.github.io/jfrevents on sap.github.io/SapMachine/jfrevents

fixes #1930
