### PR TITLE
SapMachine (27) #2318: Need larger timeout for jmc agent tests for 26+

### DIFF
--- a/test/jdk/sap/JmcAgentIntegrationTest.java
+++ b/test/jdk/sap/JmcAgentIntegrationTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Runs the test for the SAP JMC agent integration.
  *
- * @run main/othervm JmcAgentIntegrationTest
+ * @run main/othervm/timeout=1200 JmcAgentIntegrationTest
  */
 
 import java.lang.reflect.Method;


### PR DESCRIPTION
Increases the test timeout.

fixes #2318
