### PR TITLE
SapMachine (21) #2218: Fix missing policy permission for zipfs symlink support

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -225,6 +225,8 @@ grant codeBase "jrt:/jdk.security.jgss" {
 
 grant codeBase "jrt:/jdk.zipfs" {
     permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+    // SapMachine 2026-04-13: symlink support for zipfs entries in sapext.
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.access";
     permission java.lang.RuntimePermission "fileSystemProvider";
     permission java.lang.RuntimePermission "accessUserInformation";
     permission java.util.PropertyPermission "os.name", "read";


### PR DESCRIPTION
The backport of #2218 to sapmachine21 requires an additional policy permission for `jrt:/jdk.zipfs` to access `jdk.internal.access` package classes used by the symlink support in sapext.

fixes #2218