### PR TITLE
SapMachine (26) #2236: Bump Bootstrap JDKs to current versions (May 2026)

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,21 +29,21 @@ GTEST_VERSION=1.14.0
 JTREG_VERSION=8.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=af77b90d3b326b1e8cb1be0a9d8773e1eba167081c6da21391be05f2d89bebe6
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=4422a642da9764419477a80bea1d614391c40b71060f0de1610467d4c70807a0
 
 ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_linux-x64-musl_bin.tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_SHA256=5c0ad882de88c9200859a68b749c1fb9096d2e2aed09c0611957e458af747dce
+ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_linux-x64-musl_bin.tar.gz
+ALPINE_LINUX_X64_BOOT_JDK_SHA256=58dad03eaf3ec5d40bc2f94d8c1bd5f6e47c650d2d6b52fe3572926285f62e04
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_macos-aarch64_bin.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=8f050771b58bf09db9f352840f23c914aa069c609950d55614ca938d13cdbc71
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_macos-aarch64_bin.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=3663faab53b08e20c87112166bae3399340ead434d8e3a58cbb2a28ef1e0c584
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=47482ad9888991ecac9b2bcc131e2b53ff78aff275104cef85f66252308e8a09
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_mac_hotspot_26.0.1_8.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=02ccc14e55949b8eb03bcf5d631c99510c55983b68b04dfe6ecc4927d0ae398f
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=1b7ff2fe4bb201047a7e43b83c318b9e0bf53bd8a9ea8e8ac95df2917ff0cbd8


### PR DESCRIPTION
Bump boot JDKs used in GitHub Actions to the most recent available versions for the `sapmachine26` branch.

| Platform | Before | After |
|----------|--------|-------|
| Linux x64 | SapMachine 25.0.1 | SapMachine 26.0.1 |
| Alpine Linux x64 | SapMachine 25.0.1 | SapMachine 26.0.1 |
| macOS aarch64 | SapMachine 25.0.1 | SapMachine 26.0.1 |
| macOS x64 | OpenJDK 25 (java.net) | Temurin 26.0.1+8 |
| Windows x64 | SapMachine 25.0.1 | SapMachine 26.0.1 |

macOS x64 is switched from OpenJDK (java.net) to Temurin since no SapMachine build exists for that platform. All SHA256 checksums taken from the respective release assets.

fixes #2236