### PR TITLE
SapMachine (26) #2366: Don't use jcmd in static builds

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/PartialArrayContentTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/PartialArrayContentTest.java
@@ -41,8 +41,17 @@ import jdk.test.lib.hprof.parser.Reader;
  * @test
  * @summary Checks if -XX:+LimitPrimitiveArrayContentInHeapDump works.
  * @requires os.maxMemory > 4G
+ * @requires !jdk.static
  * @library /test/lib
- * @run driver PartialArrayContentTest
+ * @run driver PartialArrayContentTest jmc
+ */
+
+/*
+ * @test
+ * @summary Checks if -XX:+LimitPrimitiveArrayContentInHeapDump works.
+ * @requires os.maxMemory > 4G
+ * @library /test/lib
+ * @run driver PartialArrayContentTest oom
  */
 class ArrayAllocApp extends LingeredApp {
     public static int arraySize = 54321;
@@ -91,8 +100,11 @@ public class PartialArrayContentTest {
     private static int nonCharLikeLimit = 50;
 
     public static void main(String[] args) throws Exception {
-        checkPartialContentWithJcmd();
-        checkPartialContentWithOOM();
+        if (args[0].equals("jmc")) {
+            checkPartialContentWithJcmd();
+        } else {
+            checkPartialContentWithOOM();
+        }
     }
 
     public static void checkPartialContentWithJcmd() throws Exception {

--- a/test/hotspot/jtreg/serviceability/HeapDump/PartialArrayContentTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/PartialArrayContentTest.java
@@ -43,7 +43,7 @@ import jdk.test.lib.hprof.parser.Reader;
  * @requires os.maxMemory > 4G
  * @requires !jdk.static
  * @library /test/lib
- * @run driver PartialArrayContentTest jmc
+ * @run driver PartialArrayContentTest jcmd
  */
 
 /*
@@ -100,7 +100,7 @@ public class PartialArrayContentTest {
     private static int nonCharLikeLimit = 50;
 
     public static void main(String[] args) throws Exception {
-        if (args[0].equals("jmc")) {
+        if (args[0].equals("jcmd")) {
             checkPartialContentWithJcmd();
         } else {
             checkPartialContentWithOOM();


### PR DESCRIPTION
Only run the part of the test which doesn't uses jcmd on static builds.

fixes #2366
