### PR TITLE
SapMachine (25) #1502: 8372757: MacOS, Accessibility: Crash in [MenuAccessibility accessibilityChildren] after JDK-8341311

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -68,6 +68,11 @@ static jclass sjc_CAccessibility = NULL;
                                                              sjm_getCurrentAccessiblePopupMenu,
                                                              fAccessible, fComponent);
 
+    CHECK_EXCEPTION();
+    if (axComponent == nil) {
+        return nil;
+    }
+
     CommonComponentAccessibility *currentElement = [CommonComponentAccessibility createWithAccessible:axComponent
                                                             withEnv:env withView:self->fView isCurrent:YES];
 


### PR DESCRIPTION
Cherry-pick of 6bbae6df769195480b46f551d8ba2ec168bc6ec3 from OpenJDK 25u-dev.

fixes #1502