### PR TITLE
SapMachine #1544: Add contents: write permission to wiki workflow

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -11,6 +11,8 @@ jobs:
   wiki:
     if: ${{ github.event_name != 'schedule' || github.repository == 'SAP/SapMachine' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout SapMachine Wiki source
         uses: actions/checkout@v4


### PR DESCRIPTION
The wiki update workflow was failing with exit code 128 on the `git push` step because the `GITHUB_TOKEN` lacked write access to the wiki repository. Adding `permissions: contents: write` to the job grants the token the necessary push permission.

fixes #1544