### PR TITLE
Sapmachine #2392: Add load average to vitals

### DIFF
--- a/src/hotspot/os/linux/vitals_linux.cpp
+++ b/src/hotspot/os/linux/vitals_linux.cpp
@@ -106,6 +106,8 @@ static Column* g_col_system_num_threads = nullptr;
 static Column* g_col_system_num_procs_running = nullptr;
 static Column* g_col_system_num_procs_blocked = nullptr;
 
+static Column* g_col_system_load_avg = nullptr;
+
 static bool g_show_cgroup_info = false;
 static Column* g_col_system_cgrp_limit_in_bytes = nullptr;
 static Column* g_col_system_cgrp_soft_limit_in_bytes = nullptr;
@@ -176,9 +178,12 @@ bool platform_columns_initialize() {
       define_column<PlainValueColumn>(system_cat, nullptr, "t", "Number of threads", true);
 
   g_col_system_num_procs_running =
-      define_column<PlainValueColumn>(system_cat, nullptr, "tr", "Number of threads running", true);
+      define_column<PlainValueColumn>(system_cat, nullptr, "tr", "Number of running and runnable threads", true);
   g_col_system_num_procs_blocked =
       define_column<PlainValueColumn>(system_cat, nullptr, "tb", "Number of threads blocked on disk IO", true);
+
+  g_col_system_load_avg =
+      define_column<LoadAverageColumn>(system_cat, nullptr, "la", "Load average in percent", true, MAX);
 
   g_col_system_cpu_user =
       define_column<CPUTimeColumn>(system_cat, "cpu", "us", "CPU user time [host]", true);
@@ -286,6 +291,8 @@ void sample_platform_values(Sample* sample) {
 
   set_value_in_sample(g_col_system_num_procs_running, sample, OSWrapper::syst_tr());
   set_value_in_sample(g_col_system_num_procs_blocked, sample, OSWrapper::syst_tb());
+
+  set_value_in_sample(g_col_system_load_avg, sample, OSWrapper::syst_ldavg());
 
   // cgroups business
   if (g_show_cgroup_info) {

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -35,7 +35,6 @@
 #include <fcntl.h>
 #include <string.h>
 
-
 #define LOG_HERE_F(msg, ...)  { printf("[%d] ", (int)::getpid()); ::printf(msg, __VA_ARGS__); printf("\n"); fflush(stdout); }
 #define LOG_HERE(msg)         { printf("[%d] ", (int)::getpid()); ::printf("%s", msg); printf("\n"); fflush(stdout); }
 
@@ -371,6 +370,7 @@ const char* CGroups::_file_lim = nullptr;
 const char* CGroups::_file_limsw = nullptr;
 const char* CGroups::_file_slim = nullptr;
 const char* CGroups::_file_kusg = nullptr;
+double proc_scale_factor = 0.0;
 
 void OSWrapper::update_if_needed() {
 
@@ -394,6 +394,7 @@ ALL_VALUES_DO(RESETVAL)
 
     if (first_call) {
       log_trace(vitals)("Read /proc/meminfo: \n%s", bf.text());
+      proc_scale_factor = 100.0 / MAX2(1, os::processor_count());
     }
 
     // All values in /proc/meminfo are in KB
@@ -436,7 +437,7 @@ ALL_VALUES_DO(RESETVAL)
     _syst_cpu_st = values.steal;
     _syst_cpu_gu = values.guest + values.guest_nice;
 
-    // procs_running: this is actually number of threads running
+    // procs_running: this is running and runnable threads.
     // procs_blocked: number of threads blocked on real disk IO
     // See https://utcc.utoronto.ca/~cks/space/blog/linux/ProcessStatesAndProcStat
     // and https://lore.kernel.org/lkml/12601530441257@xenotime.net/#t
@@ -555,6 +556,22 @@ ALL_VALUES_DO(RESETVAL)
     }
   }
 #endif // __GLIBC__
+
+  if (bf.read("/proc/loadavg")) {
+    float l1, l5, l15;
+    if (sscanf(bf.text(), "%f %f %f", &l1, &l5, &l15) == 3) {
+      // Convert to relative percentage-based loads, where 100 percent
+      // means the number of runnable threads equals the number of CPUs.
+      value_t rl1 = (value_t) MAX2(0.0, MIN2(65535.0, proc_scale_factor * l1));
+      value_t rl5 = (value_t) MAX2(0.0, MIN2(65535.0, proc_scale_factor * l5));
+      value_t rl15 = (value_t) MAX2(0.0, MIN2(65535.0, proc_scale_factor * l15));
+      // We put the three values into one, since we want to display
+      // the longer averaged one in table with coarser resolution.
+      _syst_ldavg = (rl1 << 32) | (rl5 << 16) | rl15;
+    } else {
+      _syst_ldavg = INVALID_VALUE;
+    }
+  }
 
   first_call = false;
 

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.cpp
@@ -570,6 +570,12 @@ ALL_VALUES_DO(RESETVAL)
       _syst_ldavg = (rl1 << 32) | (rl5 << 16) | rl15;
     } else {
       _syst_ldavg = INVALID_VALUE;
+      static bool traced = false;
+
+      if (!traced) {
+        log_trace(vitals)("Could not parse /proc/loadavg: \n%s", bf.text());
+        traced = true;
+      }
     }
   }
 

--- a/src/hotspot/os/linux/vitals_linux_oswrapper.hpp
+++ b/src/hotspot/os/linux/vitals_linux_oswrapper.hpp
@@ -48,6 +48,7 @@ class OSWrapper {
 	  f(syst_t) \
 	  f(syst_tr) \
 	  f(syst_tb) \
+	  f(syst_ldavg) \
 	  f(syst_cpu_us) \
 	  f(syst_cpu_sy) \
 	  f(syst_cpu_id) \

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -551,11 +551,15 @@ int Column::do_print(outputStream* st, value_t value, value_t last_value,
     }
   } else {
     if (pi->raw) {
-      return printf_helper(st, UINT64_FORMAT, value);
+      return do_print_raw0(st, value);
     } else {
       return do_print0(st, value, last_value, last_value_age, pi);
     }
   }
+}
+
+int Column::do_print_raw0(outputStream* st, value_t value) const {
+  return printf_helper(st, UINT64_FORMAT, value);
 }
 
 int PlainValueColumn::do_print0(outputStream* st, value_t value,
@@ -589,6 +593,32 @@ int DeltaMemorySizeColumn::do_print0(outputStream* st, value_t value,
     return print_memory_size(st, value - last_value, pi->scale);
   }
   return 0;
+}
+
+int LoadAverageColumn::do_print0(outputStream* st, value_t value,
+    value_t last_value, int last_value_age, const print_info_t* pi) const {
+  if (value != INVALID_VALUE) {
+    value_t load_average;
+
+    // Use the minute resolution until an age of 2.5 minutes
+    // and 5 minute resulution until an age of 7.5 minutes.
+    // The extremes use last_value_age, so they use the one minute average.
+    if (last_value_age <= 150) {
+      load_average = value >> 32;
+    } else if (last_value_age < 450) {
+      load_average = (value >> 16) & 0xffff;
+    } else {
+      load_average = value & 0xffff;
+    }
+
+    return printf_helper(st, UINT64_FORMAT, load_average);
+  }
+
+  return 0;
+}
+
+int LoadAverageColumn::do_print_raw0(outputStream* st, value_t value) const {
+  return do_print0(st, value, INVALID_VALUE, 0, nullptr);
 }
 
 ////////////// sample printing ///////////////////////////

--- a/src/hotspot/share/vitals/vitals.cpp
+++ b/src/hotspot/share/vitals/vitals.cpp
@@ -601,7 +601,7 @@ int LoadAverageColumn::do_print0(outputStream* st, value_t value,
     value_t load_average;
 
     // Use the minute resolution until an age of 2.5 minutes
-    // and 5 minute resulution until an age of 7.5 minutes.
+    // and 5 minute resolution until an age of 7.5 minutes.
     // The extremes use last_value_age, so they use the one minute average.
     if (last_value_age <= 150) {
       load_average = value >> 32;

--- a/src/hotspot/share/vitals/vitals_internals.hpp
+++ b/src/hotspot/share/vitals/vitals_internals.hpp
@@ -93,6 +93,8 @@ namespace sapmachine_vitals {
     // output stream can be nullptr; in that case, method shall return number of characters it would have printed.
     virtual int do_print0(outputStream* os, value_t value,
         value_t last_value, int last_value_age, const print_info_t* pi) const = 0;
+    // Can be overridden by the implementation. By default writes the 64 bit value.
+    virtual int do_print_raw0(outputStream* os, value_t value) const;
 
   public:
 
@@ -167,6 +169,17 @@ namespace sapmachine_vitals {
         int last_value_age, const print_info_t* pi) const;
   public:
     TimeStampColumn(const char* category, const char* header, const char* name, const char* description, Extremum extremum)
+      : Column(category, header, name, description, extremum)
+    {}
+  };
+
+  // Special column which can handle the 3 load averages in the raw value.
+  class LoadAverageColumn: public Column {
+    int do_print0(outputStream* os, value_t value, value_t last_value,
+        int last_value_age, const print_info_t* pi) const;
+    int do_print_raw0(outputStream* os, value_t value) const;
+  public:
+    LoadAverageColumn(const char* category, const char* header, const char* name, const char* description, Extremum extremum)
       : Column(category, header, name, description, extremum)
     {}
   };


### PR DESCRIPTION
This adds the load average to the vitals.

Since there are actually 3 load average values (taken over 1 minute, 5 minutes or 15 minutes) and the vitals table are already cryz big, this only adds one of the values which is most appropriate for the table (short term or long term). 

The load average is given in percent, with 100 percent meaning the system has exactly as many CPUs as runnable threads. This is done so we don't have to know the number of CPUs on the system to see if the system is overloaded.

In principle with the load average added. the "tr" column could be removed, since it is analog to the load average for a very small interval. Since this makes the value fluctuate wildly, not be suitable for the long term table and needs knowing the number of CPUs to interpret it, we could remove it. On the other hand, who knows who uses it and would not be happy to see it removed.
 
fixes #2392
