### PR TITLE
Don't run platform builds for docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ on:
   pull_request:
     branches:
       - sapmachine
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
Stops running the full build and test pipeline when only markdown files or files in the `doc` folder changed.

fixes #2135
