### PR TITLE
SapMachine (26) #2244: Disable GHA builds for platforms not delivered by SapMachine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,10 +199,12 @@ jobs:
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
-          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "macos-x64=false" >> $GITHUB_OUTPUT
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
-          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "windows-aarch64=false" >> $GITHUB_OUTPUT
           echo "docs=$(check_platform docs)" >> $GITHUB_OUTPUT
           echo "dry-run=$(check_dry_run)" >> $GITHUB_OUTPUT
 

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -41,8 +41,8 @@ MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/s
 MACOS_AARCH64_BOOT_JDK_SHA256=3663faab53b08e20c87112166bae3399340ead434d8e3a58cbb2a28ef1e0c584
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_mac_hotspot_26.0.1_8.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319
+MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=47482ad9888991ecac9b2bcc131e2b53ff78aff275104cef85f66252308e8a09
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-26.0.1/sapmachine-jdk-26.0.1_windows-x64_bin.zip


### PR DESCRIPTION
Backport of #2244 to sapmachine26.

Disable GitHub Actions build jobs for macos-x64 and windows-aarch64, which are not delivered by SapMachine 26. Also switches the macOS x64 boot JDK from Temurin back to the OpenJDK GA download (java.net).

Note for reviewers: compared to the trunk cherry-pick, the macOS x64 boot JDK URL was adjusted to point to OpenJDK 25 (the N-1 boot JDK), matching the value at the upstream tag jdk-26.0.1+8.

fixes #2244