### PR TITLE
SapMachine (27) #2161:  CheckFiles jtreg tests fails in SapMachine 27

### DIFF
--- a/test/jdk/build/CheckFiles.java
+++ b/test/jdk/build/CheckFiles.java
@@ -84,7 +84,9 @@ public class CheckFiles {
         allowedEndingsLibDir.add("fontconfig.bfc");
         allowedEndingsLibDir.add("fontconfig.properties.src");
         allowedEndingsLibDir.add("ct.sym");
-        allowedEndingsLibDir.add("jrt-fs.jar");
+        // SapMachine 2026-01-28 allow all jars because of our added async-profiler
+        //allowedEndingsLibDir.add("jrt-fs.jar");
+        allowedEndingsLibDir.add(".jar");
         allowedEndingsLibDir.add("jvm.cfg");
         allowedEndingsLibDir.add("modules");
         allowedEndingsLibDir.add("psfontj2d.properties");


### PR DESCRIPTION
Relax the check of the lib folder, because we might include async-profiler jars

fixes #2161 
