### PR TITLE
SapMachine (21) #2236: Bump Bootstrap JDKs to current versions (May 2026)

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,17 +29,17 @@ GTEST_VERSION=1.14.0
 JTREG_VERSION=7.5.2+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.6/sapmachine-jdk-21.0.6_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=ff64ee0a4d6e48f9d164a0de070e413455dab34c89a6fa24d2a48ea63e556dfd
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.11/sapmachine-jdk-21.0.11_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=8c3f89840069bcca458664ff967c878a2711cf826d4b1c03eaf7b5df632e7079
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.6/sapmachine-jdk-21.0.6_macos-aarch64_bin.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=5b5acc052a823f6861bf43aacbecf0b0c3c93204a3bced36d7426591c4792a8f
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.11/sapmachine-jdk-21.0.11_macos-aarch64_bin.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=a2e8c57e87dd09b75efe5e7573b16f894f84f20319b67f1f1bb80562c84926c2
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.6/sapmachine-jdk-21.0.6_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=7f550106bf0bcf926b9637c70c3ce3a40e7b311c01f2a81a0dc7d95064c5054d
+MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.11/sapmachine-jdk-21.0.11_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=dbbffaa9ccacee3589315deee46e0a9db0be0ee204e1830414fa3ba2fa9073ee
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.6/sapmachine-jdk-21.0.6_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=7c3eab46f0e9c6ab374c6821baf33971dc5500364461745c1139fe37fd13dd49
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.11/sapmachine-jdk-21.0.11_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=32d8d2b5d8fe4c761a625d6d8f51cd5e3cf3e427c715f8c8a828c668e00839be


### PR DESCRIPTION
Bump boot JDKs used in GitHub Actions to the most recent available versions for the `sapmachine21` branch.

| Platform | Before | After |
|----------|--------|-------|
| Linux x64 | SapMachine 21.0.6 | SapMachine 21.0.11 |
| macOS aarch64 | SapMachine 21.0.6 | SapMachine 21.0.11 |
| macOS x64 | SapMachine 21.0.6 | SapMachine 21.0.11 |
| Windows x64 | SapMachine 21.0.6 | SapMachine 21.0.11 |

All SHA256 checksums taken from the respective release assets.

fixes #2236