### PR TITLE
SapMachine (21) #1502: 8372757: MacOS, Accessibility: Crash in [MenuAccessibility accessibilityChildren] after JDK-8341311

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -68,6 +68,11 @@ static jclass sjc_CAccessibility = NULL;
                                                              sjm_getCurrentAccessiblePopupMenu,
                                                              fAccessible, fComponent);
 
+    CHECK_EXCEPTION();
+    if (axComponent == nil) {
+        return nil;
+    }
+
     CommonComponentAccessibility *currentElement = [CommonComponentAccessibility createWithAccessible:axComponent
                                                             withEnv:env withView:self->fView isCurrent:YES];
 


### PR DESCRIPTION
Cherry-pick of 30b1b4b77fb019e910ac130acf45dda211f10c07 from OpenJDK 21u-dev.

fixes #1502