### PR TITLE
SapMachine (25) #2360: Downport himem test improvements from mainline

### DIFF
--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -97,6 +97,7 @@ public:
     char* endptr = nullptr;
     value = (value_t)::strtoll(text, &endptr, 10);
     if (endptr == text || errno != 0) {
+      log_debug(vitals, os)("Failed to parse \"%s\"", text);
       value = INVALID_VALUE;
     } else {
       value *= scale;
@@ -120,7 +121,10 @@ public:
     if (s != nullptr) {
       errno = 0;
       const char* p = s + ::strlen(prefix);
-      return as_value(p, scale);
+      value = as_value(p, scale);
+      log_trace(vitals, os)("Reading \"%s\": %llu", prefix, (unsigned long long) value);
+    } else {
+      log_debug(vitals, os)("Could not find prefix \"%s\"", prefix);
     }
     return value;
   }

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReport.java
@@ -100,7 +100,7 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:NativeMemoryTracking=summary",
-                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace,vitals+os=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
                 "sleep", "2" // num seconds to sleep to give the reporter thread time to generate output
@@ -120,7 +120,7 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:NativeMemoryTracking=summary",
-                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace,vitals+os=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:HiMemReportDir=himemreport-1",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
@@ -154,12 +154,12 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:HiMemReportDir=himemreport-2",
-                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace,vitals+os=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders;GC.heap_dump",
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
-                "sleep", "12" // num seconds to sleep to give the reporter thread time to generate output
+                "sleep", "30" // num seconds to sleep to give the reporter thread time to generate output
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -262,7 +262,7 @@ public class TestHiMemReport {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+HiMemReport", "-XX:HiMemReportMax=64m",
                 "-XX:HiMemReportExec=VM.flags -all;VM.metaspace show-loaders",
-                "-Xlog:vitals=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
+                "-Xlog:vitals=trace,vitals+os=trace", "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
                 "-XX:NativeMemoryTracking=summary",
                 "-Xmx128m", "-Xms128m", "-XX:+AlwaysPreTouch",
                 TestHiMemReport.class.getName(),
@@ -309,7 +309,7 @@ public class TestHiMemReport {
     static void testHasNaturalMax() throws IOException {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+PrintVitalsAtExit", "-XX:VitalsSampleInterval=1",
-                "-XX:+HiMemReport", "-Xlog:vitals=trace", "-Xmx64m", "-version");
+                "-XX:+HiMemReport", "-Xlog:vitals=trace,vitals+os=trace", "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldNotMatch("HiMemReport.*limit could not be established");

--- a/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportArgParsing.java
+++ b/test/hotspot/jtreg/runtime/Vitals/TestHiMemReportArgParsing.java
@@ -78,8 +78,8 @@ public class TestHiMemReportArgParsing {
         File subdir = VitalsUtils.createSubTestDir("test-outputdir-1", false);
         VitalsUtils.fileShouldNotExist(subdir);
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(), "-Xlog:vitals",
-                "-Xmx64m", "-version");
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(),
+                "-Xlog:vitals=trace,vitals+os=trace", "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();
         output.shouldHaveExitValue(0);
@@ -97,8 +97,8 @@ public class TestHiMemReportArgParsing {
         File subdir = VitalsUtils.createSubTestDir("test-outputdir-2", true);
         VitalsUtils.fileShouldExist(subdir);
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(), "-Xlog:vitals",
-                "-Xmx64m", "-version");
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + subdir.getAbsolutePath(),
+                "-Xlog:vitals=trace,vitals+os=trace", "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();
         output.shouldHaveExitValue(0);
@@ -117,8 +117,8 @@ public class TestHiMemReportArgParsing {
         File f = new File("/tmp/gibsnicht/gibsnicht/gibsnicht");
         VitalsUtils.fileShouldNotExist(f);
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + f.getAbsolutePath(), "-Xlog:vitals",
-                "-Xmx64m", "-version");
+                "-XX:+HiMemReport", "-XX:HiMemReportDir=" + f.getAbsolutePath(),
+                "-Xlog:vitals=trace,vitals+os=trace", "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();
         output.shouldNotHaveExitValue(0);
@@ -134,7 +134,7 @@ public class TestHiMemReportArgParsing {
      */
     static void testHiMemReportOn() throws IOException {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:+HiMemReport", "-Xlog:vitals",
+                "-XX:+HiMemReport", "-Xlog:vitals=trace,vitals+os=trace",
                 "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();
@@ -150,7 +150,7 @@ public class TestHiMemReportArgParsing {
      */
     static void testHiMemReportOff() throws IOException {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:-HiMemReport", "-Xlog:vitals",
+                "-XX:-HiMemReport", "-Xlog:vitals=trace,vitals+os=trace",
                 "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();
@@ -163,7 +163,7 @@ public class TestHiMemReportArgParsing {
      */
     static void testHiMemReportOffByDefault() throws IOException {
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-Xlog:vitals",
+                "-Xlog:vitals=trace,vitals+os=trace",
                 "-Xmx64m", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.reportDiagnosticSummary();


### PR DESCRIPTION
Downport of the test improvements. Needed to increase time sleep time for one test which triggers a heap dump, since at least on debug versions this takes quiet some time and the additional logging makes the test even slower.

fixes #2360
