### PR TITLE
SapMachine (25) #2236: Bump Bootstrap JDKs to current versions (May 2026)

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,21 +29,21 @@ GTEST_VERSION=1.14.0
 JTREG_VERSION=8+2
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=af77b90d3b326b1e8cb1be0a9d8773e1eba167081c6da21391be05f2d89bebe6
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.3/sapmachine-jdk-25.0.3_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=7b451a32c231384aa867dcd91ce9d71866fafc18182300e38d7359a18b1fd6ce
 
 ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_linux-x64-musl_bin.tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_SHA256=5c0ad882de88c9200859a68b749c1fb9096d2e2aed09c0611957e458af747dce
+ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.3/sapmachine-jdk-25.0.3_linux-x64-musl_bin.tar.gz
+ALPINE_LINUX_X64_BOOT_JDK_SHA256=3e236a772dedf92db2a48c02e5c4443cda158e3038ee9cc253df40f9fe61a7e9
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_macos-aarch64_bin.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=8f050771b58bf09db9f352840f23c914aa069c609950d55614ca938d13cdbc71
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.3/sapmachine-jdk-25.0.3_macos-aarch64_bin.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=5e17522ae15cc57b7d57e8317b2f5c425aa38a50bd105e3c763a73317e1d8658
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-24.0.2/sapmachine-jdk-24.0.2_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=9009da7da2b4b71e360e555de6a710a3c0c0b179eb3417d9abea1302ef6d3690
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_mac_hotspot_25.0.3_9.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=4c539a18b4d656960ff6766727e9ca546fc17f7a29714dba9e7b47bdcb37c447
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.1/sapmachine-jdk-25.0.1_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=02ccc14e55949b8eb03bcf5d631c99510c55983b68b04dfe6ecc4927d0ae398f
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.3/sapmachine-jdk-25.0.3_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=e3f9894946f8023b548db1ec75f1107434e0e172cb635c15607343f03a88077c


### PR DESCRIPTION
Bump boot JDKs used in GitHub Actions to the most recent available versions for the `sapmachine25` branch.

| Platform | Before | After |
|----------|--------|-------|
| Linux x64 | SapMachine 25.0.1 | SapMachine 25.0.3 |
| Alpine Linux x64 | SapMachine 25.0.1 | SapMachine 25.0.3 |
| macOS aarch64 | SapMachine 25.0.1 | SapMachine 25.0.3 |
| macOS x64 | SapMachine 24.0.2 | Temurin 25.0.3+9 |
| Windows x64 | SapMachine 25.0.1 | SapMachine 25.0.3 |

macOS x64 is switched from SapMachine 24.0.2 to Temurin 25.0.3+9 since no SapMachine build exists for that platform. All SHA256 checksums taken from the respective release assets.

fixes #2236