### PR TITLE
#2188: CheckFiles jtreg tests fails on legal folder in SapMachine 27

### DIFF
--- a/test/jdk/build/CheckFiles.java
+++ b/test/jdk/build/CheckFiles.java
@@ -189,13 +189,18 @@ public class CheckFiles {
                     if (Files.isDirectory(subfolder)) {
                         System.out.println("Checking legal dir subfolder for required files: " + subfolder.getFileName());
 
-                        for (String fileName : requiredFilesInLegalSubdirs) {
-                            Path filePath = subfolder.resolve(fileName);
-                            if (Files.exists(filePath)) {
-                                System.out.println("  Found " + fileName);
-                            } else {
-                                System.out.println("  Missing " + fileName);
-                                throw new Error("legal dir scan for required files failed");
+                        // SapMachine 2026-02-24: different handling for async profiler subdir we ship with SapMachine
+                        if (subfolder.getFileName().endsWith("async")) {
+                            System.out.println("Skipping async folder from SapMachine, it contains different content from the OJDK legal dirs.");
+                        } else {
+                            for (String fileName : requiredFilesInLegalSubdirs) {
+                                Path filePath = subfolder.resolve(fileName);
+                                if (Files.exists(filePath)) {
+                                    System.out.println("  Found " + fileName);
+                                } else {
+                                    System.out.println("  Missing " + fileName);
+                                    throw new Error("legal dir scan for required files failed");
+                                }
                             }
                         }
                     }

--- a/test/jdk/build/CheckFiles.java
+++ b/test/jdk/build/CheckFiles.java
@@ -192,15 +192,16 @@ public class CheckFiles {
                         // SapMachine 2026-02-24: different handling for async profiler subdir we ship with SapMachine
                         if (subfolder.getFileName().endsWith("async")) {
                             System.out.println("Skipping async folder from SapMachine, it contains different content from the OJDK legal dirs.");
-                        } else {
-                            for (String fileName : requiredFilesInLegalSubdirs) {
-                                Path filePath = subfolder.resolve(fileName);
-                                if (Files.exists(filePath)) {
-                                    System.out.println("  Found " + fileName);
-                                } else {
-                                    System.out.println("  Missing " + fileName);
-                                    throw new Error("legal dir scan for required files failed");
-                                }
+                            continue;
+                        }
+
+                        for (String fileName : requiredFilesInLegalSubdirs) {
+                            Path filePath = subfolder.resolve(fileName);
+                            if (Files.exists(filePath)) {
+                                System.out.println("  Found " + fileName);
+                            } else {
+                                System.out.println("  Missing " + fileName);
+                                throw new Error("legal dir scan for required files failed");
                             }
                         }
                     }


### PR DESCRIPTION
<!-- General instructions for SapMachine PRs:

1. The title of a PR should be "SapMachine (<Release>) #<Issue Number>: <Description>"
2. A PR needs to refer to an issue in the project by adding the issue number in the last line of the PR body in the form of 'fixes #<Issue Number>
3. When integrating a PR, please make sure you:
- Create a merge commit when merging an OpenJDK upstream PR
- Use Rebase & Merge when your PR only contains commits with meaningful commit message, e.g. of the form `SapMachine #<Issue Number>: <Description>` for SapMachine specific changes or the original commit messages for cherry-picks from OpenJDK
- Use Squash and Merge when there are several commits on the PR. Update the commit message to `SapMachine #<Issue Number>: <Description>` and remove unnecessary commit messages from sub-commits
 -->

<!-- Replace the following line with a description of this pull request -->
Handle the async folder of the legal dir differently, it deviates from the normal OpenJDK legal dirs.

<!-- replace #Issue with the issue number that the PR is referring to. Otherwise PR testing will fail. -->
fixes #2188 
