### PR TITLE
SapMachine (17) #2236: Bump Bootstrap JDKs to current versions (May 2026)

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,17 +29,17 @@ GTEST_VERSION=1.13.0
 JTREG_VERSION=7.5.2+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.14/sapmachine-jdk-17.0.14_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=5d42032738a1d2e5ce7c0b08a9ace3f678158c01670b8f21b9701e38eda6127b
+LINUX_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.19/sapmachine-jdk-17.0.19_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=6fe7413b5fb62d8307249987fc2863dfa817b54755a4b865e1b4215fbaa7d242
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.14/sapmachine-jdk-17.0.14_macos-aarch64_bin.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=8dfd53f5cc6a00d85500fc637b68e256c0b8ed6770e9b9c9779297761a24f276
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.19/sapmachine-jdk-17.0.19_macos-aarch64_bin.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=a98bd4b0f2f0e253ef670ac651205afc4a235db470809b6730e990c0e51705d6
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.14/sapmachine-jdk-17.0.14_macos-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=eca737bbc29de298da04856fdc9c856c2638df4151885050f710675a989cd31f
+MACOS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.19/sapmachine-jdk-17.0.19_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=e1da0fa345e11dd12e70b462a7e39abead4be645d96fdeeb1169a69e03f59d24
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.14/sapmachine-jdk-17.0.14_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=dce037469441f3f71d01b839cee4a95755b3f6deba34aa8c1c5649e07ecdac61
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-17.0.19/sapmachine-jdk-17.0.19_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=124de61d21a4a911827a63dc6a7f97fbb105a90568a11a56d4ff7c7a0c7421ec


### PR DESCRIPTION
Bump boot JDKs used in GitHub Actions to the most recent available versions for the `sapmachine17` branch.

| Platform | Before | After |
|----------|--------|-------|
| Linux x64 | SapMachine 17.0.14 | SapMachine 17.0.19 |
| macOS aarch64 | SapMachine 17.0.14 | SapMachine 17.0.19 |
| macOS x64 | SapMachine 17.0.14 | SapMachine 17.0.19 |
| Windows x64 | SapMachine 17.0.14 | SapMachine 17.0.19 |

All SHA256 checksums taken from the respective release assets.

fixes #2236