### PR TITLE
SapMachine #2244: Disable GHA builds for platforms not delivered by SapMachine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,10 +201,12 @@ jobs:
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
-          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "macos-x64=false" >> $GITHUB_OUTPUT
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
-          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "windows-aarch64=false" >> $GITHUB_OUTPUT
           echo "docs=$(check_platform docs)" >> $GITHUB_OUTPUT
           echo "dry-run=$(check_dry_run)" >> $GITHUB_OUTPUT
 

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -41,8 +41,8 @@ MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/s
 MACOS_AARCH64_BOOT_JDK_SHA256=3663faab53b08e20c87112166bae3399340ead434d8e3a58cbb2a28ef1e0c584
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_mac_hotspot_26.0.1_8.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319
+MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk26/c3cc523845074aa0af4f5e1e1ed4151d/35/GPL/openjdk-26_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=8642b89d889c14ede2c446fd5bbe3621c8a3082e3df02013fd1658e39f52929a
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_windows-x64_bin.zip


### PR DESCRIPTION
Disable GitHub Actions build jobs for macos-x64 and windows-aarch64 in the trunk workflow. These platforms are not delivered by SapMachine and running GHA builds for them wastes CI resources.

Additionally, the macOS x64 boot JDK is reverted back to the OpenJDK default (java.net), since we then don't run GHA builds for that platform anyway.

fixes #2244