### PR TITLE
SapMachine (25) #2244: Disable GHA builds for platforms not delivered by SapMachine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,10 +187,12 @@ jobs:
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
-          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "macos-x64=false" >> $GITHUB_OUTPUT
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
-          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
+          # SapMachine 2026-05-14: Disabling GHA for platforms that are not delivered
+          echo "windows-aarch64=false" >> $GITHUB_OUTPUT
           echo "docs=$(check_platform docs)" >> $GITHUB_OUTPUT
           echo "dry-run=$(check_dry_run)" >> $GITHUB_OUTPUT
 

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -41,8 +41,8 @@ MACOS_AARCH64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/s
 MACOS_AARCH64_BOOT_JDK_SHA256=5e17522ae15cc57b7d57e8317b2f5c425aa38a50bd105e3c763a73317e1d8658
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_mac_hotspot_25.0.3_9.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=4c539a18b4d656960ff6766727e9ca546fc17f7a29714dba9e7b47bdcb37c447
+MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8ca828c504ffae90/36/GPL/openjdk-24_macos-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=6bbfb1d01741cbe55ab90299cb91464b695de9a3ace85c15131aa2f50292f321
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://github.com/SAP/SapMachine/releases/download/sapmachine-25.0.3/sapmachine-jdk-25.0.3_windows-x64_bin.zip


### PR DESCRIPTION
Backport of #2249 to sapmachine25.

Disable GitHub Actions build jobs for macos-x64 and windows-aarch64, which are not delivered by SapMachine 25. Also switches the macOS x64 boot JDK from Temurin back to the OpenJDK GA download (java.net).

Note for reviewers: compared to the trunk cherry-pick, the macOS x64 boot JDK URL was adjusted to point to OpenJDK 24 (the N-1 boot JDK), matching the value at the upstream tag jdk-25.0.4+1.

fixes #2244