### PR TITLE
SapMachine (17) #2323: Improve stability of himem tests

### DIFF
--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
@@ -98,8 +98,8 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
                 "-XX:NativeMemoryTracking=summary",
-                "-Xlog:vitals", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
-                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xmx128m", "-Xms64m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
                 "sleep", "2" // num seconds to sleep to give the reporter thread time to generate output
         );
@@ -118,9 +118,9 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
                 "-XX:NativeMemoryTracking=summary",
-                "-Xlog:vitals", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:HiMemReportDir=himemreport-1",
-                "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
+                "-Xmx128m", "-Xms64m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
                 "sleep", "2" // num seconds to sleep to give the reporter thread time to generate output
                 );
@@ -150,9 +150,9 @@ public class TestHiMemReport {
         String reportDirName = "himemreport-2";
         // Here we not only dump, but we also execute several jcmds. Therefore we take some more seconds to sleep
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:HiMemReportDir=himemreport-2",
-                "-Xlog:vitals", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders;GC.heap_dump",
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
@@ -207,7 +207,7 @@ public class TestHiMemReport {
                 ".*HiMemReport *= *true.*",
                 ".*HiMemReportDir *= *himemreport-2.*",
                 ".*HiMemReportExec *= *VM.flags.*VM.metaspace.*GC.heap_dump.*",
-                ".*HiMemReportMax *= *134217728.*"
+                ".*HiMemReportMax *= *67108864.*"
         });
 
         // "VM.metaspace":
@@ -258,9 +258,9 @@ public class TestHiMemReport {
     // Test multiple Execs, with the output of the commands going to stderr
     static void testDumpWithExecToStderr() throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-XX:HiMemReportMax=128m",
+                "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders",
-                "-Xlog:vitals", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
@@ -280,7 +280,7 @@ public class TestHiMemReport {
         // ... as well as the output of VM.flags
         line = VitalsUtils.matchPatterns(lines, line + 1, new String [] {
                         ".*HiMemReport *= *true.*",
-                        ".*HiMemReportMax *= *134217728.*",
+                        ".*HiMemReportMax *= *67108864.*",
                         "HiMemReport: Successfully executed \"VM.flags -all\" \\(\\d+ ms\\)"
         });
 
@@ -307,7 +307,7 @@ public class TestHiMemReport {
     static void testHasNaturalMax() throws IOException {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
-                "-XX:+HiMemReport", "-Xlog:vitals", "-Xmx64m", "-version");
+                "-XX:+HiMemReport", "-Xlog:vitals=trace", "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldNotMatch("HiMemReport.*limit could not be established");
@@ -326,7 +326,7 @@ public class TestHiMemReport {
             testHasNaturalMax();
         else if (args[0].equals("sleep")) {
             int numSeconds = Integer.parseInt(args[1]);
-            Thread.sleep(numSeconds * 1000 * 4); // TODO: Remove the additional time factor of 4 later.
+            Thread.sleep(numSeconds * 1000);
         } else
             throw new RuntimeException("Invalid test " + args[0]);
     }


### PR DESCRIPTION
Fixes most of the sporadic failures.

For the one which is caused by a failure to parse proc, additional trace was added.

fixes #2323
