### PR TITLE
SapMachine (26) #2318: Need larger timeout for jmc agent tests for 26+

### DIFF
--- a/test/jdk/sap/JmcAgentIntegrationTest.java
+++ b/test/jdk/sap/JmcAgentIntegrationTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Runs the test for the SAP JMC agent integration.
  *
- * @run main/othervm JmcAgentIntegrationTest
+ * @run main/othervm/timeout=1200 JmcAgentIntegrationTest
  */
 
 import java.lang.reflect.Method;


### PR DESCRIPTION
Avoids timeout of the jmc agent test.

fixes #2318
