### PR TITLE
SapMachine 21 #2165: G1 should initiate the next concurrent cycle even before finishing a mixed phase if there are excessive hum. allocations

### DIFF
--- a/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.hpp
@@ -50,6 +50,9 @@ class G1OldGenAllocationTracker : public CHeapObj<mtGC> {
 public:
   G1OldGenAllocationTracker();
 
+  // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
+  size_t allocated_humongous_bytes_since_last_gc() const { return _allocated_humongous_bytes_since_last_gc; }
+
   void add_allocated_bytes_since_last_gc(size_t bytes) { _allocated_bytes_since_last_gc += bytes; }
   void add_allocated_humongous_bytes_since_last_gc(size_t bytes) { _allocated_humongous_bytes_since_last_gc += bytes; }
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1258,7 +1258,12 @@ void G1Policy::decide_on_concurrent_start_pause() {
       abort_time_to_mixed_tracking();
       initiate_conc_mark();
       // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-      log_debug(gc, ergo)("Initiate concurrent cycle (%s)", GCCause::to_string(cause));
+      if (cause == GCCause::_g1_humongous_allocation) {
+        log_debug(gc, ergo)("Initiate concurrent cycle (%s)", GCCause::to_string(cause));
+      } else {
+        log_debug(gc, ergo)("Initiate concurrent cycle (%s requested concurrent cycle)",
+                            (cause == GCCause::_wb_breakpoint) ? "run_to breakpoint" : "user");
+      }
     } else {
       // The concurrent marking thread is still finishing up the
       // previous cycle. If we start one right now the two cycles

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -706,7 +706,7 @@ bool G1Policy::about_to_start_mixed_phase() const {
 }
 
 // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-bool G1Policy::force_concurrent_ending_mixed_phase(bool hum_alloc) {
+bool G1Policy::should_force_concurrent_ending_mixed_phase(bool hum_alloc) {
   // Only humongous allocations are subject to the policy. It applies if a maximum > 0 is given.
   bool policy_applies =
       (_max_hum_bytes_in_mixed_phase > 0) && hum_alloc && !_g1h->concurrent_mark()->cm_thread()->in_progress();
@@ -727,7 +727,7 @@ bool G1Policy::force_concurrent_ending_mixed_phase(bool hum_alloc) {
 
 bool G1Policy::need_to_start_conc_mark(const char* source, size_t alloc_word_size) {
   // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-  bool should_force_cm = force_concurrent_ending_mixed_phase(_g1h->is_humongous(alloc_word_size));
+  bool should_force_cm = should_force_concurrent_ending_mixed_phase(_g1h->is_humongous(alloc_word_size));
   if (about_to_start_mixed_phase() && !should_force_cm) {
     return false;
   }
@@ -1245,7 +1245,7 @@ void G1Policy::decide_on_concurrent_start_pause() {
                (cause == GCCause::_codecache_GC_aggressive) ||
                (cause == GCCause::_wb_breakpoint) ||
                // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-               (force_concurrent_ending_mixed_phase(cause == GCCause::_g1_humongous_allocation))) {
+               (should_force_concurrent_ending_mixed_phase(cause == GCCause::_g1_humongous_allocation))) {
       // Initiate a concurrent start.  A concurrent start must be a young only
       // GC, so the collector state must be updated to reflect this.
       collector_state()->set_in_young_only_phase(true);

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -706,10 +706,9 @@ bool G1Policy::about_to_start_mixed_phase() const {
 }
 
 // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-bool G1Policy::should_force_concurrent_ending_mixed_phase(bool hum_alloc) {
-  // Only humongous allocations are subject to the policy. It applies if a maximum > 0 is given.
+bool G1Policy::should_force_concurrent_ending_mixed_phase() {
   bool policy_applies =
-      (_max_hum_bytes_in_mixed_phase > 0) && hum_alloc && !_g1h->concurrent_mark()->cm_thread()->in_progress();
+      (_max_hum_bytes_in_mixed_phase > 0) && !_g1h->concurrent_mark()->cm_thread()->in_progress();
 
   // The collector might not honor marking requests if expecting mixed collections.
   // Force in case of excessive humongous allocations.
@@ -727,7 +726,7 @@ bool G1Policy::should_force_concurrent_ending_mixed_phase(bool hum_alloc) {
 
 bool G1Policy::need_to_start_conc_mark(const char* source, size_t alloc_word_size) {
   // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-  bool should_force_cm = should_force_concurrent_ending_mixed_phase(_g1h->is_humongous(alloc_word_size));
+  bool should_force_cm = _g1h->is_humongous(alloc_word_size) && should_force_concurrent_ending_mixed_phase();
   if (about_to_start_mixed_phase() && !should_force_cm) {
     return false;
   }
@@ -1245,7 +1244,7 @@ void G1Policy::decide_on_concurrent_start_pause() {
                (cause == GCCause::_codecache_GC_aggressive) ||
                (cause == GCCause::_wb_breakpoint) ||
                // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-               (should_force_concurrent_ending_mixed_phase(cause == GCCause::_g1_humongous_allocation))) {
+               (cause == GCCause::_g1_humongous_allocation && should_force_concurrent_ending_mixed_phase())) {
       // Initiate a concurrent start.  A concurrent start must be a young only
       // GC, so the collector state must be updated to reflect this.
       collector_state()->set_in_young_only_phase(true);

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -110,7 +110,7 @@ void G1Policy::init(G1CollectedHeap* g1h, G1CollectionSet* collection_set) {
   _collection_set->start_incremental_building();
 
   // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-  _max_hum_bytes_in_mixed_phase = _g1h->reserved().byte_size() * G1HumAllocPercentUntilConcurrent / 100;
+  _max_hum_bytes_in_mixed_phase = _g1h->reserved().byte_size() * G1MixedGCHumongousAllocThreshold / 100;
 }
 
 void G1Policy::record_young_gc_pause_start() {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -109,6 +109,11 @@ class G1Policy: public CHeapObj<mtGC> {
 
   G1ConcurrentStartToMixedTimeTracker _concurrent_start_to_mixed;
 
+  // SapMachine 2026-01-20
+  // Threshold for humongous allocations since last gc for ending the current mixed phase
+  // and initiate a new marking cycle
+  size_t _max_hum_bytes_in_mixed_phase;
+
   bool should_update_surv_rate_group_predictors() {
     return collector_state()->in_young_only_phase() && !collector_state()->mark_or_rebuild_in_progress();
   }
@@ -284,6 +289,9 @@ private:
 
   // Indicate that we aborted marking before doing any mixed GCs.
   void abort_time_to_mixed_tracking();
+
+  // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
+  bool force_concurrent_ending_mixed_phase(bool hum_alloc);
 
 public:
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -291,7 +291,7 @@ private:
   void abort_time_to_mixed_tracking();
 
   // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-  bool should_force_concurrent_ending_mixed_phase(bool hum_alloc);
+  bool should_force_concurrent_ending_mixed_phase();
 
 public:
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -291,7 +291,7 @@ private:
   void abort_time_to_mixed_tracking();
 
   // SapMachine 2026-01-20: force G1 marking in mixed phase in case of excessive hum. allocations
-  bool force_concurrent_ending_mixed_phase(bool hum_alloc);
+  bool should_force_concurrent_ending_mixed_phase(bool hum_alloc);
 
 public:
 

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -323,6 +323,15 @@
           "related prediction sample. That sample must involve the same or "\
           "more than that number of cards to be used.")                     \
                                                                             \
+  /* SapMachine 2026-01-20 */                                               \
+  product(uintx, G1HumAllocPercentUntilConcurrent, 0, EXPERIMENTAL,         \
+          "Threashold for humongous allocations since last gc to initiate a"\
+          "new concurrent cycle even if the collector is not yet done with" \
+          "mixed collections. This can help in longer phases where no"      \
+          "evacuation pauses are scheduled because most allocations are"    \
+          "humongous.  The value is a percentage of the maximum heap size.")\
+          range(0, 100)                                                     \
+                                                                            \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \
                     develop_pd,                                             \
                     product,                                                \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -324,7 +324,7 @@
           "more than that number of cards to be used.")                     \
                                                                             \
   /* SapMachine 2026-01-20 */                                               \
-  product(uintx, G1HumAllocPercentUntilConcurrent, 0, EXPERIMENTAL,         \
+  product(uintx, G1MixedGCHumongousAllocThreshold, 0, EXPERIMENTAL,         \
           "Threshold for humongous allocations since last gc to initiate a "\
           "new concurrent cycle even if the collector is not yet done with "\
           "mixed collections. This can help in longer phases where no "     \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -325,11 +325,11 @@
                                                                             \
   /* SapMachine 2026-01-20 */                                               \
   product(uintx, G1HumAllocPercentUntilConcurrent, 0, EXPERIMENTAL,         \
-          "Threashold for humongous allocations since last gc to initiate a"\
-          "new concurrent cycle even if the collector is not yet done with" \
-          "mixed collections. This can help in longer phases where no"      \
-          "evacuation pauses are scheduled because most allocations are"    \
-          "humongous.  The value is a percentage of the maximum heap size.")\
+          "Threshold for humongous allocations since last gc to initiate a "\
+          "new concurrent cycle even if the collector is not yet done with "\
+          "mixed collections. This can help in longer phases where no "     \
+          "evacuation pauses are scheduled because most allocations are "   \
+          "humongous. The value is a percentage of the maximum heap size.") \
           range(0, 100)                                                     \
                                                                             \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+import static gc.testlibrary.Allocation.blackHole;
+
+/*
+ * @test TestHumongousAllocMixedPhase
+ * @bug 8355972
+ * @summary G1: should finish mixed phase and start a new concurrent
+ *          cycle if there are excessive humongous allocations
+ * @requires vm.gc.G1
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @library /
+ * @run driver gc.g1.TestHumongousAllocMixedPhase
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestHumongousAllocMixedPhase {
+    // Heap sizes < 224 MB are increased to 224 MB if vm_page_size == 64K to
+    // fulfill alignment constraints.
+    private static final int heapSize                       = 224; // MB
+    private static final int heapRegionSize                 = 1;   // MB
+
+    public static void main(String[] args) throws Exception {
+        boolean success = false;
+        int allocDelayMsMax = 500;
+        for(int allocDelayMs = 10; !success; allocDelayMs *= 4) {
+            System.out.println("Testing with allocDelayMs=" + allocDelayMs);
+            success = runTest(allocDelayMs, allocDelayMs >= allocDelayMsMax /* lastTry*/);
+        }
+    }
+
+    static boolean runTest(int allocDelayMs, boolean lastTry) throws Exception {
+        OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+            "-XX:+UseG1GC",
+            "-Xms" + heapSize + "m",
+            "-Xmx" + heapSize + "m",
+            "-XX:G1HeapRegionSize=" + heapRegionSize + "m",
+            "-Xlog:gc*",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:G1HumAllocPercentUntilConcurrent=30",
+            HumongousObjectAllocator.class.getName(),
+            Integer.toString(allocDelayMs));
+
+        boolean success = false;
+        String pauseFull = "Pause Full (G1 Compaction Pause)";
+        if (lastTry) {
+            output.shouldNotContain(pauseFull);
+            output.shouldHaveExitValue(0);
+            success = true;
+        } else {
+            success = !output.stdoutContains(pauseFull) && !output.getStderr().contains(pauseFull) &&
+                output.getExitValue() == 0;
+        }
+        return success;
+    }
+
+    static class HumongousObjectAllocator {
+        public static void main(String[] args) throws Exception {
+            int allocDelayMs = Integer.parseInt(args[0]);
+            // Make sure there are some candidate regions for mixed pauses.
+            // (Eg w/o CDS there might be none)
+            System.gc();
+            for (int i = 0; i < 100; i++) {
+                Integer[] humongous = new Integer[5_000_000];
+                blackHole(humongous);
+                System.out.println(i);
+                Thread.sleep(allocDelayMs);
+            }
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
@@ -43,8 +43,8 @@ import jdk.test.lib.process.ProcessTools;
 public class TestHumongousAllocMixedPhase {
     // Heap sizes < 224 MB are increased to 224 MB if vm_page_size == 64K to
     // fulfill alignment constraints.
-    private static final int heapSize                       = 224; // MB
-    private static final int heapRegionSize                 = 1;   // MB
+    private static final int heapSize       = 224; // MB
+    private static final int heapRegionSize = 1;   // MB
 
     public static void main(String[] args) throws Exception {
         boolean success = false;

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
@@ -63,7 +63,7 @@ public class TestHumongousAllocMixedPhase {
             "-XX:G1HeapRegionSize=" + heapRegionSize + "m",
             "-Xlog:gc*",
             "-XX:+UnlockExperimentalVMOptions",
-            "-XX:G1HumAllocPercentUntilConcurrent=30",
+            "-XX:G1MixedGCHumongousAllocThreshold=30",
             HumongousObjectAllocator.class.getName(),
             Integer.toString(allocDelayMs));
 

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocMixedPhase.java
@@ -49,7 +49,7 @@ public class TestHumongousAllocMixedPhase {
     public static void main(String[] args) throws Exception {
         boolean success = false;
         int allocDelayMsMax = 500;
-        for(int allocDelayMs = 10; !success; allocDelayMs *= 4) {
+        for (int allocDelayMs = 10; !success; allocDelayMs *= 4) {
             System.out.println("Testing with allocDelayMs=" + allocDelayMs);
             success = runTest(allocDelayMs, allocDelayMs >= allocDelayMsMax /* lastTry*/);
         }


### PR DESCRIPTION
**UPDATE**: The new option was renamed to `G1MixedGCHumongousAllocThreshold`.

This pr introduces a new experimental option `G1HumAllocPercentUntilConcurrent` that controls the G1 enhancement described below. With its default value 0 the enhancement is disabled.

A value >0 is interpreted as threshold for humongous allocations given as percentage of the maximum heap size. The threshold limits humongous allocations between mixed evacuation pauses. If reached the current mixed phase is aborted in favor of a new concurrent marking cycle.

Without this enhancement G1 would not initiate concurrent marking in a mixed phase. The problem with this behavior is that the heap can fill up with humongous allocations while G1 waits for the next mixed evacuation pause that will be scheduled only when eden is full. If the heap is full of humongous objects before then a full gc is necessary.

_Testing_

The reproducer from

> [8355972:](https://bugs.openjdk.org/browse/JDK-8355972) G1: Exclusive humongous allocations trigger unnecessary Full GC

doesn't show full gcs if the enhancement is enabled with `-XX:+UnlockExperimentalVMOptions -XX:G1HumAllocPercentUntilConcurrent=30`

Full command:

```
java -Xmx1g -Xlog:gc* -XX:+UnlockExperimentalVMOptions -XX:G1HumAllocPercentUntilConcurrent=30 HumongousGc.java
```

The change includes a regression test similar to the reproducer.

A patch with G1HumAllocPercentUntilConcurrent=10 is part of our nightly testing since January 30.

Also tested with https://github.com/reinrich/TestGC

```
./images/jdk/bin/java
-Xmx8g
-XX:+UseG1GC
-XX:+UnlockExperimentalVMOptions -XX:G1MixedGCHumongousAllocThreshold=5
test.gc.MAIN MEDIUM HUM_MEDIUM HUM_ONLY_MEDIUM
```


fixes #2165
