### PR TITLE
SapMachine (17) #2218: Fix missing policy permission for zipfs symlink support in sapmachine17

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -218,6 +218,8 @@ grant codeBase "jrt:/jdk.security.jgss" {
 
 grant codeBase "jrt:/jdk.zipfs" {
     permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+    // SapMachine 2026-04-13: symlink support for zipfs entries in sapext.
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.access";
     permission java.lang.RuntimePermission "fileSystemProvider";
     permission java.lang.RuntimePermission "accessUserInformation";
     permission java.util.PropertyPermission "os.name", "read";


### PR DESCRIPTION
Backport of #2247 to sapmachine17.

fixes #2218